### PR TITLE
Fix tenant company lookup to prevent missing company context and server errors

### DIFF
--- a/models.py
+++ b/models.py
@@ -199,7 +199,8 @@ class User(UserMixin, db.Model):
             if access:
                 return access.company
 
-            return Company.query.filter_by(is_active=True).order_by(Company.id.asc()).first()
+            user_companies = self.get_all_companies()
+            return user_companies[0] if user_companies else None
         except Exception as exc:
             try:
                 db.session.rollback()
@@ -217,13 +218,37 @@ class User(UserMixin, db.Model):
 
     def get_all_companies(self):
         try:
-            return (
+            companies_by_access = (
                 Company.query
-                .join(user_company, (user_company.c.company_id == Company.id) & (user_company.c.user_id == self.id))
-                .filter(Company.is_active == True)
-                .order_by(Company.name)
+                .join(UserCompanyAccess, UserCompanyAccess.company_id == Company.id)
+                .filter(
+                    UserCompanyAccess.user_id == self.id,
+                    Company.is_active == True,
+                )
                 .all()
             )
+
+            companies_by_legacy_link = (
+                Company.query
+                .join(
+                    user_company,
+                    (user_company.c.company_id == Company.id)
+                    & (user_company.c.user_id == self.id),
+                )
+                .filter(Company.is_active == True)
+                .all()
+            )
+
+            merged = {c.id: c for c in companies_by_access + companies_by_legacy_link}
+
+            if self.default_company_id:
+                default_company = Company.query.filter_by(
+                    id=self.default_company_id, is_active=True
+                ).first()
+                if default_company:
+                    merged[default_company.id] = default_company
+
+            return sorted(merged.values(), key=lambda c: (c.name or "").lower())
         except Exception:
             return list(self.companies)
 


### PR DESCRIPTION
### Motivation
- Some users had no active tenant/company in UI flows because membership could live in either the legacy `user_company` join table or the newer `user_company_access` model, which caused templates and routes that assume a company to raise internal server errors. 
- The `get_default_company` fallback previously returned the first global active company which could produce the wrong tenant context or still return nothing for users with only one of the membership mappings.

### Description
- Updated `User.get_all_companies()` to aggregate companies from both `UserCompanyAccess` and the legacy `user_company` join table, deduplicate by `id`, and return a deterministically sorted list by company name. 
- Ensure the user's `default_company_id` (if set and active) is injected into the merged company list so default context is always available when appropriate. 
- Changed `User.get_default_company()` fallback to use the user-specific company list from `get_all_companies()` instead of selecting the first globally active company, avoiding incorrect tenant selection and reducing downstream failures.

### Testing
- Ran `python -m py_compile models.py` which completed successfully. 
- Ran `pytest -q` in this environment; test collection failed with missing third-party packages (errors for missing `flask`, `werkzeug`, `flask_sqlalchemy`, `requests`, `stripe`, etc.), so full test suite could not be executed here (collection aborted with 18 import errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a11521ce4bc83228f0fc21d864f91f7)