### PR TITLE
Require explicit Mobile Inbox approval; add startup self-heal and deploy tenant sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -369,6 +369,56 @@ def create_app() -> Flask:
 
         db.create_all()
 
+        # Self-heal guard: ensure at least one company exists and users are linked.
+        # This prevents post-sync "no company" outages when ops scripts were skipped.
+        try:
+            from models import Company, User, UserCompanyAccess
+
+            company = Company.query.first()
+            if not company:
+                company = Company(
+                    name="LUXit Marketing",
+                    is_active=True,
+                    billing_tier="professional",
+                    billing_status="active",
+                    subscription_tier="professional",
+                    onboarding_status="complete",
+                )
+                db.session.add(company)
+                db.session.flush()
+                logging.warning(
+                    "Startup self-heal created fallback company '%s' (id=%s)",
+                    company.name,
+                    company.id,
+                )
+
+            changed = 0
+            for user in User.query.all():
+                acc = UserCompanyAccess.query.filter_by(
+                    user_id=user.id, company_id=company.id
+                ).first()
+                if not acc:
+                    acc = UserCompanyAccess(
+                        user_id=user.id,
+                        company_id=company.id,
+                        role="owner" if user.is_admin else "viewer",
+                        is_default=True,
+                        can_access_full_app=True,
+                        can_access_mobile_inbox=bool(user.is_admin),
+                    )
+                    db.session.add(acc)
+                    changed += 1
+                if not user.default_company_id:
+                    user.default_company_id = company.id
+                    changed += 1
+
+            if changed:
+                db.session.commit()
+                logging.warning("Startup self-heal updated %s user/company links.", changed)
+        except Exception as _self_heal_exc:
+            db.session.rollback()
+            logging.warning("Startup self-heal skipped due to error: %s", _self_heal_exc)
+
         # ── DB startup report (never logs secrets) ─────────────────────────
         try:
             from models import User, Company

--- a/deploy.sh
+++ b/deploy.sh
@@ -96,9 +96,24 @@ fi
 pkill -f "gunicorn.*127\.0\.0\.1:8000" 2>/dev/null \
   && warn "Killed stale gunicorn on port 8000" || true
 
-# ── 6. Restart service ────────────────────────────────────────────────────────
+# ── 6. Database migration + tenant sync ──────────────────────────────────────
 echo ""
-echo "── 5. Restart luxit service ──"
+echo "── 5. Database migration + tenant sync ──"
+if "$VENV/bin/python3" "$APP_DIR/scripts/migrate_db.py"; then
+  ok "migrate_db.py complete"
+else
+  fail "migrate_db.py failed"
+fi
+
+if "$VENV/bin/python3" "$APP_DIR/scripts/create_company.py"; then
+  ok "create_company.py complete"
+else
+  fail "create_company.py failed"
+fi
+
+# ── 7. Restart service ────────────────────────────────────────────────────────
+echo ""
+echo "── 6. Restart luxit service ──"
 systemctl daemon-reload
 systemctl restart "$SERVICE"
 sleep 3
@@ -110,9 +125,9 @@ else
   fail "$SERVICE failed to start"
 fi
 
-# ── 7. Health check ───────────────────────────────────────────────────────────
+# ── 8. Health check ───────────────────────────────────────────────────────────
 echo ""
-echo "── 6. Health check ──"
+echo "── 7. Health check ──"
 sleep 2
 HTTP=$(curl -s -o /dev/null -w '%{http_code}' -L --max-time 15 "$SITE/" 2>/dev/null || echo "000")
 if [[ "$HTTP" =~ ^(200|301|302)$ ]]; then

--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -98,10 +98,8 @@ def _get_company(user):
 def _check_mobile_inbox_access(user, company) -> bool:
     """Return True if the user may access the Mobile Inbox PWA.
 
-    Any authenticated user who belongs to a company is allowed by default.
-    Access is only denied when an admin has explicitly restricted the account
-    (both can_access_mobile_inbox AND can_access_full_app set to False).
-    Platform admins always pass regardless of access rows.
+    Access requires explicit admin approval per-user via
+    UserCompanyAccess.can_access_mobile_inbox. Platform admins always pass.
     """
     if user.is_admin:
         return True
@@ -117,8 +115,16 @@ def _check_mobile_inbox_access(user, company) -> bool:
     any_acc = UserCompanyAccess.query.filter_by(user_id=user.id).first()
     if any_acc:
         return any_acc.has_mobile_inbox_access()
-    # Has a company (via default_company_id) but no access row yet — allow through
-    return True
+    # No access row means not approved yet.
+    return False
+
+
+def _require_company(user):
+    """Resolve company context for APIs and avoid None.id crashes."""
+    company = _get_company(user)
+    if not company:
+        abort(409, "No company configured for this user.")
+    return company
 
 
 def _get_twilio_account(company_id):
@@ -716,12 +722,8 @@ def sse_stream():
 @inbox_pwa_bp.route("/api/inbox/badge-counts")
 def badge_counts():
     """Return missed-call and unread-voicemail counts for PWA badges."""
-    user, err = _require_auth()
-    if err:
-        return jsonify({"missed_calls": 0, "voicemails": 0})
-    company = _get_company(user)
-    if not company:
-        return jsonify({"missed_calls": 0, "voicemails": 0})
+    user = _require_auth()
+    company = _require_company(user)
 
     missed = 0
     vmails = 0
@@ -747,12 +749,8 @@ def badge_counts():
 @inbox_pwa_bp.route("/api/inbox/contacts/search")
 def search_contacts():
     """Search contacts by name or phone for the compose modal autocomplete."""
-    user, err = _require_auth()
-    if err:
-        return jsonify({"contacts": []})
-    company = _get_company(user)
-    if not company:
-        return jsonify({"contacts": []})
+    user = _require_auth()
+    company = _require_company(user)
 
     q = request.args.get("q", "").strip()
     if len(q) < 2:

--- a/models.py
+++ b/models.py
@@ -80,25 +80,16 @@ class UserCompanyAccess(db.Model):
         return self.role == self.ROLE_OWNER
 
     def has_mobile_inbox_access(self) -> bool:
-        """Any user with a company link can use the Mobile Inbox PWA.
+        """Mobile Inbox requires explicit admin approval.
 
-        Access is ON by default for every role.  The ``can_access_mobile_inbox``
-        column is an explicit *revoke* flag — it only blocks when an admin has
-        deliberately set it to False for a non-privileged role.  Because the
-        migration added this column with DEFAULT 0 we cannot use the raw column
-        value as a gate; instead we only honour a False value when the role
-        is not already privileged AND the flag is explicitly False *and* the
-        full-app flag is also False (i.e. a truly restricted account).
-
-        In practice: owner / admin / inbox_only always have access; every other
-        role has access unless both access flags are False simultaneously.
+        Rules:
+        - owner/admin role: always allowed
+        - inbox_only role: must still be explicitly approved
+        - all other roles: must be explicitly approved
         """
-        if self.role in (self.ROLE_OWNER, self.ROLE_ADMIN, self.ROLE_INBOX_ONLY):
+        if self.role in (self.ROLE_OWNER, self.ROLE_ADMIN):
             return True
-        # Explicitly restricted: admin turned off both flags on this account
-        if self.can_access_mobile_inbox is False and self.can_access_full_app is False:
-            return False
-        return True  # default — all roles can reach the PWA
+        return bool(self.can_access_mobile_inbox)
 
     def has_full_app_access(self) -> bool:
         """Inbox-only role never gets full app; all other roles default to True."""

--- a/scripts/create_company.py
+++ b/scripts/create_company.py
@@ -44,14 +44,15 @@ def run():
                 user_id=user.id, company_id=company.id
             ).first()
             if not acc:
-                role = "owner" if user.is_admin else "member"
+                role = "owner" if user.is_admin else "viewer"
                 acc = UserCompanyAccess(
                     user_id=user.id,
                     company_id=company.id,
                     role=role,
                     is_default=True,
                     can_access_full_app=True,
-                    can_access_mobile_inbox=True,
+                    # Mobile inbox requires explicit admin approval.
+                    can_access_mobile_inbox=bool(user.is_admin),
                 )
                 db.session.add(acc)
                 linked += 1

--- a/scripts/post-merge.sh
+++ b/scripts/post-merge.sh
@@ -7,11 +7,9 @@ echo "Installing Python dependencies..."
 pip install -q -r requirements.txt 2>&1 || echo "pip install completed with warnings"
 
 echo "Running database migrations..."
-python -c "
-from app import app, db
-with app.app_context():
-    db.create_all()
-    print('Database tables synced')
-"
+python scripts/migrate_db.py
+
+echo "Ensuring tenant company + user access links..."
+python scripts/create_company.py
 
 echo "=== Post-merge setup complete ==="

--- a/update.sh
+++ b/update.sh
@@ -36,10 +36,13 @@ chown -R "$APP_USER:$APP_USER" "$APP_DIR"
 echo "Updating Python dependencies..."
 sudo -u "$APP_USER" "$VENV_DIR/bin/pip" install --upgrade -r "$APP_DIR/deploy_requirements.txt"
 
-# Run database migrations if needed
+# Run database migrations + tenant data sync
 echo "Running database migrations..."
 cd "$APP_DIR"
-sudo -u "$APP_USER" bash -c "source $VENV_DIR/bin/activate && source .env && python3 -c 'from app import app, db; app.app_context().push(); db.create_all()'"
+sudo -u "$APP_USER" bash -c "source $VENV_DIR/bin/activate && source .env && python3 scripts/migrate_db.py"
+
+echo "Ensuring company + access rows exist..."
+sudo -u "$APP_USER" bash -c "source $VENV_DIR/bin/activate && source .env && python3 scripts/create_company.py"
 
 # Start the application
 echo "Starting application..."


### PR DESCRIPTION
### Motivation
- Prevent accidental open access to the Mobile Inbox PWA by making inbox access require explicit admin approval.
- Avoid outages on fresh/partial deployments where no Company row exists by ensuring a fallback company and linking users at startup.
- Ensure deployments and post-merge updates run DB migrations and tenant sync to keep schema and tenant rows consistent.

### Description
- Change access model: `UserCompanyAccess.has_mobile_inbox_access` now requires explicit approval for non-admin/owner roles and returns `bool(self.can_access_mobile_inbox)` for those roles. Owners/admins remain always allowed.
- Update PWA helpers in `inbox_pwa.py` to require an explicit per-company access row for mobile inbox usage, add `_require_company` which aborts with `409` when no company is resolvable, and switch several endpoints to use `_require_company` so they fail fast instead of returning empty payloads.
- Add a startup self-heal block in `app.py` that ensures at least one `Company` exists and creates/updates `UserCompanyAccess` rows and `default_company_id` for existing users to avoid "no company" crashes.
- Add/adjust scripts and deployment flow: `scripts/create_company.py` creates a default company, links users with role `owner` for admins and `viewer` for others, and sets `can_access_mobile_inbox` only for admins; `post-merge.sh`, `deploy.sh`, and `update.sh` were updated to run `scripts/migrate_db.py` and `scripts/create_company.py` during deployments/updates.

### Testing
- Ran syntax checks via the deploy script's `python -m py_compile` step for the modified files and confirmed no syntax errors during the test run.
- Executed `scripts/migrate_db.py` and `scripts/create_company.py` in a staging run to validate DB migration and tenant creation/linking, and both completed successfully.
- Started the app in a staging environment to verify it boots without errors and the agent scheduler initializes; health-checked endpoints for expected HTTP responses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a16774058948322a4b48831925a5584)