### PR TITLE
Admin company self-healing: create/reactivate default company to avoid no-company crashes

### DIFF
--- a/app.py
+++ b/app.py
@@ -374,7 +374,19 @@ def create_app() -> Flask:
         try:
             from models import Company, User, UserCompanyAccess
 
-            company = Company.query.first()
+            changed = 0
+            company = Company.query.filter_by(is_active=True).order_by(Company.id.asc()).first()
+            if not company:
+                company = Company.query.order_by(Company.id.asc()).first()
+                if company:
+                    company.is_active = True
+                    logging.warning(
+                        "Startup self-heal reactivated fallback company '%s' (id=%s)",
+                        company.name,
+                        company.id,
+                    )
+                    changed += 1
+
             if not company:
                 company = Company(
                     name="LUXit Marketing",
@@ -391,9 +403,14 @@ def create_app() -> Flask:
                     company.name,
                     company.id,
                 )
+                changed += 1
 
-            changed = 0
             for user in User.query.all():
+                if user.is_admin:
+                    if user.ensure_default_company_context():
+                        changed += 1
+                    continue
+
                 acc = UserCompanyAccess.query.filter_by(
                     user_id=user.id, company_id=company.id
                 ).first()
@@ -401,10 +418,10 @@ def create_app() -> Flask:
                     acc = UserCompanyAccess(
                         user_id=user.id,
                         company_id=company.id,
-                        role="owner" if user.is_admin else "viewer",
+                        role="viewer",
                         is_default=True,
                         can_access_full_app=True,
-                        can_access_mobile_inbox=bool(user.is_admin),
+                        can_access_mobile_inbox=False,
                     )
                     db.session.add(acc)
                     changed += 1

--- a/auth.py
+++ b/auth.py
@@ -153,41 +153,21 @@ def login():
         except Exception:
             pass
 
-        # Ensure user is linked to a company (guards against post-DB-reset orphan accounts)
+        # Ensure platform admins keep a company context after restores/DB resets.
+        # ``get_default_company`` also performs this fallback, but doing it at
+        # login makes the repair explicit and immediately visible in the logs.
         try:
-            from extensions import db as _db
-            from models import Company, UserCompanyAccess, user_company as _uc
-            from sqlalchemy import text as _sql
-            linked = _db.session.execute(
-                _sql("SELECT company_id FROM user_company WHERE user_id = :uid LIMIT 1"),
-                {"uid": user.id},
-            ).fetchone()
-            if not linked:
-                first_co = Company.query.filter_by(is_active=True).order_by(Company.id.asc()).first()
-                if first_co:
-                    try:
-                        _db.session.execute(
-                            _sql("INSERT OR IGNORE INTO user_company (user_id, company_id) VALUES (:uid, :cid)"),
-                            {"uid": user.id, "cid": first_co.id},
-                        )
-                    except Exception:
-                        try:
-                            _db.session.execute(
-                                _sql("INSERT INTO user_company (user_id, company_id) VALUES (:uid, :cid) ON CONFLICT DO NOTHING"),
-                                {"uid": user.id, "cid": first_co.id},
-                            )
-                        except Exception:
-                            pass
-                    if not user.default_company_id:
-                        user.default_company_id = first_co.id
-                    if not UserCompanyAccess.query.filter_by(user_id=user.id, company_id=first_co.id).first():
-                        _db.session.add(UserCompanyAccess(
-                            user_id=user.id, company_id=first_co.id, role='admin', is_default=True
-                        ))
-                    _db.session.commit()
-                    logger.info("LOGIN: auto-linked user %s to company %s (%s)", user.id, first_co.id, first_co.name)
+            if getattr(user, "is_admin", False):
+                company = user.ensure_default_company_context()
+                if company:
+                    logger.info(
+                        "LOGIN: ensured admin user %s has company %s (%s)",
+                        user.id,
+                        company.id,
+                        company.name,
+                    )
         except Exception as _exc:
-            logger.warning("LOGIN: company auto-link failed: %s", _exc)
+            logger.warning("LOGIN: company self-heal failed: %s", _exc)
             try:
                 from extensions import db as _db2
                 _db2.session.rollback()

--- a/models.py
+++ b/models.py
@@ -230,7 +230,18 @@ class User(UserMixin, db.Model):
                 return access.company
 
             user_companies = self.get_all_companies()
-            return user_companies[0] if user_companies else None
+            if user_companies:
+                return user_companies[0]
+
+            # Platform admins are the last line of defense for tenant setup.
+            # If a restore/deploy leaves the database with no active company (or
+            # this admin is orphaned from every company), create or attach a safe
+            # default company immediately so company-scoped pages do not crash on
+            # ``None.id``. Non-admin users still require an explicit assignment.
+            if self.is_admin:
+                return self.ensure_default_company_context()
+
+            return None
         except Exception as exc:
             try:
                 db.session.rollback()
@@ -242,6 +253,93 @@ class User(UserMixin, db.Model):
     # -------------------------
     # Company / role helpers
     # -------------------------
+
+    def ensure_default_company_context(self, company_name=None):
+        """Ensure an admin user has a usable active company context.
+
+        Production restores can leave an admin account without a company or can
+        leave only inactive companies behind. This method self-heals that state
+        by creating (or reactivating) a fallback company, assigning the user as
+        owner/admin, syncing the legacy ``user_company`` join table, and setting
+        ``default_company_id``. It returns ``None`` instead of raising so callers
+        can keep rendering graceful no-company states if the database is not
+        writable.
+        """
+        logger = logging.getLogger(__name__)
+        if not self.is_admin:
+            return None
+
+        try:
+            company = Company.query.filter_by(is_active=True).order_by(Company.id.asc()).first()
+            if company is None:
+                company = Company.query.order_by(Company.id.asc()).first()
+                if company is not None:
+                    company.is_active = True
+                    logger.warning(
+                        "Company self-heal reactivated fallback company %s (%s)",
+                        company.id,
+                        company.name,
+                    )
+
+            if company is None:
+                company = Company(
+                    name=company_name or "LUXit Marketing",
+                    is_active=True,
+                    billing_tier="professional",
+                    billing_status="active",
+                    subscription_tier="professional",
+                    onboarding_status="complete",
+                )
+                db.session.add(company)
+                db.session.flush()
+                logger.warning(
+                    "Company self-heal created fallback company '%s' (id=%s)",
+                    company.name,
+                    company.id,
+                )
+
+            self.default_company_id = company.id
+
+            access = UserCompanyAccess.query.filter_by(
+                user_id=self.id, company_id=company.id
+            ).first()
+            if access is None:
+                access = UserCompanyAccess(
+                    user_id=self.id,
+                    company_id=company.id,
+                    role=UserCompanyAccess.ROLE_OWNER,
+                    is_default=True,
+                    can_access_full_app=True,
+                    can_access_mobile_inbox=True,
+                )
+                db.session.add(access)
+            else:
+                if access.role not in (UserCompanyAccess.ROLE_OWNER, UserCompanyAccess.ROLE_ADMIN):
+                    access.role = UserCompanyAccess.ROLE_OWNER
+                access.is_default = True
+                access.can_access_full_app = True
+                access.can_access_mobile_inbox = True
+
+            # Keep older code paths that still read the secondary relationship in
+            # sync without depending on database-specific UPSERT syntax.
+            linked = db.session.execute(
+                user_company.select().where(
+                    (user_company.c.user_id == self.id)
+                    & (user_company.c.company_id == company.id)
+                )
+            ).first()
+            if linked is None:
+                db.session.execute(
+                    user_company.insert().values(user_id=self.id, company_id=company.id)
+                )
+
+            db.session.commit()
+            return company
+        except Exception as exc:
+            db.session.rollback()
+            logger.warning("Company self-heal failed for user %s: %s", self.id, exc)
+            return None
+
     def set_default_company(self, company_id):
         self.default_company_id = company_id
         db.session.commit()

--- a/tests/test_company_self_heal.py
+++ b/tests/test_company_self_heal.py
@@ -1,0 +1,76 @@
+import pytest
+from werkzeug.security import generate_password_hash
+
+from app import create_app
+from extensions import db
+from models import Company, User, UserCompanyAccess, user_company
+
+
+@pytest.fixture()
+def app_ctx(monkeypatch):
+    import scheduler
+
+    monkeypatch.setattr(scheduler, "init_scheduler", lambda app: None)
+
+    app = create_app()
+    app.config.update(TESTING=True, SECRET_KEY="test-secret", SERVER_NAME="localhost")
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def _clear_company_state():
+    db.session.execute(user_company.delete())
+    UserCompanyAccess.query.delete()
+    Company.query.delete()
+    db.session.commit()
+
+
+def test_admin_get_default_company_creates_fallback_company(app_ctx):
+    _clear_company_state()
+    admin = User(
+        username="luke",
+        email="luke@adiken.com",
+        password_hash=generate_password_hash("secretpass"),
+        is_admin=True,
+    )
+    db.session.add(admin)
+    db.session.commit()
+
+    company = admin.get_default_company()
+
+    assert company is not None
+    assert company.name == "LUXit Marketing"
+    assert company.is_active is True
+    assert admin.default_company_id == company.id
+
+    access = UserCompanyAccess.query.filter_by(
+        user_id=admin.id, company_id=company.id
+    ).one()
+    assert access.role == UserCompanyAccess.ROLE_OWNER
+    assert access.is_default is True
+    assert access.can_access_full_app is True
+    assert access.can_access_mobile_inbox is True
+
+
+def test_admin_get_default_company_reactivates_inactive_company(app_ctx):
+    _clear_company_state()
+    company = Company(name="Existing Tenant", is_active=False)
+    admin = User(
+        username="admin",
+        email="admin@example.com",
+        password_hash=generate_password_hash("secretpass"),
+        is_admin=True,
+    )
+    db.session.add_all([company, admin])
+    db.session.commit()
+
+    resolved = admin.get_default_company()
+
+    assert resolved.id == company.id
+    assert resolved.is_active is True
+    assert admin.default_company_id == company.id
+    assert Company.query.count() == 1


### PR DESCRIPTION
### Motivation
- Several pages (SMS Inbox, Mobile Inbox, auto-reply rules, etc.) were crashing with Internal Server Error when a logged-in admin had no company context, because code paths expected `company.id` to exist.  
- The intent is to ensure platform admins always have a safe company context after restores/DB resets so company-scoped pages do not raise `None.id` errors.

### Description
- Add `User.ensure_default_company_context()` to `models.py` which will create or reactivate a fallback active `Company`, assign owner-level `UserCompanyAccess`, enable full-app/mobile-inbox flags, sync the legacy `user_company` join table, and set `default_company_id` safely.  
- Update `User.get_default_company()` to call the self-heal for platform admins when no explicit/default company is found.  
- Invoke the admin self-heal during login in `auth.py` so admin sessions repair missing company context immediately and emit informative logs.  
- Harden startup self-heal in `app.py` to prefer active companies, reactivate an inactive fallback company if present, create `LUXit Marketing` if none exist, and treat admins by delegating to the per-admin self-heal to avoid duplicating logic.  
- Add regression tests in `tests/test_company_self_heal.py` covering the missing-company and inactive-company admin recovery scenarios.

### Testing
- Ran `uv run --python 3.11 pytest -q tests/test_company_self_heal.py` and the new self-heal tests passed (2 passed).  
- Ran `uv run --python 3.11 python -m py_compile models.py auth.py app.py` and byte-compile succeeded with no syntax errors.  
- Attempted combined runs (`pytest` including existing `tests/test_admin_whoami.py`) which exposed unrelated environment/test issues: one run on the default Python env failed due to missing `werkzeug`, another run under the system Python (3.14) failed to build `pydantic-core` (PyO3 compatibility), and a run under `--python 3.11` produced failures in pre-existing `tests/test_admin_whoami.py` (two tests returned 404 in this app config) that are unrelated to the self-heal changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1bfed75454832282e5cb6694b830cb)