### PR TITLE
Add provider_message_sid column to SMSRecipient and persist Twilio SID

### DIFF
--- a/migrations/20260613_sms_campaign_compliance.sql
+++ b/migrations/20260613_sms_campaign_compliance.sql
@@ -10,7 +10,9 @@ ALTER TABLE sms_campaign ADD COLUMN IF NOT EXISTS estimated_recipient_count INTE
 ALTER TABLE sms_campaign ADD COLUMN IF NOT EXISTS test_sent_at TIMESTAMP NULL;
 ALTER TABLE sms_recipient ADD COLUMN IF NOT EXISTS phone_number VARCHAR(50) NULL;
 ALTER TABLE sms_recipient ADD COLUMN IF NOT EXISTS message_sid VARCHAR(100) NULL;
+ALTER TABLE sms_recipient ADD COLUMN IF NOT EXISTS provider_message_sid VARCHAR(255) NULL;
 ALTER TABLE sms_recipient ADD COLUMN IF NOT EXISTS error_code VARCHAR(50) NULL;
 ALTER TABLE twilio_account ADD COLUMN IF NOT EXISTS after_hours_cooldown_minutes INTEGER NOT NULL DEFAULT 720;
 CREATE INDEX IF NOT EXISTS ix_sms_campaign_company_id ON sms_campaign(company_id);
 CREATE INDEX IF NOT EXISTS ix_sms_recipient_campaign_status ON sms_recipient(campaign_id, status);
+CREATE INDEX IF NOT EXISTS ix_sms_recipient_provider_message_sid ON sms_recipient(provider_message_sid);

--- a/migrations/20260613_sms_campaign_compliance_rollback.sql
+++ b/migrations/20260613_sms_campaign_compliance_rollback.sql
@@ -1,8 +1,10 @@
 -- Rollback for 20260613_sms_campaign_compliance.sql (PostgreSQL).
+DROP INDEX IF EXISTS ix_sms_recipient_provider_message_sid;
 DROP INDEX IF EXISTS ix_sms_recipient_campaign_status;
 DROP INDEX IF EXISTS ix_sms_campaign_company_id;
 ALTER TABLE twilio_account DROP COLUMN IF EXISTS after_hours_cooldown_minutes;
 ALTER TABLE sms_recipient DROP COLUMN IF EXISTS error_code;
+ALTER TABLE sms_recipient DROP COLUMN IF EXISTS provider_message_sid;
 ALTER TABLE sms_recipient DROP COLUMN IF EXISTS message_sid;
 ALTER TABLE sms_recipient DROP COLUMN IF EXISTS phone_number;
 ALTER TABLE sms_campaign DROP COLUMN IF EXISTS test_sent_at;

--- a/models.py
+++ b/models.py
@@ -920,6 +920,7 @@ class SMSRecipient(db.Model):
     phone_number = db.Column(db.String(50))
     status = db.Column(db.String(50), default="pending")
     message_sid = db.Column(db.String(100))
+    provider_message_sid = db.Column(db.String(255), nullable=True, index=True)
     error_code = db.Column(db.String(50))
     sent_at = db.Column(db.DateTime)
     delivered_at = db.Column(db.DateTime)

--- a/services/sms_service.py
+++ b/services/sms_service.py
@@ -330,6 +330,7 @@ class SMSService:
                 recipient.status = 'sent'
                 recipient.sent_at = datetime.utcnow()
                 recipient.message_sid = result.get('message_sid')
+                recipient.provider_message_sid = result.get('message_sid')
                 sent += 1
             else:
                 recipient.status = 'failed'


### PR DESCRIPTION
### Motivation
- Resolve startup crash caused by a UniqueConstraint referencing a non-existent `provider_message_sid` column on `sms_recipient` so production can create the constraint and perform delivery-status lookups.
- Preserve existing duplicate-send protections and delivery-status logic that rely on provider SIDs.

### Description
- Add `provider_message_sid = db.Column(db.String(255), nullable=True, index=True)` to `SMSRecipient` so the model matches migrations and queries.
- Keep the existing `uq_sms_recipient_campaign_contact` unique constraint and retain the `uq_sms_recipient_provider_message_sid` constraint now that the column exists.
- Persist the Twilio SID to `provider_message_sid` when campaign SMS sends succeed in `services/sms_service.py` so delivery-status lookups (e.g., `SMSRecipient.query.filter_by(provider_message_sid=...)`) continue to work.
- Update `migrations/20260613_sms_campaign_compliance.sql` to add `provider_message_sid` and an index, and update the corresponding rollback file to remove the index/column.

### Testing
- Ran `python -m py_compile models.py routes.py twilio_sms.py services/sms_service.py` and compilation completed without syntax errors.
- Ran `FLASK_ENV=testing python - <<'PY'
from app import app
print("app import ok")
PY` and the app imported successfully in the testing environment.
- Attempted a normal app import (no `FLASK_ENV`) and it failed due to missing/unreachable `DATABASE_URL` in this environment, so a full live startup test was not performed here; remote deployment was not performed from this environment because no remote is configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a30b5ca418083228bd37fb168ce089c)