### PR TITLE
Add startup safety tests, env policy docs, and health config endpoint

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,30 @@
+# Configuration Overview
+
+This document lists required and optional environment variables used by the app.
+Optional integrations are disabled gracefully when credentials are missing.
+
+## Required
+
+| Variable | Purpose |
+| --- | --- |
+| `DATABASE_URL` | SQLAlchemy database connection string. |
+| `SESSION_SECRET` (or `SECRET_KEY`) | Flask session secret. |
+
+## Optional (Feature-Dependent)
+
+| Feature | Variables | Notes |
+| --- | --- | --- |
+| OpenAI (AI content) | `OPENAI_API_KEY` | Enables AI features; disabled when missing. |
+| Replit Auth | `REPL_ID`, `ISSUER_URL` | Replit OAuth is disabled without `REPL_ID`. |
+| TikTok OAuth | `TIKTOK_CLIENT_KEY`, `TIKTOK_CLIENT_SECRET` | TikTok integration disabled without both. |
+| Microsoft Graph Email | `MS_CLIENT_ID`, `MS_CLIENT_SECRET`, `MS_TENANT_ID`, `MS_FROM_EMAIL` | Email via Microsoft Graph; SMTP fallback available. |
+| SMTP fallback | `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD` | Used only if configured. |
+| Twilio SMS | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_PHONE_NUMBER` | SMS disabled without all three. |
+| Stripe | `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY` | Payments for events. |
+| WooCommerce | `WC_STORE_URL`, `WC_CONSUMER_KEY`, `WC_CONSUMER_SECRET` | WooCommerce integrations. |
+| GA4 | `GA4_PROPERTY_ID`, `GOOGLE_APPLICATION_CREDENTIALS` | Analytics integration. |
+| Mailgun | `MAILGUN_API_KEY`, `MAILGUN_DOMAIN`, `MAILGUN_FROM` | Optional email provider. |
+| Bitly | `BITLY_ACCESS_TOKEN` | Optional URL shortening. |
+| Unsplash | `UNSPLASH_ACCESS_KEY` | Optional image search. |
+| Pexels | `PEXELS_API_KEY` | Optional image search. |
+| Ad networks | `EXOCLICK_API_BASE`, `EXOCLICK_API_TOKEN`, `CLICKADILLA_TOKEN`, `TUBECORPORATE_*` | Optional ad integrations. |

--- a/app.py
+++ b/app.py
@@ -297,6 +297,31 @@ except Exception as e:
 # Request lifecycle helpers
 # ============================================================
 
+def _log_startup_feature_summary():
+    logger = logging.getLogger(__name__)
+    feature_flags = {
+        "openai": bool(os.getenv("OPENAI_API_KEY")),
+        "replit_auth": bool(os.getenv("REPL_ID")),
+        "tiktok": bool(os.getenv("TIKTOK_CLIENT_KEY") and os.getenv("TIKTOK_CLIENT_SECRET")),
+        "microsoft_graph": bool(os.getenv("MS_CLIENT_ID") and os.getenv("MS_CLIENT_SECRET") and os.getenv("MS_TENANT_ID")),
+        "twilio": bool(
+            os.getenv("TWILIO_ACCOUNT_SID")
+            and os.getenv("TWILIO_AUTH_TOKEN")
+            and os.getenv("TWILIO_PHONE_NUMBER")
+        ),
+        "stripe": bool(os.getenv("STRIPE_SECRET_KEY")),
+        "woocommerce": bool(
+            os.getenv("WC_STORE_URL")
+            and os.getenv("WC_CONSUMER_KEY")
+            and os.getenv("WC_CONSUMER_SECRET")
+        ),
+        "ga4": bool(os.getenv("GA4_PROPERTY_ID")),
+    }
+    logger.info("Startup feature summary: %s", feature_flags)
+
+
+_log_startup_feature_summary()
+
 @app.route("/")
 def index():
     return redirect(url_for("auth.login"))

--- a/replit_auth.py
+++ b/replit_auth.py
@@ -364,9 +364,14 @@ def require_replit_login(f):
                 try:
                     issuer_url = os.environ.get('ISSUER_URL', "https://replit.com/oidc")
                     refresh_token_url = issuer_url + "/token"
+                    repl_id = os.getenv('REPL_ID')
+                    if not repl_id:
+                        logger.warning("REPL_ID missing; skipping Replit token refresh.")
+                        session["next_url"] = get_next_navigation_url(request)
+                        return redirect(url_for('replit_auth.login'))
                     token = g.flask_dance_replit.refresh_token(
                         token_url=refresh_token_url,
-                        client_id=os.environ['REPL_ID']
+                        client_id=repl_id
                     )
                     g.flask_dance_replit.token_updater(token)
                 except InvalidGrantError:

--- a/routes.py
+++ b/routes.py
@@ -22,7 +22,7 @@ from utils import validate_email, safe_count
 from tracking import decode_tracking_data, record_email_event
 import logging
 import json
-from ai_agent import lux_agent
+from ai_agent import get_lux_agent
 from seo_service import seo_service
 from error_logger import log_application_error, ApplicationDiagnostics, ErrorLog
 from log_reader import LogReader
@@ -1443,8 +1443,7 @@ def auto_generate_campaign():
         if not campaign_name:
             return jsonify({'success': False, 'error': 'Campaign name is required'}), 400
         
-        from ai_agent import LUXAgent
-        lux_agent = LUXAgent()
+        lux_agent = get_lux_agent()
         
         subjects = lux_agent.generate_subject_lines(campaign_name, "general audience")
         
@@ -2320,7 +2319,7 @@ def campaign_analytics_api(campaign_id):
 def lux_generate_campaign():
     """LUX AI agent - Generate automated campaign"""
     try:
-        from ai_agent import lux_agent
+        lux_agent = get_lux_agent()
         
         data = request.get_json() or {}
         campaign_brief = {
@@ -2364,7 +2363,7 @@ def lux_generate_campaign():
 def lux_optimize_campaign(campaign_id):
     """LUX AI agent - Optimize campaign performance"""
     try:
-        from ai_agent import lux_agent
+        lux_agent = get_lux_agent()
         
         optimization = lux_agent.optimize_campaign_performance(campaign_id)
         
@@ -2391,7 +2390,7 @@ def lux_optimize_campaign(campaign_id):
 def lux_audience_analysis():
     """LUX AI agent - Analyze audience segments"""
     try:
-        from ai_agent import lux_agent
+        lux_agent = get_lux_agent()
         
         contacts = Contact.query.filter_by(is_active=True).all()
         analysis = lux_agent.analyze_audience_segments(contacts)
@@ -2419,7 +2418,7 @@ def lux_audience_analysis():
 def lux_subject_variants():
     """LUX AI agent - Generate subject line variants"""
     try:
-        from ai_agent import lux_agent
+        lux_agent = get_lux_agent()
         
         data = request.get_json() or {}
         objective = data.get('objective', 'Engage audience')
@@ -2450,7 +2449,7 @@ def lux_subject_variants():
 def lux_recommendations():
     """LUX AI agent - Get campaign recommendations"""
     try:
-        from ai_agent import lux_agent
+        lux_agent = get_lux_agent()
         from tracking import get_campaign_analytics
         
         # Gather data to pass to LUX agent (avoiding circular imports)
@@ -2570,7 +2569,7 @@ def lux_generate_image():
     csrf.exempt(lux_generate_image)
     
     try:
-        from ai_agent import lux_agent
+        lux_agent = get_lux_agent()
         
         data = request.get_json() or {}
         description = data.get('description', 'Professional marketing campaign')
@@ -2616,7 +2615,7 @@ def lux_product_campaign():
                 if mod in sys.modules:
                     del sys.modules[mod]
         
-        from ai_agent import lux_agent
+        lux_agent = get_lux_agent()
         
         data = request.get_json() or {}
         
@@ -2705,7 +2704,7 @@ def lux_product_campaign():
 def lux_test_woocommerce():
     """Test WooCommerce API connection"""
     try:
-        from ai_agent import lux_agent
+        lux_agent = get_lux_agent()
         
         data = request.get_json() or {}
         
@@ -2801,6 +2800,7 @@ def generate_ai_content():
             return jsonify({'success': False, 'message': 'Prompt is required'})
             
         # Generate content using LUX AI agent
+        lux_agent = get_lux_agent()
         content_options = lux_agent.generate_email_content(prompt, content_type)
         
         return jsonify({'success': True, 'content': content_options})
@@ -2818,6 +2818,7 @@ def generate_subject_lines():
         campaign_type = data.get('campaign_type', '')
         audience = data.get('audience', '')
         
+        lux_agent = get_lux_agent()
         subject_lines = lux_agent.generate_subject_lines(campaign_type, audience)
         
         return jsonify({'success': True, 'subject_lines': subject_lines})
@@ -4834,8 +4835,7 @@ def ai_generate_newsletter():
         if not title:
             return jsonify({'success': False, 'message': 'Title required'}), 400
         
-        from ai_agent import LUXAgent
-        lux_agent = LUXAgent()
+        lux_agent = get_lux_agent()
         
         system_prompt = """Generate a professional newsletter HTML content. Include:
 - A header section with the title
@@ -6463,6 +6463,41 @@ def health_check():
         payload["db_error"] = db_error[:200]
     return jsonify(payload), 200 if db_ok else 500
 
+
+def _feature_config_summary():
+    return {
+        "openai": bool(os.getenv("OPENAI_API_KEY")),
+        "replit_auth": bool(os.getenv("REPL_ID")),
+        "tiktok": bool(os.getenv("TIKTOK_CLIENT_KEY") and os.getenv("TIKTOK_CLIENT_SECRET")),
+        "microsoft_graph": bool(
+            os.getenv("MS_CLIENT_ID")
+            and os.getenv("MS_CLIENT_SECRET")
+            and os.getenv("MS_TENANT_ID")
+        ),
+        "twilio": bool(
+            os.getenv("TWILIO_ACCOUNT_SID")
+            and os.getenv("TWILIO_AUTH_TOKEN")
+            and os.getenv("TWILIO_PHONE_NUMBER")
+        ),
+        "stripe": bool(os.getenv("STRIPE_SECRET_KEY")),
+        "woocommerce": bool(
+            os.getenv("WC_STORE_URL")
+            and os.getenv("WC_CONSUMER_KEY")
+            and os.getenv("WC_CONSUMER_SECRET")
+        ),
+        "ga4": bool(os.getenv("GA4_PROPERTY_ID")),
+    }
+
+
+@main_bp.route('/health/config')
+def health_config():
+    """Configuration summary for optional features (no secrets)."""
+    return jsonify({
+        "status": "ok",
+        "features": _feature_config_summary(),
+        "timestamp": datetime.utcnow().isoformat(),
+    })
+
 @main_bp.route('/health/deep')
 def health_check_deep():
     """Deep health check (admin only)"""
@@ -6694,8 +6729,7 @@ def ai_generate_landing_page():
         if not prompt:
             return jsonify({'success': False, 'message': 'Please provide a description'}), 400
         
-        from ai_agent import LUXAgent
-        lux_agent = LUXAgent()
+        lux_agent = get_lux_agent()
         
         system_prompt = f"""You are a landing page HTML generator. Create a responsive, Bootstrap 5 landing page based on the user's description.
         
@@ -6923,7 +6957,7 @@ def chatbot_send_with_auto_fix():
         api_key = os.environ.get('OPENAI_API_KEY') or os.getenv('OPENAI_API_KEY')
         if not api_key:
             error_msg = 'OpenAI API key not configured in environment'
-            logger.error(error_msg)
+            logger.warning("OpenAI features disabled: missing OPENAI_API_KEY.")
             log_application_error(
                 error_type='ConfigurationError',
                 error_message=error_msg,
@@ -7167,6 +7201,7 @@ def generate_content():
         # Get API key
         api_key = os.getenv('OPENAI_API_KEY') or os.getenv('OPENAI_API_BOUTIQUELUX')
         if not api_key:
+            logger.warning("OpenAI content generation disabled: missing API key.")
             return jsonify({'error': 'OpenAI API key not configured'}), 500
         
         openai.api_key = api_key
@@ -8865,6 +8900,7 @@ def generate_blog_content():
         if not topic:
             return jsonify({'success': False, 'error': 'Topic is required'}), 400
         
+        lux_agent = get_lux_agent()
         result = lux_agent.generate_blog_post(topic, keywords, tone)
         
         if result:
@@ -9474,6 +9510,7 @@ def api_agent_chat():
         
         api_key = os.environ.get("OPENAI_API_KEY")
         if not api_key:
+            logger.warning("Agent chat disabled: missing OPENAI_API_KEY.")
             return jsonify({'success': True, 'response': "I'm sorry, but I can't process your request right now. Please ensure the OpenAI API key is configured."})
         
         client = OpenAI(api_key=api_key)
@@ -9611,6 +9648,7 @@ def get_agent_suggestions(agent_type):
         
         api_key = os.environ.get("OPENAI_API_KEY")
         if not api_key:
+            logger.warning("Agent suggestions disabled: missing OPENAI_API_KEY.")
             return jsonify({'success': True, 'suggestions': []})
         
         client = OpenAI(api_key=api_key)

--- a/services/sms_service.py
+++ b/services/sms_service.py
@@ -185,8 +185,8 @@ class SMSService:
     def ai_generate_sms(prompt, tone='professional', max_length=160):
         """Generate SMS content using AI"""
         try:
-            from ai_agent import LUXAgent
-            lux_agent = LUXAgent()
+            from ai_agent import get_lux_agent
+            lux_agent = get_lux_agent()
             
             full_prompt = f"""Create a short SMS marketing message (max {max_length} chars) with a {tone} tone.
             Topic: {prompt}

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -20,3 +20,58 @@ def test_missing_session_secret_logs_warning():
 
     assert result.returncode == 0
     assert "SESSION_SECRET is missing. Set it in your environment to start the app." in result.stderr
+
+
+def test_app_imports_without_optional_env_vars():
+    env = os.environ.copy()
+    env["CODEX_ENV"] = "dev"
+    env["DATABASE_URL"] = "sqlite:///:memory:"
+    env["SESSION_SECRET"] = "test-secret"
+    for key in [
+        "OPENAI_API_KEY",
+        "REPL_ID",
+        "TIKTOK_CLIENT_KEY",
+        "TIKTOK_CLIENT_SECRET",
+    ]:
+        env.pop(key, None)
+
+    result = subprocess.run(
+        ["python", "-c", "import app; print('ok')"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0
+
+
+def test_login_route_loads_without_optional_env_vars():
+    env = os.environ.copy()
+    env["CODEX_ENV"] = "dev"
+    env["DATABASE_URL"] = "sqlite:///:memory:"
+    env["SESSION_SECRET"] = "test-secret"
+    for key in [
+        "OPENAI_API_KEY",
+        "REPL_ID",
+        "TIKTOK_CLIENT_KEY",
+        "TIKTOK_CLIENT_SECRET",
+    ]:
+        env.pop(key, None)
+
+    script = (
+        "from app import app as flask_app;"
+        "client = flask_app.test_client();"
+        "response = client.get('/auth/login');"
+        "print(response.status_code)"
+    )
+    result = subprocess.run(
+        ["python", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "200"


### PR DESCRIPTION
### Motivation
- Prevent the app from crashing or exhibiting unexpected behavior at import/startup when optional integration credentials are missing by avoiding required import-time initialization and direct `os.environ['...']` indexing.
- Provide clear, machine-readable visibility into which optional features are configured at runtime via logging and a read-only endpoint so ops can detect missing integrations without exposing secrets.
- Add minimal automated coverage to guard against regressions where optional env vars would previously break app import or common routes.

### Description
- Add `CONFIG.md` documenting required vs optional environment variables and feature gating for integrations such as OpenAI, Replit, TikTok, Twilio, Stripe, WooCommerce, and others.
- Log a startup feature summary in `app.py` (`_log_startup_feature_summary`) and add a read-only `/health/config` endpoint in `routes.py` (and helper `_feature_config_summary`) to report boolean availability of optional integrations without revealing secrets.
- Make OpenAI client initialization lazy and tolerant of missing API keys by adding `_get_client`/`_require_client` in `agents/base_agent.py` and `ai_agent.py`, introduce `get_lux_agent()` (lazy global agent getter), and update routes/services to use the lazy getter (`get_lux_agent()`), avoiding import-time failures.
- Harden integrations: add safety checks for Replit token refresh (`replit_auth.py` checks `REPL_ID`), make TikTok integration tolerant of missing credentials (`services/tiktok_service.py` adds `is_configured()` and returns controlled error objects), and add `_ensure_tiktok_configured()` guards in `tiktok_auth.py` so endpoints return friendly errors/503 instead of raising.

### Testing
- Added new unit tests in `tests/test_startup.py` that verify the app can be imported and the login route loads when optional env vars (`OPENAI_API_KEY`, `REPL_ID`, `TIKTOK_CLIENT_KEY`, `TIKTOK_CLIENT_SECRET`) are absent.
- No automated test suite was executed as part of this change; the new tests were added and committed but not run in CI or locally during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69669ebe6c9883228b18d2994f6bb76a)