### PR TITLE
PWA: restrict shell to mobile, add Twilio error mapping, call UI & rendering fixes

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -119,6 +119,25 @@ def _check_mobile_inbox_access(user, company) -> bool:
     return False
 
 
+def _is_mobile_request() -> bool:
+    """Return True when the PWA shell is requested from a mobile device.
+
+    The PWA is intentionally a mobile-only surface. Desktop users should use
+    the standard SMS Inbox at /twilio/inbox instead of a duplicate desktop PWA
+    shell.
+    """
+    sec_ch_mobile = (request.headers.get("Sec-CH-UA-Mobile") or "").strip().lower()
+    if sec_ch_mobile == "?1":
+        return True
+
+    ua = (request.headers.get("User-Agent") or "").lower()
+    mobile_tokens = (
+        "android", "iphone", "ipad", "ipod", "mobile", "windows phone",
+        "blackberry", "opera mini",
+    )
+    return any(token in ua for token in mobile_tokens)
+
+
 def _require_company(user):
     """Resolve company context for APIs and avoid None.id crashes."""
     company = _get_company(user)
@@ -160,6 +179,52 @@ def _sanitize_body(text: str) -> str:
     return text.replace("\x00", "")
 
 
+def _twilio_send_error_message(exc) -> str:
+    """Return a PWA-safe, action-oriented explanation for Twilio send failures."""
+    raw = str(exc) or type(exc).__name__
+    code = getattr(exc, "code", None)
+    status = getattr(exc, "status", None)
+
+    guidance_by_code = {
+        21211: "The recipient phone number is invalid. Check the number and try again.",
+        21408: "Twilio is not allowed to send SMS to that destination. Enable the region in Twilio geo permissions.",
+        21606: "The configured Twilio From number cannot send SMS. Check SMS Settings or use an SMS-capable Twilio number.",
+        21610: "This customer has opted out. They must reply START before texts can be sent again.",
+        21612: "Twilio cannot route SMS to that phone number. Check the recipient number and carrier support.",
+        21614: "The recipient does not appear to be a mobile/SMS-capable number.",
+        21617: "The message is too long for Twilio to send. Shorten it and try again.",
+        30003: "The carrier could not deliver the text. Verify the customer's number or try calling.",
+        30004: "The destination handset could not receive the text. Try again later or call the customer.",
+        30005: "The destination number is unknown or inactive. Check the customer's phone number.",
+        30006: "The destination number is a landline or unreachable by SMS. Try calling instead.",
+        30007: "The carrier filtered the message. Reword it to avoid links or promotional wording, then try again.",
+    }
+    if code in guidance_by_code:
+        return guidance_by_code[code]
+    if status == 403:
+        return (
+            "Twilio rejected the request with HTTP 403. Check that the Twilio "
+            "number is SMS/voice-capable, the Account SID/Auth Token are correct, "
+            "and the destination is allowed in Twilio. For urgent contact, place a call."
+        )
+
+    lower_raw = raw.lower()
+    if ("unable to create record" in lower_raw and "forbidden" in lower_raw) or "http 403" in lower_raw:
+        return (
+            "Twilio rejected the request with HTTP 403. Check that the Twilio "
+            "number is SMS/voice-capable, the Account SID/Auth Token are correct, "
+            "and the destination is allowed in Twilio. For urgent contact, place a call."
+        )
+    if "unverified" in lower_raw and "trial" in lower_raw:
+        return "Twilio trial accounts can only text verified recipient numbers. Verify this customer in Twilio or upgrade the account."
+    if "authenticate" in lower_raw or "authentication" in lower_raw or "account sid" in lower_raw:
+        return "Twilio authentication failed. Check the Account SID and Auth Token in SMS Settings."
+    if "not a valid phone number" in lower_raw:
+        return "The recipient phone number is invalid. Check the number and try again."
+
+    return raw
+
+
 def _send_sms_internal(ta, to_number: str, body: str, conversation_id=None):
     """Send SMS via Twilio — mirrors twilio_sms._send_sms."""
     from models import TwilioMessage
@@ -193,7 +258,7 @@ def _send_sms_internal(ta, to_number: str, body: str, conversation_id=None):
         return record, None
     except Exception as exc:
         logger.error("PWA Inbox SMS send error: %s", exc)
-        return None, str(exc)
+        return None, _twilio_send_error_message(exc)
 
 
 def _conv_to_dict(conv, brief=True):
@@ -241,10 +306,12 @@ def _msg_to_dict(m):
 
 @inbox_pwa_bp.route("/app/inbox")
 def pwa_index():
-    from flask import redirect
+    from flask import redirect, url_for
     user = _current_user()
     if not user:
         return redirect("/auth/login?next=/app/inbox")
+    if not _is_mobile_request():
+        return redirect(url_for("twilio.inbox"))
     company = _get_company(user)
     # No company assigned → show setup page
     if not company:
@@ -318,7 +385,7 @@ def list_conversations():
 @inbox_pwa_bp.route("/api/inbox/conversations/<int:conv_id>")
 def get_conversation(conv_id):
     user    = _require_auth()
-    company = _get_company(user)
+    company = _require_company(user)
     from models import TwilioConversation
     conv = TwilioConversation.query.filter_by(id=conv_id, company_id=company.id).first_or_404()
 
@@ -355,7 +422,7 @@ def get_conversation(conv_id):
 @inbox_pwa_bp.route("/api/inbox/conversations/<int:conv_id>/messages", methods=["POST"])
 def send_message(conv_id):
     user    = _require_auth()
-    company = _get_company(user)
+    company = _require_company(user)
     from models import TwilioConversation
     conv = TwilioConversation.query.filter_by(id=conv_id, company_id=company.id).first_or_404()
 
@@ -419,7 +486,7 @@ def _normalize_phone(raw: str) -> str:
 @inbox_pwa_bp.route("/api/inbox/conversations", methods=["POST"])
 def new_conversation():
     user    = _require_auth()
-    company = _get_company(user)
+    company = _require_company(user)
     payload = request.get_json() or {}
     to_raw  = (payload.get("to") or "").strip()
     body    = (payload.get("body") or "").strip()
@@ -817,9 +884,7 @@ def place_outbound_call(conv_id):
     message or testing).  Requires Twilio to be configured for the company.
     """
     user = _require_auth()
-    company = _get_company(user)
-    if not company:
-        return jsonify({"success": False, "error": "No company found."}), 400
+    company = _require_company(user)
 
     from models import TwilioConversation
     conv = TwilioConversation.query.filter_by(
@@ -828,9 +893,9 @@ def place_outbound_call(conv_id):
 
     ta = _get_twilio_account(company.id)
     if not ta:
-        return jsonify({"success": False, "error": "Twilio is not configured for this account."})
+        return jsonify({"success": False, "error": "Twilio is not configured for this account."}), 400
     if not ta.from_phone:
-        return jsonify({"success": False, "error": "No outbound phone number configured in Twilio settings."})
+        return jsonify({"success": False, "error": "No outbound phone number configured in Twilio settings."}), 400
 
     try:
         from twilio.rest import Client
@@ -873,7 +938,7 @@ def place_outbound_call(conv_id):
 
     except Exception as exc:
         logger.error("Outbound call error: %s", exc)
-        return jsonify({"success": False, "error": str(exc)})
+        return jsonify({"success": False, "error": _twilio_send_error_message(exc)}), 500
 
 
 def _fire_push_notification(company_id: int, conv, message_body: str):

--- a/templates/base.html
+++ b/templates/base.html
@@ -554,18 +554,11 @@
                     <a href="{{ url_for('twilio.inbox') }}" class="sidebar-nav-item{% if _p.startswith('/twilio/inbox') or _p.startswith('/twilio/conversation') %} active{% endif %}">
                         <i data-feather="message-square"></i> SMS Inbox
                     </a>
-                    {% set _co = current_user.get_default_company() if current_user.is_authenticated else None %}
-                    {% if _co %}
-                        <a href="/app/inbox" class="sidebar-nav-item{% if _p.startswith('/app/inbox') %} active{% endif %}" title="Mobile-friendly PWA inbox">
-                            <i data-feather="smartphone"></i> Mobile Inbox
-                            <span style="font-size:.6rem;padding:1px 6px;border-radius:10px;background:rgba(124,58,237,.3);color:#a78bfa;margin-left:4px;">PWA</span>
-                        </a>
-                    {% endif %}
-                    <a href="{{ url_for('twilio.rules') }}" class="sidebar-nav-item{% if _p.startswith('/twilio/rules') %} active{% endif %}">
-                        <i data-feather="zap"></i> Auto-Reply Rules
-                    </a>
-                    <a href="{{ url_for('twilio.settings') }}" class="sidebar-nav-item{% if _p.startswith('/twilio/settings') or _p.startswith('/twilio/hours') or _p.startswith('/twilio/analytics') or _p.startswith('/twilio/calls') %} active{% endif %}">
+                    <a href="{{ url_for('twilio.settings') }}" class="sidebar-nav-item{% if _p.startswith('/twilio/settings') or _p.startswith('/twilio/rules') or _p.startswith('/twilio/hours') or _p.startswith('/twilio/analytics') or _p.startswith('/twilio/calls') %} active{% endif %}">
                         <i data-feather="settings"></i> SMS Settings
+                    </a>
+                    <a href="{{ url_for('twilio.rules') }}" class="sidebar-nav-item{% if _p.startswith('/twilio/rules') %} active{% endif %}" style="padding-left:2.15rem;font-size:.82rem;">
+                        <i data-feather="zap"></i> Auto-Reply Rules
                     </a>
                     <a href="{{ url_for('main.social_media') }}" class="sidebar-nav-item{% if _p.startswith('/social') %} active{% endif %}">
                         <i data-feather="share-2"></i> Social

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -193,9 +193,10 @@
     .msg-row.out { justify-content: flex-end; }
     .msg-row.in  { justify-content: flex-start; }
     .bubble {
-      max-width: 72%; padding: 9px 14px; border-radius: 16px;
-      font-size: .88rem; line-height: 1.45; word-break: break-word;
-      white-space: pre-wrap;
+      display: inline-block;
+      max-width: min(72vw, 420px); padding: 9px 14px; border-radius: 16px;
+      font-size: .88rem; line-height: 1.45; word-break: normal;
+      overflow-wrap: break-word; white-space: pre-wrap;
     }
     .bubble.out { background: var(--purple); color: #fff; border-bottom-right-radius: 4px; }
     .bubble.in  { background: #1e2535; color: var(--text); border-bottom-left-radius: 4px; }
@@ -380,14 +381,15 @@
     }
 
     /* ── Thread call button ─────────────────────────── */
-    .thread-act-call {
+    .thread-actions .thread-act-call {
       display: flex; align-items: center; justify-content: center;
-      width: 30px; height: 30px; border-radius: 8px;
+      width: 30px; height: 30px; border-radius: 8px; padding: 0;
       background: rgba(34,197,94,.15); border: 1px solid rgba(34,197,94,.35);
-      color: var(--green); text-decoration: none; flex-shrink: 0;
+      color: var(--green); text-decoration: none; flex-shrink: 0; cursor: pointer;
       transition: background .15s;
     }
-    .thread-act-call:hover { background: rgba(34,197,94,.28); }
+    .thread-actions .thread-act-call:hover { background: rgba(34,197,94,.28); }
+    .thread-actions .thread-act-call:disabled { opacity: .6; cursor: wait; }
 
     /* ── Settings sheet links ──────────────────────── */
     .settings-link-row {
@@ -529,9 +531,9 @@
           <div class="thread-number" id="threadNumber"></div>
         </div>
         <div class="thread-actions">
-          <a  id="callBtn" href="tel:" class="thread-act-call" title="Call this contact">
+          <button id="callBtn" type="button" class="thread-act-call" title="Call via the LUXit Twilio number" onclick="placeTwilioCall()">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1 4.69 12 19.79 19.79 0 0 1 1.62 3.42 2 2 0 0 1 3.6 1.26h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L7.91 8.83a16 16 0 0 0 6.29 6.29l1.13-.91a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg>
-          </a>
+          </button>
           <button onclick="markCurrentRead(false)" title="Mark unread">◎</button>
           <button onclick="archiveCurrent()"       title="Archive">⊡</button>
           <button onclick="toggleContactPanel()"   title="Contact info">👤</button>
@@ -1014,7 +1016,7 @@ async function openConversation(convId) {
   document.getElementById('threadName').textContent   = c.display_name || c.from_number;
   document.getElementById('threadNumber').textContent = c.from_number !== c.display_name ? c.from_number : '';
   const callBtn = document.getElementById('callBtn');
-  if (callBtn) callBtn.href = 'tel:' + (c.from_number || '');
+  if (callBtn) callBtn.dataset.phone = c.from_number || '';
   document.getElementById('optOutBanner').style.display = c.is_opted_out ? '' : 'none';
   document.getElementById('msgInput').disabled = c.is_opted_out;
   document.getElementById('sendBtn').disabled  = c.is_opted_out;
@@ -1181,6 +1183,27 @@ function renderContactPanel(c, contact) {
 function toggleContactPanel() {
   const p = document.getElementById('contactPanel');
   p.style.display = p.style.display === 'flex' ? 'none' : 'flex';
+}
+
+/* ── Twilio click-to-call ─────────────────────────────────────── */
+async function placeTwilioCall() {
+  if (!state.activeConvId || state.isCalling) return;
+  const btn = document.getElementById('callBtn');
+  state.isCalling = true;
+  if (btn) btn.disabled = true;
+  try {
+    const data = await apiFetch(`/api/inbox/conversations/${state.activeConvId}/call`, 'POST', {});
+    if (data?.success) {
+      toast(data.message || 'Calling through the LUXit Twilio number now.', 'success');
+    } else {
+      toast(data?.error || 'Could not start a Twilio call.', 'error');
+    }
+  } catch (err) {
+    toast('Call error: ' + (err.message || 'Unknown error.'), 'error');
+  } finally {
+    state.isCalling = false;
+    if (btn) btn.disabled = false;
+  }
 }
 
 /* ── Send message ─────────────────────────────────────────────── */
@@ -1446,11 +1469,23 @@ function formatTime(iso) {
   return d.toLocaleDateString('en-US',{month:'short',day:'numeric'});
 }
 
+function normalizeSmsBody(str) {
+  let text = String(str || '').replace(/\r\n/g, '\n');
+  const lines = text.split('\n');
+  const nonEmpty = lines.filter(line => line.trim().length);
+  // Some provider/webhook payloads arrive with one visible character per line.
+  // Collapse only that pathological shape; preserve normal multi-line messages.
+  if (nonEmpty.length >= 4 && nonEmpty.every(line => line.trim().length === 1)) {
+    text = lines.map(line => line.trim()).join('');
+  }
+  return text;
+}
+
 function esc(str) {
   // HTML-escape only. Newlines are preserved as-is because the .bubble
   // uses white-space:pre-wrap, which renders them as visual line-breaks
   // without needing <br> tags (and without doubling up when combined with pre-wrap).
-  return String(str || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  return normalizeSmsBody(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
 }
 
 function openModal(id)  { document.getElementById(id).classList.add('show'); }

--- a/tests/test_inbox_pwa_sms_errors.py
+++ b/tests/test_inbox_pwa_sms_errors.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+from flask import Flask
+
+from inbox_pwa import _is_mobile_request, _twilio_send_error_message
+
+
+def test_twilio_send_error_message_maps_opt_out_code():
+    exc = SimpleNamespace(code=21610)
+
+    assert _twilio_send_error_message(exc) == (
+        "This customer has opted out. They must reply START before texts can be sent again."
+    )
+
+
+def test_twilio_send_error_message_explains_trial_unverified_numbers():
+    exc = Exception("The number +15551234567 is unverified. Trial accounts cannot message it.")
+
+    assert _twilio_send_error_message(exc) == (
+        "Twilio trial accounts can only text verified recipient numbers. "
+        "Verify this customer in Twilio or upgrade the account."
+    )
+
+
+def test_twilio_send_error_message_explains_http_403():
+    exc = SimpleNamespace(code=None, status=403)
+
+    assert _twilio_send_error_message(exc).startswith(
+        "Twilio rejected the request with HTTP 403."
+    )
+
+
+def test_twilio_send_error_message_explains_forbidden_record_text():
+    exc = Exception("Unable to create record: Forbidden")
+
+    assert _twilio_send_error_message(exc).startswith(
+        "Twilio rejected the request with HTTP 403."
+    )
+
+
+def test_mobile_request_detection_accepts_phone_user_agent():
+    app = Flask(__name__)
+
+    with app.test_request_context(headers={"User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)"}):
+        assert _is_mobile_request() is True
+
+
+def test_mobile_request_detection_rejects_desktop_user_agent():
+    app = Flask(__name__)
+
+    with app.test_request_context(headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64)"}):
+        assert _is_mobile_request() is False

--- a/tests/test_pwa_template_regressions.py
+++ b/tests/test_pwa_template_regressions.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pwa_call_button_uses_twilio_api_not_native_tel():
+    html = (ROOT / "templates" / "inbox_pwa" / "index.html").read_text()
+
+    assert 'id="callBtn"' in html
+    assert 'href="tel:' not in html
+    assert "/api/inbox/conversations/${state.activeConvId}/call" in html
+
+
+def test_pwa_message_bubbles_avoid_character_stacking_regression():
+    html = (ROOT / "templates" / "inbox_pwa" / "index.html").read_text()
+
+    assert "word-break: normal" in html
+    assert "overflow-wrap: break-word" in html
+    assert "function normalizeSmsBody" in html
+
+
+def test_desktop_sidebar_hides_duplicate_mobile_inbox_link():
+    html = (ROOT / "templates" / "base.html").read_text()
+
+    assert "Mobile Inbox" not in html
+    assert "/app/inbox" not in html
+    assert "SMS Inbox" in html
+    assert html.index("SMS Settings") < html.index("Auto-Reply Rules")


### PR DESCRIPTION
### Motivation
- Prevent desktop users from loading the mobile PWA shell and encourage using the existing desktop SMS Inbox instead.  
- Provide clearer, actionable error messages for Twilio send/call failures so agents know how to remediate issues.  
- Fix UI/UX regressions in the PWA (character stacking in message bubbles, click-to-call behavior, and button states).  

### Description
- Added `_is_mobile_request()` to detect mobile clients and updated `pwa_index()` to redirect desktop users to `url_for('twilio.inbox')`.  
- Introduced `_twilio_send_error_message()` to map Twilio error codes and common error text to user-friendly guidance, and wired it into `_send_sms_internal()` and outbound call error handling.  
- Replaced several `company = _get_company(user)` usages with `company = _require_company(user)` in API endpoints to enforce company presence and avoid None.id crashes.  
- Template changes in `templates/base.html` remove the duplicate "Mobile Inbox" sidebar link and reorder/merge SMS settings/rules links to avoid confusing desktop users.  
- PWA template updates in `templates/inbox_pwa/index.html` include CSS fixes for message bubbles (`word-break: normal`, `overflow-wrap: break-word`, max-width logic), switch the call control from a native `tel:` link to a JS button that POSTs to the server API, add `placeTwilioCall()` client function, add `normalizeSmsBody()` and apply it via `esc()` to avoid character-stacking and line-per-char webhook regressions, and improve call button disabled state styling.  
- Minor HTTP status code fixes: API error responses now include explicit status codes (400/500) in relevant locations.  
- Added tests: `tests/test_inbox_pwa_sms_errors.py` for error mapping and mobile detection, and `tests/test_pwa_template_regressions.py` for template/JS/CSS regressions.  

### Testing
- Ran `pytest tests/test_inbox_pwa_sms_errors.py` and `pytest tests/test_pwa_template_regressions.py`; both test modules passed.  
- Existing template/JS unit assertions verify the new call button, SMS normalization helpers, and that the desktop sidebar no longer contains the `/app/inbox` link, and those assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1cef75e16c83229c8a33969b377c88)