### PR TITLE
SMS campaign audit: schema repair migration, tenant scoping, route/template updates, and tests

### DIFF
--- a/SMS_CAMPAIGN_DEPLOYMENT_NOTES.md
+++ b/SMS_CAMPAIGN_DEPLOYMENT_NOTES.md
@@ -205,3 +205,82 @@ Rollback guidance:
 - [ ] Delivery status callback persists recipient status without secrets.
 - [ ] Tenant routing by To number / tenant Twilio config verified.
 - [ ] Browser QA confirms Social and SMS Campaign pages load and branding/navigation/responsive layout are unchanged.
+
+## 2026-06-17 SMS campaign audit hotfix post-merge checklist
+
+Apply this checklist immediately after deploying the SMS campaign audit fix that added
+`migrations/20260617_sms_campaign_audit_fix.sql`.
+
+### 1. Apply migration
+
+Run with `ON_ERROR_STOP` so deployment fails fast if PostgreSQL rejects any
+schema repair statement:
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f migrations/20260617_sms_campaign_audit_fix.sql
+```
+
+Recommended idempotency confirmation:
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f migrations/20260617_sms_campaign_audit_fix.sql
+```
+
+### 2. Restart services
+
+Use the command that matches the production process manager:
+
+```bash
+systemctl restart lux-email-bot
+```
+
+or
+
+```bash
+docker compose restart web lux-email-bot
+```
+
+or
+
+```bash
+pm2 restart all
+```
+
+### 3. Smoke test the SMS campaign flow
+
+In a browser session for an authorized tenant admin/manager/editor:
+
+- Open `/app/sms-campaigns` and confirm it loads.
+- Click the left sidebar **SMS Campaigns** link and confirm it lands on the canonical campaign list.
+- Open `/sms` and confirm it redirects to `/app/sms-campaigns`.
+- Open `/sms-dashboard` and confirm it redirects to `/app/sms-campaigns`.
+- Open `/sms/create` and confirm it loads without a 500.
+- Create a draft SMS campaign.
+- Schedule an SMS campaign.
+- Confirm the scheduled campaign appears on the marketing calendar.
+- Confirm the calendar SMS campaign edit link opens the campaign edit page.
+- Confirm the analytics page loads SMS metrics without crashing.
+- Confirm AI reports/agent context include only the active tenant's SMS campaigns.
+
+### 4. Watch production logs
+
+Watch the web worker and background worker logs during the smoke test and verify
+there are no new occurrences of:
+
+- `UndefinedColumn`
+- `BuildError`
+- `500`
+- `Company.query.first()`
+- cross-tenant SMS campaign/template/contact leakage
+
+Example journal command:
+
+```bash
+journalctl -u lux-email-bot -f | rg "UndefinedColumn|BuildError|\b500\b|Company\.query\.first\(|cross-tenant|sms_campaign|sms_template"
+```
+
+Example Docker command:
+
+```bash
+docker compose logs -f web lux-email-bot | rg "UndefinedColumn|BuildError|\b500\b|Company\.query\.first\(|cross-tenant|sms_campaign|sms_template"
+```

--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -64,6 +64,18 @@ class BaseAgent:
             self._client = None
         return self._client
     
+
+    def _get_current_company_id(self) -> Optional[int]:
+        """Resolve the active request tenant without falling back across tenants."""
+        try:
+            from flask_login import current_user
+            if current_user and current_user.is_authenticated:
+                company = current_user.get_default_company() if hasattr(current_user, "get_default_company") else None
+                return company.id if company else getattr(current_user, "default_company_id", None)
+        except Exception:
+            pass
+        return None
+
     def _define_personality(self) -> str:
         """Define the agent's personality and expertise. Override in subclasses."""
         return f"""
@@ -220,7 +232,7 @@ class BaseAgent:
             task_name: Name/description of task
             task_data: Task configuration and parameters
             scheduled_at: When to execute (None = now)
-            company_id: Company context (falls back to first active company)
+            company_id: Required company context for background tasks
             user_id: User context (optional)
 
         Returns:
@@ -229,18 +241,9 @@ class BaseAgent:
         try:
             from models import AgentTask, Company, db
 
-            # Resolve company_id — required by the NOT NULL constraint.
-            # Scheduled agents run outside any request context, so we fall
-            # back to the first active company rather than crashing.
-            resolved_company_id = company_id
-            if resolved_company_id is None:
-                try:
-                    first_company = Company.query.filter_by(is_active=True).first()
-                    if first_company is None:
-                        first_company = Company.query.first()
-                    resolved_company_id = first_company.id if first_company else None
-                except Exception:
-                    resolved_company_id = None
+            # Resolve company_id from the active tenant only. Scheduled/background
+            # agents must pass company_id explicitly to avoid cross-tenant leakage.
+            resolved_company_id = company_id or self._get_current_company_id()
 
             if resolved_company_id is None:
                 logger.warning(
@@ -355,10 +358,9 @@ class BaseAgent:
         """
         try:
             from services.approval_service import ApprovalService, FeatureToggleService
-            from models import Company
-            
-            company = Company.query.first()
-            company_id = company.id if company else 1
+            company_id = self._get_current_company_id()
+            if not company_id:
+                return {'success': False, 'reason': 'No active company context'}
             
             feature_key = f'agent_{self.agent_type}'
             if not FeatureToggleService.is_enabled(company_id, feature_key):
@@ -405,10 +407,9 @@ class BaseAgent:
         """Check if this agent's feature is enabled"""
         try:
             from services.approval_service import FeatureToggleService
-            from models import Company
-            
-            company = Company.query.first()
-            company_id = company.id if company else 1
+            company_id = self._get_current_company_id()
+            if not company_id:
+                return False
             
             key = feature_key or f'agent_{self.agent_type}'
             return FeatureToggleService.is_enabled(company_id, key)

--- a/agents/orchestrator_agent.py
+++ b/agents/orchestrator_agent.py
@@ -282,10 +282,7 @@ class OrchestratorAgent:
         try:
             from models import FeatureToggle, Company
             company_id = self._get_current_company_id()
-            if company_id:
-                company = db.session.get(Company, company_id)
-            else:
-                company = Company.query.first()
+            company = db.session.get(Company, company_id) if company_id else None
             if not company:
                 return {'success': True, 'toggles': [], 'total': 0}
 

--- a/migrations/20260617_sms_campaign_audit_fix.sql
+++ b/migrations/20260617_sms_campaign_audit_fix.sql
@@ -1,0 +1,94 @@
+-- Durable/idempotent SMS Campaign audit schema repair.
+-- Safe for PostgreSQL production: only adds missing columns/indexes and preserves rows.
+
+ALTER TABLE sms_campaign
+    ADD COLUMN IF NOT EXISTS company_id INTEGER NULL REFERENCES company(id),
+    ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER NULL REFERENCES "user"(id),
+    ADD COLUMN IF NOT EXISTS name VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS objective TEXT,
+    ADD COLUMN IF NOT EXISTS message VARCHAR(1000),
+    ADD COLUMN IF NOT EXISTS segment VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS status VARCHAR(50) DEFAULT 'draft',
+    ADD COLUMN IF NOT EXISTS audience_filter JSONB DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS estimated_recipient_count INTEGER DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS test_sent_at TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS scheduled_at TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS sent_at TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT now();
+
+ALTER TABLE sms_recipient
+    ADD COLUMN IF NOT EXISTS company_id INTEGER NULL REFERENCES company(id),
+    ADD COLUMN IF NOT EXISTS campaign_id INTEGER NULL REFERENCES sms_campaign(id),
+    ADD COLUMN IF NOT EXISTS contact_id INTEGER NULL REFERENCES contact(id),
+    ADD COLUMN IF NOT EXISTS phone_number VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS status VARCHAR(50) DEFAULT 'pending',
+    ADD COLUMN IF NOT EXISTS message_sid VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS provider_message_sid VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS error_code VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS sent_at TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS delivered_at TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS replied_at TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS opted_out_at TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS provider_error_code VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS error_message TEXT,
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT now();
+
+ALTER TABLE sms_template
+    ADD COLUMN IF NOT EXISTS company_id INTEGER NULL REFERENCES company(id),
+    ADD COLUMN IF NOT EXISTS name VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS message TEXT,
+    ADD COLUMN IF NOT EXISTS category VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS tone VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS has_opt_out BOOLEAN DEFAULT true,
+    ADD COLUMN IF NOT EXISTS is_compliant BOOLEAN DEFAULT true,
+    ADD COLUMN IF NOT EXISTS usage_count INTEGER DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS is_active BOOLEAN DEFAULT true,
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT now();
+
+ALTER TABLE sms_keyword_rule
+    ADD COLUMN IF NOT EXISTS company_id INTEGER NULL REFERENCES company(id),
+    ADD COLUMN IF NOT EXISTS campaign_id INTEGER NULL REFERENCES sms_campaign(id),
+    ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER NULL REFERENCES "user"(id),
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT now();
+
+ALTER TABLE sms_auto_reply_rule
+    ADD COLUMN IF NOT EXISTS company_id INTEGER NULL REFERENCES company(id),
+    ADD COLUMN IF NOT EXISTS campaign_id INTEGER NULL REFERENCES sms_campaign(id),
+    ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER NULL REFERENCES "user"(id),
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT now();
+
+ALTER TABLE segment ADD COLUMN IF NOT EXISTS company_id INTEGER NULL REFERENCES company(id);
+
+ALTER TABLE calendar_event
+    ADD COLUMN IF NOT EXISTS company_id INTEGER NULL REFERENCES company(id),
+    ADD COLUMN IF NOT EXISTS created_by_id INTEGER NULL REFERENCES "user"(id),
+    ADD COLUMN IF NOT EXISTS title VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS description TEXT,
+    ADD COLUMN IF NOT EXISTS channel VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS content_type VARCHAR(80),
+    ADD COLUMN IF NOT EXISTS content_id INTEGER,
+    ADD COLUMN IF NOT EXISTS status VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS audience VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS estimated_recipient_count INTEGER DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS end_date TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS all_day BOOLEAN DEFAULT false,
+    ADD COLUMN IF NOT EXISTS notes TEXT,
+    ADD COLUMN IF NOT EXISTS color VARCHAR(40),
+    ADD COLUMN IF NOT EXISTS deadline_at TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT now();
+
+CREATE INDEX IF NOT EXISTS ix_sms_campaign_company_status ON sms_campaign(company_id, status);
+CREATE INDEX IF NOT EXISTS ix_sms_campaign_company_scheduled_at ON sms_campaign(company_id, scheduled_at);
+CREATE INDEX IF NOT EXISTS ix_sms_recipient_campaign_status ON sms_recipient(campaign_id, status);
+CREATE INDEX IF NOT EXISTS ix_sms_recipient_company_id ON sms_recipient(company_id);
+CREATE INDEX IF NOT EXISTS ix_sms_recipient_provider_message_sid ON sms_recipient(provider_message_sid);
+CREATE INDEX IF NOT EXISTS ix_sms_template_company_active ON sms_template(company_id, is_active);
+CREATE INDEX IF NOT EXISTS ix_sms_keyword_rule_company_id ON sms_keyword_rule(company_id);
+CREATE INDEX IF NOT EXISTS ix_sms_auto_reply_rule_company_id ON sms_auto_reply_rule(company_id);
+CREATE INDEX IF NOT EXISTS ix_segment_company_id ON segment(company_id);
+CREATE INDEX IF NOT EXISTS ix_calendar_event_company_channel_start ON calendar_event(company_id, channel, start_date);
+CREATE INDEX IF NOT EXISTS ix_calendar_event_sms_content ON calendar_event(content_type, content_id) WHERE content_type = 'sms_campaign';

--- a/models.py
+++ b/models.py
@@ -944,6 +944,7 @@ class SMSTemplate(db.Model):
     __tablename__ = "sms_template"
 
     id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=True, index=True)
     name = db.Column(db.String(255))
     message = db.Column(db.Text)
     category = db.Column(db.String(100))
@@ -978,6 +979,7 @@ class Segment(db.Model):
     __tablename__ = "segment"
 
     id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=True, index=True)
     name = db.Column(db.String(255), nullable=False)
     description = db.Column(db.Text, nullable=True)
     segment_type = db.Column(db.String(100), default="behavioral")
@@ -1115,8 +1117,43 @@ class CalendarEvent(db.Model):
     __tablename__ = "calendar_event"
 
     id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=True, index=True)
+    created_by_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    title = db.Column(db.String(255))
+    description = db.Column(db.Text)
     event_type = db.Column(db.String(50))
+    channel = db.Column(db.String(50))
+    content_type = db.Column(db.String(80))
+    content_id = db.Column(db.Integer)
+    status = db.Column(db.String(50))
+    audience = db.Column(db.String(255))
+    estimated_recipient_count = db.Column(db.Integer, default=0)
     start_date = db.Column(db.DateTime)
+    end_date = db.Column(db.DateTime)
+    all_day = db.Column(db.Boolean, default=False)
+    notes = db.Column(db.Text)
+    color = db.Column(db.String(40))
+    deadline_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "event_type": self.event_type,
+            "channel": self.channel,
+            "content_type": self.content_type,
+            "content_id": self.content_id,
+            "status": self.status,
+            "audience": self.audience,
+            "estimated_recipient_count": self.estimated_recipient_count or 0,
+            "start_date": self.start_date.isoformat() if self.start_date else None,
+            "end_date": self.end_date.isoformat() if self.end_date else None,
+            "all_day": bool(self.all_day),
+            "color": self.color,
+        }
 
 
 class AutomationTemplate(db.Model):

--- a/routes.py
+++ b/routes.py
@@ -3432,40 +3432,8 @@ def resume_automation(id):
 @main_bp.route('/sms-dashboard')
 @login_required
 def sms_dashboard():
-    """SMS marketing dashboard"""
-    # # from services.sms_service import SMSService
-    company_id = getattr(current_user, 'default_company_id', None)
-    
-    campaigns_query = SMSCampaign.query
-    if company_id:
-        campaigns_query = campaigns_query.filter_by(company_id=company_id)
-    campaigns = campaigns_query.order_by(SMSCampaign.created_at.desc()).all()
-    templates = SMSTemplate.query.order_by(SMSTemplate.created_at.desc()).limit(10).all()
-    
-    # Stats
-    total_campaigns = campaigns_query.count()
-    sent_campaigns = campaigns_query.filter_by(status='sent').count()
-    scheduled_campaigns = campaigns_query.filter_by(status='scheduled').count()
-    
-    # Check if Twilio is configured for this company
-    twilio_configured = False
-    try:
-        from models import TwilioAccount
-        company = current_user.get_default_company() if current_user.is_authenticated else None
-        if company:
-            ta = TwilioAccount.query.filter_by(company_id=company.id).first()
-            twilio_configured = bool(ta and ta.is_configured)
-    except Exception:
-        pass
-
-    return render_template('sms_campaigns.html',
-                         campaigns=campaigns,
-                         templates=templates,
-                         total_campaigns=total_campaigns,
-                         sent_campaigns=sent_campaigns,
-                         scheduled_campaigns=scheduled_campaigns,
-                         sms_enabled=True,
-                         twilio_configured=twilio_configured)
+    """Legacy SMS marketing dashboard routes; redirect to canonical app route."""
+    return redirect(url_for('main.sms_campaigns'), code=302)
 
 @main_bp.route('/sms/create', methods=['GET', 'POST'])
 @login_required
@@ -3487,21 +3455,23 @@ def create_sms_campaign():
                 if scheduled_date and scheduled_time:
                     scheduled_at = datetime.fromisoformat(f"{scheduled_date}T{scheduled_time}")
             
-            company_id = getattr(current_user, 'default_company_id', None)
+            company_id = _current_company_id()
             if not company_id:
                 flash('Company/tenant is required to create an SMS campaign.', 'error')
-                return redirect(url_for('main.sms_dashboard'))
+                return redirect(url_for('main.sms_campaigns'))
 
             # Create campaign
-            company = current_user.get_default_company() if hasattr(current_user, 'get_default_company') else None
-            campaign = SMSService.create_campaign(
+            campaign = SMSCampaign(
+                company_id=company_id,
+                created_by_user_id=current_user.id,
                 name=name,
-                message=message,
+                message=SMSService.ensure_opt_out_language(message or '') if SMSService else message,
+                segment=request.form.get('segment_tags') or None,
+                status='scheduled' if scheduled_at else 'draft',
                 scheduled_at=scheduled_at,
-                company_id=company.id if company else getattr(current_user, 'default_company_id', None)
+                audience_filter={'segment_tags': request.form.get('segment_tags', '')},
+                created_at=datetime.utcnow(),
             )
-            if campaign.message and 'STOP' not in campaign.message.upper():
-                campaign.message = f"{campaign.message.strip()} Reply STOP to opt out."
             db.session.add(campaign)
             db.session.flush()
             
@@ -3550,6 +3520,8 @@ def create_sms_campaign():
                     Contact.sms_consent_status.in_(['opted_in', 'subscribed'])
                 ).all()
             
+            campaign.estimated_recipient_count = len(contacts_to_target)
+
             # Add recipients
             if contacts_to_target:
                 for contact in contacts_to_target:
@@ -3577,7 +3549,7 @@ def create_sms_campaign():
             db.session.commit()
             log_activity(current_user.id, 'Created SMS campaign', name, 'message-square')
             flash('SMS campaign created successfully!', 'success')
-            return redirect(url_for('main.sms_dashboard'))
+            return redirect(url_for('main.sms_campaigns'))
             
         except Exception as e:
             logger.error(f"Error creating SMS campaign: {e}")
@@ -3592,8 +3564,14 @@ def create_sms_campaign():
         Contact.sms_consent_status.in_(['opted_in', 'subscribed'])
     ).all()
     tags = CampaignTaggingService.get_all_tags()
-    templates = SMSTemplate.query.all()
-    segments = Segment.query.all()
+    templates_query = SMSTemplate.query
+    if hasattr(SMSTemplate, 'company_id'):
+        templates_query = templates_query.filter(or_(SMSTemplate.company_id == company_id, SMSTemplate.company_id.is_(None)))
+    templates = templates_query.filter_by(is_active=True).order_by(SMSTemplate.name.asc()).all()
+    segments_query = Segment.query
+    if hasattr(Segment, 'company_id'):
+        segments_query = segments_query.filter_by(company_id=company_id)
+    segments = segments_query.order_by(Segment.name.asc()).all()
     
     return render_template('create_sms_campaign.html',
                          contacts=contacts,
@@ -3619,10 +3597,11 @@ def edit_sms_campaign(campaign_id):
             scheduled_time = request.form.get('scheduled_time')
             if scheduled_date and scheduled_time:
                 campaign.scheduled_at = datetime.fromisoformat(f"{scheduled_date}T{scheduled_time}")
+                campaign.status = 'scheduled'
             
             db.session.commit()
             flash('SMS campaign updated successfully!', 'success')
-            return redirect(url_for('main.sms_dashboard'))
+            return redirect(url_for('main.sms_campaigns'))
         except Exception as e:
             logger.error(f"Error updating SMS campaign: {e}")
             flash('Error updating campaign', 'error')
@@ -3635,7 +3614,10 @@ def edit_sms_campaign(campaign_id):
         Contact.sms_opt_out_at.is_(None),
         Contact.sms_consent_status.in_(['opted_in', 'subscribed'])
     ).all()
-    templates = SMSTemplate.query.all()
+    templates_query = SMSTemplate.query
+    if hasattr(SMSTemplate, 'company_id'):
+        templates_query = templates_query.filter(or_(SMSTemplate.company_id == company_id, SMSTemplate.company_id.is_(None)))
+    templates = templates_query.filter_by(is_active=True).order_by(SMSTemplate.name.asc()).all()
     
     return render_template('edit_sms_campaign.html',
                          campaign=campaign,
@@ -3650,13 +3632,14 @@ def archive_sms_campaign(campaign_id):
         company_id = _current_company_id()
         campaign = SMSCampaign.query.filter_by(id=campaign_id, company_id=company_id).first_or_404()
         campaign.status = 'archived'
+        campaign.scheduled_at = None
         db.session.commit()
         flash('Campaign archived successfully', 'success')
     except Exception as e:
         logger.error(f"Error archiving SMS campaign: {e}")
         flash('Error archiving campaign', 'error')
     
-    return redirect(url_for('main.sms_dashboard'))
+    return redirect(url_for('main.sms_campaigns'))
 
 @main_bp.route('/sms/templates/create', methods=['GET', 'POST'])
 @login_required
@@ -3674,7 +3657,7 @@ def create_sms_template():
             template = SMSService.create_template(name, message, category, tone)
             
             flash(f'SMS template "{name}" created successfully!', 'success')
-            return redirect(url_for('main.sms_dashboard'))
+            return redirect(url_for('main.sms_campaigns'))
             
         except Exception as e:
             logger.error(f"Error creating SMS template: {e}")
@@ -5230,7 +5213,8 @@ def marketing_calendar():
         SMSCampaign.scheduled_at.isnot(None),
         SMSCampaign.scheduled_at >= start_date,
         SMSCampaign.scheduled_at < end_date,
-        SMSCampaign.status.in_(['draft', 'scheduled'])
+        SMSCampaign.status.in_(['draft', 'scheduled']),
+        SMSCampaign.company_id == _current_company_id()
     ).all()
     
     for campaign in sms_campaigns:
@@ -5291,7 +5275,8 @@ def marketing_calendar():
         SMSCampaign.scheduled_at.isnot(None),
         SMSCampaign.scheduled_at >= now,
         SMSCampaign.scheduled_at <= now + timedelta(days=30),
-        SMSCampaign.status.in_(['draft', 'scheduled'])
+        SMSCampaign.status.in_(['draft', 'scheduled']),
+        SMSCampaign.company_id == _current_company_id()
     ).order_by(SMSCampaign.scheduled_at).limit(10).all()
     
     upcoming_social = SocialPost.query.filter(
@@ -5397,7 +5382,8 @@ def api_calendar_events():
         sms_campaigns = SMSCampaign.query.filter(
             SMSCampaign.scheduled_at.isnot(None),
             SMSCampaign.scheduled_at >= start_date,
-            SMSCampaign.scheduled_at <= end_date
+            SMSCampaign.scheduled_at <= end_date,
+            SMSCampaign.company_id == _current_company_id()
         ).all()
         for c in sms_campaigns:
             events.append({
@@ -5410,7 +5396,7 @@ def api_calendar_events():
                 'content_id': c.id,
                 'color': '#28a745',
                 'className': 'event-sms',
-                'extendedProps': {'type': 'sms', 'status': c.status, 'edit_url': f'/sms/campaigns/{c.id}'}
+                'extendedProps': {'type': 'sms', 'status': c.status, 'edit_url': f'/sms/campaign/{c.id}/edit'}
             })
     
     if not event_types or 'social' in event_types:
@@ -5647,7 +5633,7 @@ def api_calendar_get_event(event_id):
                         'scheduled_at': campaign.scheduled_at.isoformat() if campaign.scheduled_at else None,
                         'status': campaign.status,
                         'message': campaign.message,
-                        'edit_url': f'/sms/campaigns/{campaign.id}'
+                        'edit_url': f'/sms/campaign/{campaign.id}/edit'
                     }
                 })
         

--- a/templates/base.html
+++ b/templates/base.html
@@ -540,7 +540,7 @@
                     <a href="{{ url_for('main.email_hub') }}" class="sidebar-nav-item{% if _p.startswith('/email') %} active{% endif %}">
                         <i data-feather="mail"></i> Email
                     </a>
-                    <a href="{{ url_for('main.sms_dashboard') }}" class="sidebar-nav-item{% if _p.startswith('/sms') and not _p.startswith('/twilio') %} active{% endif %}">
+                    <a href="{{ url_for('main.sms_campaigns') }}" class="sidebar-nav-item{% if _p.startswith('/sms') and not _p.startswith('/twilio') %} active{% endif %}">
                         <i data-feather="smartphone"></i> SMS Campaigns
                     </a>
                     <a href="{{ url_for('twilio.comms_hub') }}" class="sidebar-nav-item{% if _p.startswith('/twilio/comms') or _p.startswith('/twilio/inbox') or _p.startswith('/twilio/conversation') or _p.startswith('/app/inbox') %} active{% endif %}">

--- a/templates/create_sms_campaign.html
+++ b/templates/create_sms_campaign.html
@@ -114,7 +114,7 @@
                     </div>
                     
                     <div class="d-flex justify-content-between">
-                        <a href="{{ url_for('main.sms_dashboard') }}" class="btn btn-outline-secondary">
+                        <a href="{{ url_for('main.sms_campaigns') }}" class="btn btn-outline-secondary">
                             Cancel
                         </a>
                         <button type="submit" class="btn btn-primary">

--- a/templates/edit_sms_campaign.html
+++ b/templates/edit_sms_campaign.html
@@ -4,7 +4,7 @@
 <div class="mb-4">
     <div class="d-flex justify-content-between align-items-center">
         <h1><i data-feather="edit"></i> Edit SMS Campaign</h1>
-        <a href="{{ url_for('main.sms_dashboard') }}" class="btn btn-outline-secondary">
+        <a href="{{ url_for('main.sms_campaigns') }}" class="btn btn-outline-secondary">
             <i data-feather="arrow-left"></i> Back to Campaigns
         </a>
     </div>
@@ -60,7 +60,7 @@
                         <button type="submit" class="btn btn-primary">
                             <i data-feather="save"></i> Save Changes
                         </button>
-                        <a href="{{ url_for('main.sms_dashboard') }}" class="btn btn-secondary">Cancel</a>
+                        <a href="{{ url_for('main.sms_campaigns') }}" class="btn btn-secondary">Cancel</a>
                     </div>
                 </form>
             </div>

--- a/templates/sms_analytics.html
+++ b/templates/sms_analytics.html
@@ -16,7 +16,7 @@
         </h1>
         <p class="text-muted mb-0">{{ campaign.name }}</p>
     </div>
-    <a href="{{ url_for('main.sms_dashboard') }}" class="btn btn-outline-secondary">
+    <a href="{{ url_for('main.sms_campaigns') }}" class="btn btn-outline-secondary">
         <i data-feather="arrow-left"></i> Back to Campaigns
     </a>
 </div>

--- a/templates/twilio/inbox.html
+++ b/templates/twilio/inbox.html
@@ -154,7 +154,7 @@
     <a href="{{ url_for('twilio.business_hours') }}" class="text-muted text-decoration-none">
       <i data-feather="clock" style="width:13px;height:13px;"></i> Business Hours
     </a>
-    <a href="{{ url_for('main.sms_dashboard') }}" class="text-muted text-decoration-none">
+    <a href="{{ url_for('main.sms_campaigns') }}" class="text-muted text-decoration-none">
       <i data-feather="send" style="width:13px;height:13px;"></i> SMS Campaigns
     </a>
   </div>

--- a/tests/test_sms_campaign_routes_audit.py
+++ b/tests/test_sms_campaign_routes_audit.py
@@ -1,0 +1,82 @@
+from datetime import datetime, timedelta
+
+from werkzeug.security import generate_password_hash
+
+from app import create_app
+from extensions import db
+from models import Company, Contact, SMSCampaign, SMSTemplate, User, UserCompanyAccess
+
+
+def _login_fixture():
+    app = create_app()
+    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False, SECRET_KEY="test-secret", SERVER_NAME="localhost")
+    with app.app_context():
+        db.create_all()
+        company = Company(name="SMS Route Tenant")
+        other = Company(name="Other SMS Tenant")
+        db.session.add_all([company, other])
+        db.session.flush()
+        user = User(username="sms-route-admin", email="sms-route-admin@example.com", password_hash=generate_password_hash("password"), is_admin=True, default_company_id=company.id)
+        db.session.add(user)
+        db.session.flush()
+        db.session.add(UserCompanyAccess(user_id=user.id, company_id=company.id, role="admin", is_default=True))
+        db.session.add(Contact(company_id=company.id, first_name="In", phone="+15550100001", sms_marketing_opt_in=True, sms_consent_status="opted_in"))
+        db.session.add(Contact(company_id=other.id, first_name="Out", phone="+15550100002", sms_marketing_opt_in=True, sms_consent_status="opted_in"))
+        db.session.add(SMSTemplate(company_id=company.id, name="Tenant Template", message="Hi Reply STOP", is_active=True))
+        db.session.add(SMSTemplate(company_id=other.id, name="Other Template", message="Nope Reply STOP", is_active=True))
+        db.session.commit()
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess["_user_id"] = str(user.id)
+            sess["_fresh"] = True
+        yield app, client, company, other, user
+        db.session.remove()
+        db.drop_all()
+
+
+def test_sms_legacy_nav_routes_redirect_and_create_loads():
+    for app, client, company, _other, _user in _login_fixture():
+        for url in ("/sms", "/sms-dashboard"):
+            response = client.get(url, follow_redirects=False)
+            assert response.status_code in (301, 302)
+            assert response.headers["Location"].endswith("/app/sms-campaigns")
+
+        response = client.get("/sms/create")
+        body = response.get_data(as_text=True)
+        assert response.status_code == 200
+        assert "Tenant Template" in body
+        assert "Other Template" not in body
+        assert "Internal Server Error" not in body
+
+
+def test_sms_create_persists_tenant_user_and_calendar_api_includes_campaign():
+    for app, client, company, other, user in _login_fixture():
+        scheduled_at = datetime.utcnow() + timedelta(days=2)
+        response = client.post(
+            "/sms/create",
+            data={
+                "name": "Scheduled Route SMS",
+                "message": "Hello tenant",
+                "send_option": "scheduled",
+                "scheduled_date": scheduled_at.strftime("%Y-%m-%d"),
+                "scheduled_time": scheduled_at.strftime("%H:%M"),
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code in (302, 303)
+
+        with app.app_context():
+            campaign = SMSCampaign.query.filter_by(name="Scheduled Route SMS").one()
+            assert campaign.company_id == company.id
+            assert campaign.created_by_user_id == user.id
+            assert campaign.status == "scheduled"
+            assert campaign.estimated_recipient_count == 1
+            assert "STOP" in campaign.message.upper()
+            assert SMSCampaign.query.filter_by(company_id=other.id).count() == 0
+
+        events = client.get(
+            f"/api/calendar/events?start={(scheduled_at - timedelta(days=1)).date().isoformat()}&end={(scheduled_at + timedelta(days=3)).date().isoformat()}&types=sms"
+        )
+        assert events.status_code == 200
+        payload = events.get_json()
+        assert any(e["title"] == "Scheduled Route SMS" and e["extendedProps"]["type"] == "sms" for e in payload)


### PR DESCRIPTION
### Motivation

- Repair and harden the SMS campaign schema for auditing and reporting by adding missing columns and indexes to SMS-related tables.
- Prevent cross-tenant data leakage for background/AI agents and calendar APIs by resolving and enforcing the active company/tenant context. 
- Consolidate legacy SMS routes to the canonical app route and update UI links to use the new canonical path.

### Description

- Added durable/idempotent migration `migrations/20260617_sms_campaign_audit_fix.sql` that adds missing `company_id`, audit columns and supporting indexes for `sms_campaign`, `sms_recipient`, `sms_template`, `sms_keyword_rule`, `sms_auto_reply_rule`, `segment`, and `calendar_event`.
- Updated ORM models in `models.py` to include `company_id` on `SMSTemplate` and `Segment`, and expanded `CalendarEvent` with company, metadata fields and a `to_dict` helper.
- Strengthened agent tenant context in `agents/base_agent.py` by introducing `_get_current_company_id`, making `create_task` require explicit tenant context (falling back only to the current request tenant), and switching approval/feature checks to use the active company ID.
- Adjusted orchestrator feature governance to fetch `Company` via `db.session.get` when a company id is present to avoid ambiguous fallbacks.
- Reworked SMS routes in `routes.py`: legacy `/sms` and `/sms-dashboard` now redirect to the canonical campaign listing, `create_sms_campaign` and `edit_sms_campaign` now require/resolve the active tenant with `_current_company_id`, set `estimated_recipient_count`, persist `created_by_user_id`, scope templates/segments by company, ensure opt-out language, and update calendar/calendar API filters and event `edit_url` paths to tenant-scoped resources.
- Updated templates to point at the canonical `main.sms_campaigns` route and adjusted UI links accordingly.
- Added deployment guidance in `SMS_CAMPAIGN_DEPLOYMENT_NOTES.md` with post-merge checklist and `psql` commands for applying and re-running the migration.
- Added integration-style unit tests in `tests/test_sms_campaign_routes_audit.py` to assert legacy route redirects, tenant-scoped template visibility, campaign creation persistence (company and user), estimated recipients, opt-out text, and calendar API inclusion.

### Testing

- Executed the new test file with `pytest tests/test_sms_campaign_routes_audit.py` which verified legacy route redirects, tenant scoping for templates, campaign creation persistence, opt-out text, recipient counts, and calendar event inclusion, and the tests passed. 
- Local app smoke checks were exercised for the updated calendar endpoints and `create_sms_campaign` flow via the test client and returned expected tenant-scoped results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a32326705fc83228819ae27ccab22cb)