### PR TITLE
Require admin approval for PWA inbox and run migrations + tenant sync during updates

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -98,10 +98,8 @@ def _get_company(user):
 def _check_mobile_inbox_access(user, company) -> bool:
     """Return True if the user may access the Mobile Inbox PWA.
 
-    Any authenticated user who belongs to a company is allowed by default.
-    Access is only denied when an admin has explicitly restricted the account
-    (both can_access_mobile_inbox AND can_access_full_app set to False).
-    Platform admins always pass regardless of access rows.
+    Access requires explicit admin approval per-user via
+    UserCompanyAccess.can_access_mobile_inbox. Platform admins always pass.
     """
     if user.is_admin:
         return True
@@ -117,8 +115,8 @@ def _check_mobile_inbox_access(user, company) -> bool:
     any_acc = UserCompanyAccess.query.filter_by(user_id=user.id).first()
     if any_acc:
         return any_acc.has_mobile_inbox_access()
-    # Has a company (via default_company_id) but no access row yet — allow through
-    return True
+    # No access row means not approved yet.
+    return False
 
 
 def _get_twilio_account(company_id):

--- a/models.py
+++ b/models.py
@@ -80,25 +80,16 @@ class UserCompanyAccess(db.Model):
         return self.role == self.ROLE_OWNER
 
     def has_mobile_inbox_access(self) -> bool:
-        """Any user with a company link can use the Mobile Inbox PWA.
+        """Mobile Inbox requires explicit admin approval.
 
-        Access is ON by default for every role.  The ``can_access_mobile_inbox``
-        column is an explicit *revoke* flag — it only blocks when an admin has
-        deliberately set it to False for a non-privileged role.  Because the
-        migration added this column with DEFAULT 0 we cannot use the raw column
-        value as a gate; instead we only honour a False value when the role
-        is not already privileged AND the flag is explicitly False *and* the
-        full-app flag is also False (i.e. a truly restricted account).
-
-        In practice: owner / admin / inbox_only always have access; every other
-        role has access unless both access flags are False simultaneously.
+        Rules:
+        - owner/admin role: always allowed
+        - inbox_only role: must still be explicitly approved
+        - all other roles: must be explicitly approved
         """
-        if self.role in (self.ROLE_OWNER, self.ROLE_ADMIN, self.ROLE_INBOX_ONLY):
+        if self.role in (self.ROLE_OWNER, self.ROLE_ADMIN):
             return True
-        # Explicitly restricted: admin turned off both flags on this account
-        if self.can_access_mobile_inbox is False and self.can_access_full_app is False:
-            return False
-        return True  # default — all roles can reach the PWA
+        return bool(self.can_access_mobile_inbox)
 
     def has_full_app_access(self) -> bool:
         """Inbox-only role never gets full app; all other roles default to True."""

--- a/scripts/create_company.py
+++ b/scripts/create_company.py
@@ -44,14 +44,15 @@ def run():
                 user_id=user.id, company_id=company.id
             ).first()
             if not acc:
-                role = "owner" if user.is_admin else "member"
+                role = "owner" if user.is_admin else "viewer"
                 acc = UserCompanyAccess(
                     user_id=user.id,
                     company_id=company.id,
                     role=role,
                     is_default=True,
                     can_access_full_app=True,
-                    can_access_mobile_inbox=True,
+                    # Mobile inbox requires explicit admin approval.
+                    can_access_mobile_inbox=bool(user.is_admin),
                 )
                 db.session.add(acc)
                 linked += 1

--- a/scripts/post-merge.sh
+++ b/scripts/post-merge.sh
@@ -7,11 +7,9 @@ echo "Installing Python dependencies..."
 pip install -q -r requirements.txt 2>&1 || echo "pip install completed with warnings"
 
 echo "Running database migrations..."
-python -c "
-from app import app, db
-with app.app_context():
-    db.create_all()
-    print('Database tables synced')
-"
+python scripts/migrate_db.py
+
+echo "Ensuring tenant company + user access links..."
+python scripts/create_company.py
 
 echo "=== Post-merge setup complete ==="

--- a/update.sh
+++ b/update.sh
@@ -36,10 +36,13 @@ chown -R "$APP_USER:$APP_USER" "$APP_DIR"
 echo "Updating Python dependencies..."
 sudo -u "$APP_USER" "$VENV_DIR/bin/pip" install --upgrade -r "$APP_DIR/deploy_requirements.txt"
 
-# Run database migrations if needed
+# Run database migrations + tenant data sync
 echo "Running database migrations..."
 cd "$APP_DIR"
-sudo -u "$APP_USER" bash -c "source $VENV_DIR/bin/activate && source .env && python3 -c 'from app import app, db; app.app_context().push(); db.create_all()'"
+sudo -u "$APP_USER" bash -c "source $VENV_DIR/bin/activate && source .env && python3 scripts/migrate_db.py"
+
+echo "Ensuring company + access rows exist..."
+sudo -u "$APP_USER" bash -c "source $VENV_DIR/bin/activate && source .env && python3 scripts/create_company.py"
 
 # Start the application
 echo "Starting application..."


### PR DESCRIPTION
### Motivation
- Users were getting access to the Mobile PWA inbox by default and the app could operate with no company context after code syncs, causing broken pages and missing data.
- VPS update/post-merge flow used `db.create_all()` which can miss schema drift and column backfills, allowing deployments to diverge from the expected schema.
- The PWA inbox must require explicit admin approval for mobile access and updates must ensure schema + tenant linkage are reconciled automatically during deployments.

### Description
- Changed `UserCompanyAccess.has_mobile_inbox_access()` in `models.py` to require explicit `can_access_mobile_inbox` for non-admin users while keeping owners/admins always allowed.
- Tightened the PWA gate in `inbox_pwa.py` so `_check_mobile_inbox_access()` denies access when no per-company access row exists and otherwise defers to `has_mobile_inbox_access()`.
- Fixed bootstrap linking in `scripts/create_company.py` to use a valid non-admin role (`viewer` instead of `member`) and to default `can_access_mobile_inbox=False` for non-admin users while granting it for admins.
- Replaced the simple `db.create_all()` post-merge step with running `scripts/migrate_db.py` and `scripts/create_company.py` in `scripts/post-merge.sh` and updated `update.sh` to run the same migration + tenant-access reconciliation under the VPS app user.

### Testing
- Compiled modified Python files with `python -m py_compile models.py inbox_pwa.py scripts/create_company.py scripts/migrate_db.py` and the compilation completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a16774058948322a4b48831925a5584)