### PR TITLE
Per-number Twilio config + E.164 normalization and archived-conversation filtering fixes

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -639,11 +639,6 @@ def list_conversations():
         q = q.filter_by(is_read=False)
     elif filter_by == "mine":
         q = q.filter_by(assigned_user_id=user.id)
-    elif filter_by == "archived":
-        q = q.filter(TwilioConversation.tags.contains(["archived"]))
-    else:
-        # Default "all" excludes archived
-        q = q.filter(~TwilioConversation.tags.contains(["archived"]))
 
     if filter_by == "opted_out":
         q = q.filter_by(is_opted_out=True)
@@ -655,11 +650,19 @@ def list_conversations():
             TwilioConversation.last_message_preview.ilike(f"%{search}%"),
         ))
 
-    total        = q.count()
     unread_count = TwilioConversation.query.filter_by(
         company_id=company.id, is_read=False
     ).count()
-    convs = q.order_by(TwilioConversation.last_message_at.desc()).offset((page-1)*50).limit(50).all()
+
+    convs = q.order_by(TwilioConversation.last_message_at.desc()).all()
+    if filter_by == "archived":
+        convs = [c for c in convs if "archived" in (c.tags or [])]
+    else:
+        convs = [c for c in convs if "archived" not in (c.tags or [])]
+
+    total = len(convs)
+    per_page = 50
+    convs = convs[(page - 1) * per_page:page * per_page]
 
     return jsonify({
         "conversations": [_conv_to_dict(c) for c in convs],

--- a/tests/test_pwa_phone_system.py
+++ b/tests/test_pwa_phone_system.py
@@ -9,8 +9,10 @@ from models import (
     CallEvent,
     Company,
     PhoneSettings,
+    AutoReplyRule,
     TwilioAccount,
     TwilioCallLog,
+    TwilioPhoneNumber,
     User,
     UserCompanyAccess,
     VoiceVoicemailMessage,
@@ -263,3 +265,261 @@ def test_missed_call_sms_only_sends_when_enabled(app, client, world, monkeypatch
         db.session.add(log); db.session.commit()
     client.post("/twilio/voice/no-answer", data={"To": "+15550001000", "From": "+15551112222", "CallSid": "CAnoanswer", "DialCallStatus": "no-answer"})
     assert sent == []
+
+
+def test_inbox_conversations_all_excludes_archived_json_tags(client, app, world):
+    with app.app_context():
+        visible = TwilioConversation(
+            company_id=world["co_a"],
+            from_number="+15551000001",
+            to_number="+15550001000",
+            contact_name="Visible SMS",
+            tags=["lead"],
+            last_message_at=datetime(2026, 1, 2),
+        )
+        archived = TwilioConversation(
+            company_id=world["co_a"],
+            from_number="+15551000002",
+            to_number="+15550001000",
+            contact_name="Archived SMS",
+            tags=["archived"],
+            last_message_at=datetime(2026, 1, 3),
+        )
+        db.session.add_all([visible, archived])
+        db.session.commit()
+    login(client, world["alice"])
+
+    resp = client.get("/api/inbox/conversations?filter=all")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    names = {c["contact_name"] for c in body["conversations"]}
+    assert "Visible SMS" in names
+    assert "Archived SMS" not in names
+
+
+def test_inbox_conversations_archived_filter_uses_python_json_tag_check(client, app, world):
+    with app.app_context():
+        visible = TwilioConversation(
+            company_id=world["co_a"],
+            from_number="+15551000003",
+            to_number="+15550001000",
+            contact_name="Visible SMS 2",
+            tags=[],
+            last_message_at=datetime(2026, 1, 2),
+        )
+        archived = TwilioConversation(
+            company_id=world["co_a"],
+            from_number="+15551000004",
+            to_number="+15550001000",
+            contact_name="Archived SMS 2",
+            tags=["archived", "vip"],
+            last_message_at=datetime(2026, 1, 3),
+        )
+        db.session.add_all([visible, archived])
+        db.session.commit()
+    login(client, world["alice"])
+
+    resp = client.get("/api/inbox/conversations?filter=archived")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    names = {c["contact_name"] for c in body["conversations"]}
+    assert "Archived SMS 2" in names
+    assert "Visible SMS 2" not in names
+
+
+@pytest.mark.parametrize(
+    ("filter_name", "expected", "excluded"),
+    [
+        ("unread", "Unread SMS", "Read SMS"),
+        ("mine", "Assigned SMS", "Unassigned SMS"),
+        ("opted_out", "Opted Out SMS", "Opted In SMS"),
+    ],
+)
+def test_inbox_conversations_non_archived_filters_still_work(
+    client, app, world, filter_name, expected, excluded
+):
+    with app.app_context():
+        rows = [
+            TwilioConversation(
+                company_id=world["co_a"],
+                from_number="+15551000101",
+                to_number="+15550001000",
+                contact_name="Unread SMS",
+                is_read=False,
+                tags=[],
+                last_message_at=datetime(2026, 1, 4),
+            ),
+            TwilioConversation(
+                company_id=world["co_a"],
+                from_number="+15551000102",
+                to_number="+15550001000",
+                contact_name="Read SMS",
+                is_read=True,
+                tags=[],
+                last_message_at=datetime(2026, 1, 3),
+            ),
+            TwilioConversation(
+                company_id=world["co_a"],
+                from_number="+15551000103",
+                to_number="+15550001000",
+                contact_name="Assigned SMS",
+                assigned_user_id=world["alice"],
+                tags=[],
+                last_message_at=datetime(2026, 1, 2),
+            ),
+            TwilioConversation(
+                company_id=world["co_a"],
+                from_number="+15551000104",
+                to_number="+15550001000",
+                contact_name="Unassigned SMS",
+                tags=[],
+                last_message_at=datetime(2026, 1, 1),
+            ),
+            TwilioConversation(
+                company_id=world["co_a"],
+                from_number="+15551000105",
+                to_number="+15550001000",
+                contact_name="Opted Out SMS",
+                is_opted_out=True,
+                tags=[],
+                last_message_at=datetime(2026, 1, 6),
+            ),
+            TwilioConversation(
+                company_id=world["co_a"],
+                from_number="+15551000106",
+                to_number="+15550001000",
+                contact_name="Opted In SMS",
+                is_opted_out=False,
+                tags=[],
+                last_message_at=datetime(2026, 1, 5),
+            ),
+        ]
+        db.session.add_all(rows)
+        db.session.commit()
+    login(client, world["alice"])
+
+    resp = client.get(f"/api/inbox/conversations?filter={filter_name}")
+
+    assert resp.status_code == 200
+    names = {c["contact_name"] for c in resp.get_json()["conversations"]}
+    assert expected in names
+    assert excluded not in names
+
+
+def add_phone_number(company_id, number, **overrides):
+    ta = TwilioAccount.query.filter_by(company_id=company_id).one()
+    defaults = {
+        "company_id": company_id,
+        "twilio_account_id": ta.id,
+        "phone_number": number,
+        "is_active": True,
+        "sms_enabled": True,
+        "voice_enabled": True,
+    }
+    defaults.update(overrides)
+    pn = TwilioPhoneNumber(**defaults)
+    db.session.add(pn)
+    db.session.flush()
+    return pn
+
+
+def test_inbound_sms_uses_company_a_number_business_hours_and_auto_reply(app, client, world, monkeypatch):
+    sent = []
+    monkeypatch.setattr("twilio_sms._send_sms", lambda ta, to, body, **kw: sent.append((ta.company_id, ta.from_phone, to, body)) or {"success": True})
+    with app.app_context():
+        save_settings(world["co_a"], business_hours={str(i): {"is_open": False} for i in range(7)})
+        save_settings(world["co_b"], business_hours={str(i): {"is_open": True, "open": "00:00", "close": "23:59"} for i in range(7)})
+        add_phone_number(world["co_a"], "+15550001000", after_hours_text="Company A after-hours SMS")
+        add_phone_number(world["co_b"], "+15550002000", after_hours_text="Company B after-hours SMS")
+        db.session.add(AutoReplyRule(company_id=world["co_a"], name="A after hours", trigger_type="after_hours", action="reply", response="fallback A", is_active=True))
+        db.session.add(AutoReplyRule(company_id=world["co_b"], name="B after hours", trigger_type="after_hours", action="reply", response="fallback B", is_active=True))
+        db.session.commit()
+
+    resp = client.post("/twilio/sms/inbound", data={"From": "+15551110001", "To": "+15550001000", "Body": "hello", "MessageSid": "SMA"})
+
+    assert resp.status_code == 200
+    assert sent == [(world["co_a"], "+15550001000", "+15551110001", "Company A after-hours SMS")]
+
+
+def test_inbound_sms_uses_company_b_number_business_hours_and_auto_reply(app, client, world, monkeypatch):
+    sent = []
+    monkeypatch.setattr("twilio_sms._send_sms", lambda ta, to, body, **kw: sent.append((ta.company_id, ta.from_phone, to, body)) or {"success": True})
+    with app.app_context():
+        save_settings(world["co_a"], business_hours={str(i): {"is_open": True, "open": "00:00", "close": "23:59"} for i in range(7)})
+        save_settings(world["co_b"], business_hours={str(i): {"is_open": False} for i in range(7)})
+        add_phone_number(world["co_a"], "+15550001000", after_hours_text="Company A after-hours SMS")
+        add_phone_number(world["co_b"], "+15550002000", after_hours_text="Company B after-hours SMS")
+        db.session.add(AutoReplyRule(company_id=world["co_a"], name="A after hours", trigger_type="after_hours", action="reply", response="fallback A", is_active=True))
+        db.session.add(AutoReplyRule(company_id=world["co_b"], name="B after hours", trigger_type="after_hours", action="reply", response="fallback B", is_active=True))
+        db.session.commit()
+
+    resp = client.post("/twilio/sms/inbound", data={"From": "+15551110002", "To": "+1 (555) 000-2000", "Body": "hello", "MessageSid": "SMB"})
+
+    assert resp.status_code == 200
+    assert sent == [(world["co_b"], "+15550002000", "+15551110002", "Company B after-hours SMS")]
+
+
+def test_company_a_after_hours_does_not_affect_company_b_open_number(app, client, world, monkeypatch):
+    sent = []
+    monkeypatch.setattr("twilio_sms._send_sms", lambda ta, to, body, **kw: sent.append((ta.company_id, body)) or {"success": True})
+    with app.app_context():
+        save_settings(world["co_a"], business_hours={str(i): {"is_open": False} for i in range(7)})
+        save_settings(world["co_b"], business_hours={str(i): {"is_open": True, "open": "00:00", "close": "23:59"} for i in range(7)})
+        add_phone_number(world["co_a"], "+15550001000", after_hours_text="Company A after-hours SMS")
+        add_phone_number(world["co_b"], "+15550002000", after_hours_text="Company B after-hours SMS")
+        db.session.add(AutoReplyRule(company_id=world["co_a"], name="A after hours", trigger_type="after_hours", action="reply", response="fallback A", is_active=True))
+        db.session.add(AutoReplyRule(company_id=world["co_b"], name="B after hours", trigger_type="after_hours", action="reply", response="fallback B", is_active=True))
+        db.session.commit()
+
+    resp = client.post("/twilio/sms/inbound", data={"From": "+15551110003", "To": "+15550002000", "Body": "hello", "MessageSid": "SMBOPEN"})
+
+    assert resp.status_code == 200
+    assert sent == []
+
+
+def test_inbound_voice_voicemail_greeting_is_selected_by_to_number_company(app, client, world):
+    with app.app_context():
+        save_settings(world["co_a"], business_hours={str(i): {"is_open": False} for i in range(7)}, after_hours_route="voicemail")
+        save_settings(world["co_b"], business_hours={str(i): {"is_open": False} for i in range(7)}, after_hours_route="voicemail")
+        add_phone_number(world["co_a"], "+15550001000", voicemail_greeting_text="Company A voicemail greeting")
+        add_phone_number(world["co_b"], "+15550002000", voicemail_greeting_text="Company B voicemail greeting")
+        db.session.commit()
+
+    resp = client.post("/api/twilio/voice/incoming", data={"From": "+15552220000", "To": "+15550002000", "CallSid": "CABvm", "CallStatus": "ringing"})
+
+    assert resp.status_code == 200
+    assert b"Company B voicemail greeting" in resp.data
+    assert b"Company A voicemail greeting" not in resp.data
+
+
+def test_inbound_voice_forwarding_number_is_selected_by_to_number_company(app, client, world):
+    with app.app_context():
+        save_settings(world["co_a"], during_hours_route="forward", forward_number="+15554440001")
+        save_settings(world["co_b"], during_hours_route="forward", forward_number="+15554440002")
+        add_phone_number(world["co_a"], "+15550001000", call_forward_to="+15553330001")
+        add_phone_number(world["co_b"], "+15550002000", call_forward_to="+15553330002")
+        db.session.commit()
+
+    resp = client.post("/api/twilio/voice/incoming", data={"From": "+15552220001", "To": "+15550002000", "CallSid": "CABfwd", "CallStatus": "ringing"})
+
+    assert resp.status_code == 200
+    assert b"+15553330002" in resp.data
+    assert b"+15553330001" not in resp.data
+    assert b"+15554440002" not in resp.data
+
+
+def test_inbound_sms_conversation_is_assigned_to_to_number_company(app, client, world, monkeypatch):
+    monkeypatch.setattr("twilio_sms._send_sms", lambda *args, **kwargs: {"success": True})
+    with app.app_context():
+        add_phone_number(world["co_a"], "+15550001000")
+        add_phone_number(world["co_b"], "+15550002000")
+        db.session.commit()
+
+    resp = client.post("/twilio/sms/inbound", data={"From": "+15551119999", "To": "+15550002000", "Body": "route me", "MessageSid": "SMROUTE"})
+
+    assert resp.status_code == 200
+    with app.app_context():
+        assert TwilioConversation.query.filter_by(company_id=world["co_b"], from_number="+15551119999").one()
+        assert TwilioConversation.query.filter_by(company_id=world["co_a"], from_number="+15551119999").first() is None

--- a/twilio_sms.py
+++ b/twilio_sms.py
@@ -103,25 +103,82 @@ def _get_twilio_account_by_number(to_number: str):
     return ta
 
 
+def _normalize_e164(number: str) -> str:
+    """Normalize common US phone formats to E.164 for inbound Twilio lookups."""
+    raw = (number or "").strip()
+    if not raw:
+        return ""
+    if raw.startswith("+") and raw[1:].isdigit():
+        return raw
+    digits = re.sub(r"\D", "", raw)
+    if len(digits) == 10:
+        return f"+1{digits}"
+    if len(digits) == 11 and digits.startswith("1"):
+        return f"+{digits}"
+    return raw
+
+
+class _NumberScopedTwilioConfig:
+    """TwilioAccount view with TwilioPhoneNumber routing overrides applied."""
+
+    _PN_OVERRIDES = (
+        "sms_forward_to",
+        "sms_forwarding_enabled",
+        "auto_reply_enabled",
+        "call_forward_to",
+        "voice_forwarding_enabled",
+        "voicemail_greeting_text",
+        "voicemail_greeting_audio_url",
+        "missed_call_text",
+        "after_hours_text",
+        "after_hours_sms_enabled",
+        "after_hours_voicemail_enabled",
+    )
+
+    def __init__(self, account, phone_number=None):
+        self._account = account
+        self.phone_number = phone_number
+        for key in self._PN_OVERRIDES:
+            value = getattr(phone_number, key, None) if phone_number else None
+            setattr(self, key, value if value not in (None, "") else getattr(account, key, None))
+        self.company_id = phone_number.company_id if phone_number else account.company_id
+        self.from_phone = (
+            phone_number.phone_number
+            if phone_number and getattr(phone_number, "phone_number", None)
+            else account.from_phone
+        )
+        self.messaging_service_sid = account.messaging_service_sid
+
+    def __getattr__(self, name):
+        return getattr(self._account, name)
+
+
+def _effective_twilio_config(ta, phone_number=None):
+    if not ta:
+        return None
+    return _NumberScopedTwilioConfig(ta, phone_number) if phone_number else ta
+
+
 def _resolve_number(to_number: str, msg_service_sid: str = ""):
     """
     Phase A: Resolve inbound Twilio webhook to (TwilioPhoneNumber, TwilioAccount).
 
     Lookup priority:
-      1. TwilioPhoneNumber.phone_number == to_number  (multi-number DB, primary path)
+      1. TwilioPhoneNumber.phone_number == normalized to_number
       2. TwilioAccount.messaging_service_sid == msg_service_sid (messaging service)
-      3. TwilioAccount.from_phone == to_number  (legacy single-number accounts)
-      4. First active TwilioAccount (absolute fallback — existing behaviour)
+      3. TwilioAccount.from_phone == normalized to_number (legacy single-number accounts)
 
     Returns (pn_or_None, ta_or_None).
     """
     from models import TwilioPhoneNumber, TwilioAccount
 
+    normalized_to = _normalize_e164(to_number)
+
     # ── 1. Look up by phone number in new multi-number table ─────────────────
     pn = None
-    if to_number:
+    if normalized_to:
         pn = TwilioPhoneNumber.query.filter_by(
-            phone_number=to_number, is_active=True
+            phone_number=normalized_to, is_active=True
         ).first()
 
     if pn:
@@ -144,17 +201,14 @@ def _resolve_number(to_number: str, msg_service_sid: str = ""):
             return None, ta
 
     # ── 3. Legacy from_phone on TwilioAccount ────────────────────────────────
-    if to_number:
-        ta = TwilioAccount.query.filter_by(from_phone=to_number).first()
+    if normalized_to:
+        ta = TwilioAccount.query.filter_by(from_phone=normalized_to).first()
         if ta:
             logger.debug("_resolve_number: matched legacy from_phone ta=%s", ta.id)
             return None, ta
 
-    # ── 4. Absolute fallback — first active account ───────────────────────────
-    ta = TwilioAccount.query.filter_by(is_active=True).first()
-    if ta:
-        logger.debug("_resolve_number: fallback to first active TwilioAccount id=%s", ta.id)
-    return None, ta
+    logger.warning("_resolve_number: no Twilio number owner found for to=%s", to_number)
+    return None, None
 
 
 def _seed_phone_numbers_from_accounts():
@@ -507,20 +561,21 @@ def _send_sms(ta, to_number: str, body: str,
         else:
             msg = client.messages.create(**kwargs)
 
-        record = TwilioMessage(
-            conversation_id=conversation_id,
-            company_id=ta.company_id,
-            twilio_sid=msg.sid,
-            direction="outbound",
-            from_number=ta.from_phone or ta.messaging_service_sid,
-            to_number=to_number,
-            body=body,
-            status=msg.status,
-            is_auto_reply=is_auto_reply,
-            rule_id=rule_id,
-        )
-        db.session.add(record)
-        db.session.commit()
+        if conversation_id:
+            record = TwilioMessage(
+                conversation_id=conversation_id,
+                company_id=ta.company_id,
+                twilio_sid=msg.sid,
+                direction="outbound",
+                from_number=ta.from_phone or ta.messaging_service_sid,
+                to_number=to_number,
+                body=body,
+                status=msg.status,
+                is_auto_reply=is_auto_reply,
+                rule_id=rule_id,
+            )
+            db.session.add(record)
+            db.session.commit()
         logger.info("Outbound SMS sent: sid=%s to=%s", msg.sid, to_number)
         try:
             from services.posthog_client import track_event
@@ -917,10 +972,11 @@ def inbound_sms():
     )
 
     # ── 1. Find TwilioPhoneNumber + TwilioAccount (Phase A multi-number) ────
-    _pn, ta = _resolve_number(to_number, msg_service_sid)
+    pn, ta = _resolve_number(to_number, msg_service_sid)
     if not ta:
         logger.warning("Inbound SMS: no TwilioAccount found for to=%s", to_number)
         return '<Response></Response>', 200, {"Content-Type": "text/xml"}
+    ta = _effective_twilio_config(ta, pn)
 
     # ── 2. Validate Twilio signature ───────────────────────────────────────
     if not _validate_twilio_signature(ta, "/twilio/sms/inbound"):
@@ -1132,7 +1188,7 @@ def inbound_sms():
                 _capture_lead(conv, body, ta.company_id)
 
             # Run rules only if not opted out
-            if not conv.is_opted_out:
+            if not conv.is_opted_out and getattr(ta, "auto_reply_enabled", True):
                 _apply_auto_reply_rules(conv, body, ta)
         except Exception as rule_exc:
             logger.exception("Error in auto-reply rule engine: %s", rule_exc)
@@ -1285,12 +1341,13 @@ def inbound_call():
     duration    = int(data.get("CallDuration") or 0)
     caller_name = data.get("CallerName", "")
 
-    _pn, ta = _resolve_number(to_number)
+    pn, ta = _resolve_number(to_number)
 
     if not ta:
         twiml = """<?xml version="1.0" encoding="UTF-8"?>
 <Response><Say>Thank you for calling. Goodbye.</Say></Response>"""
         return twiml, 200, {"Content-Type": "text/xml"}
+    ta = _effective_twilio_config(ta, pn)
 
     # Validate Twilio signature
     signature_path = "/twilio/voice/inbound" if request.path.startswith("/twilio/") else "/api/twilio/voice/incoming"
@@ -1326,11 +1383,21 @@ def inbound_call():
 
     # Determine routing
     in_hours = _is_business_hours(ta.company_id)
-    if (not in_hours) and settings and settings.after_hours_sms_enabled and settings.after_hours_sms_body and from_number and log and not log.missed_text_sent:
+    after_hours_sms_enabled = (
+        getattr(ta, "after_hours_sms_enabled", False)
+        if pn and getattr(pn, "after_hours_sms_enabled", None) is not None
+        else bool(settings and settings.after_hours_sms_enabled)
+    )
+    after_hours_sms_body = (
+        getattr(ta, "after_hours_text", None)
+        if pn
+        else (settings.after_hours_sms_body if settings else None) or getattr(ta, "after_hours_text", None)
+    )
+    if (not in_hours) and after_hours_sms_enabled and after_hours_sms_body and from_number and log and not log.missed_text_sent:
         try:
             can_send, reason = _can_send_call_auto_sms(ta.company_id, from_number)
             if can_send:
-                result = _send_sms(ta, from_number, settings.after_hours_sms_body)
+                result = _send_sms(ta, from_number, after_hours_sms_body)
                 if result.get("success"):
                     log.missed_text_sent = True
                     db.session.commit()
@@ -1340,7 +1407,8 @@ def inbound_call():
             logger.warning("After-hours SMS auto-reply failed for call sid=%s: %s", call_sid, exc)
 
     def _voicemail_twiml(after_hours=False):
-        greeting = ((settings.after_hours_voicemail_greeting if after_hours and settings else None) or
+        greeting = ((ta.voicemail_greeting_text if pn else None) or
+                    (settings.after_hours_voicemail_greeting if after_hours and settings else None) or
                     (settings.voicemail_greeting if settings else None) or
                     ta.voicemail_greeting_text or
                     "Thank you for calling. Please leave your name and message after the tone.")
@@ -1363,7 +1431,11 @@ def inbound_call():
         )
 
     route = (settings.during_hours_route if settings and in_hours else settings.after_hours_route if settings else None)
-    forward_to = ((settings.forward_number if in_hours else settings.after_hours_forward_number) if settings else None) or ta.call_forward_to
+    forward_to = (
+        (ta.call_forward_to if pn else None)
+        or ((settings.forward_number if in_hours else settings.after_hours_forward_number) if settings else None)
+        or ta.call_forward_to
+    )
     fallback_to = ((settings.fallback_forward_number if in_hours else settings.after_hours_fallback_forward_number) if settings else None)
     timeout = (settings.ring_duration_seconds if settings else None) or 25
     record_attr = ' record="record-from-answer" recordingStatusCallback="/twilio/voice/recording"' if settings and settings.recording_enabled else ""
@@ -1378,7 +1450,7 @@ def inbound_call():
         return (
             f'<?xml version="1.0" encoding="UTF-8"?>\n'
             f"<Response>\n"
-            f'  <Dial callerId="{caller_id}" timeout="{timeout}" action="/twilio/voice/no-answer" method="POST"{record_attr}>\n'
+            f'  <Dial callerId="{caller_id}" timeout="{timeout}" action="/twilio/voice/no-answer?to={html.escape(to_number or "", quote=True)}" method="POST"{record_attr}>\n'
             f"    <Number>{number}</Number>{fallback_xml}\n"
             f"  </Dial>\n"
             f"</Response>"
@@ -1407,7 +1479,7 @@ def inbound_call():
         twiml = (
             '<?xml version="1.0" encoding="UTF-8"?>\n'
             '<Response>\n'
-            f'  <Dial callerId="{safe_caller_id}" timeout="{timeout}" action="/twilio/voice/no-answer" method="POST"{record_attr}>\n'
+            f'  <Dial callerId="{safe_caller_id}" timeout="{timeout}" action="/twilio/voice/no-answer?to={html.escape(to_number or "", quote=True)}" method="POST"{record_attr}>\n'
             '    <Client>\n'
             f'      <Identity>{client_identity}</Identity>\n'
             f'      <Parameter name="call_log_id" value="{log.id if log else ""}"/>\n'
@@ -1462,9 +1534,10 @@ def voice_no_answer():
     data        = request.form
     call_sid    = data.get("CallSid", "")
     dial_status = data.get("DialCallStatus", "")
-    to_number   = data.get("To", "")
+    to_number   = request.args.get("to") or data.get("To", "")
 
-    _pn, ta = _resolve_number(to_number)
+    pn, ta = _resolve_number(to_number)
+    ta = _effective_twilio_config(ta, pn) if ta else None
 
     logger.info("Voice no-answer: sid=%s dial_status=%s", call_sid, dial_status)
 
@@ -1479,7 +1552,9 @@ def voice_no_answer():
     from_number = data.get("From", "")
     settings = PhoneSettings.query.filter_by(company_id=ta.company_id).first() if ta else None
     sms_body = None
-    if ta and settings and settings.missed_call_sms_enabled:
+    if ta and pn and ta.missed_call_text:
+        sms_body = ta.missed_call_text
+    elif ta and settings and settings.missed_call_sms_enabled:
         sms_body = settings.missed_call_sms_body or ta.missed_call_text
     elif ta and not settings and ta.missed_call_text:
         sms_body = ta.missed_call_text
@@ -1497,7 +1572,8 @@ def voice_no_answer():
 
     # Fall through to voicemail
     if ta:
-        greeting = ((settings.voicemail_greeting if settings else None) or ta.voicemail_greeting_text or
+        greeting = ((ta.voicemail_greeting_text if pn else None) or
+                    (settings.voicemail_greeting if settings else None) or ta.voicemail_greeting_text or
                     "Thank you for calling. Please leave your name and message after the tone.")
         if ta.voicemail_greeting_audio_url:
             greeting_xml = f"<Play>{ta.voicemail_greeting_audio_url}</Play>"


### PR DESCRIPTION
### Motivation

- Ensure inbound webhooks and call/SMS routing respect per-phone-number overrides rather than only account-level settings.
- Normalize incoming `To` values to E.164 to make lookups robust across common phone formats.
- Fix inbox conversation listing so `archived` tag filtering works reliably for JSON `tags` and preserve pagination.

### Description

- Introduced `_normalize_e164`, `_NumberScopedTwilioConfig`, and `_effective_twilio_config` in `twilio_sms.py` and switched resolution to return `(pn, ta)` from `_resolve_number`, then apply phone-number-specific overrides when present. 
- Changed `_resolve_number` to look up by normalized phone number and by messaging service SID, removed the unconditional fallback to the first active `TwilioAccount`, and log when no owner is found. 
- Updated inbound handlers to use the resolved phone number + account (`pn, ta`) and `ta = _effective_twilio_config(ta, pn)` so per-number overrides (forwarding, auto-replies, voicemail text/audio, after-hours SMS, missed-call text, etc.) are respected; adjusted `inbound_sms`, `inbound_call`, and `voice_no_answer` accordingly. 
- Added `._normalize_e164` usage for legacy `from_phone` comparisons and made a small safety-change to include the `to` query param on Dial `action` callbacks so the `voice_no_answer` handler can resolve the number. 
- Modified `_send_sms` to only persist `TwilioMessage` records when a `conversation_id` is provided to avoid creating orphan message records. 
- Reworked `list_conversations` in `inbox_pwa.py` to perform archived-tag filtering in Python on the loaded rows (using `c.tags` JSON list) and changed to compute `total` before applying pagination while still ordering by `last_message_at`. 
- Added/updated tests in `tests/test_pwa_phone_system.py` to cover archived tag behavior, per-number routing and greetings, inbound SMS routing to the correct company by `To` number, business-hours/after-hours behavior per phone number, and several other scenarios; also added helper `add_phone_number` in tests.

### Testing

- Added unit tests in `tests/test_pwa_phone_system.py` exercising archived tag filtering, per-phone-number auto-reply/voicemail/forwarding selection, and routing; these tests were run as part of the project's `pytest` suite. 
- Ran the test suite via `pytest` and all tests (including the newly added ones) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a322061e8c08322beb9b04e1557810b)