### PR TITLE
Fix PWA inbox conversation persistence

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -301,7 +301,7 @@ def _send_sms_internal(ta, to_number: str, body: str, conversation_id=None):
 
 
 def _conv_to_dict(conv, brief=True):
-    tags = conv.tags or []
+    tags = _safe_conversation_tags(conv.tags)
     contact_source = getattr(conv, "contact_source", None)
     d = {
         "id":                  conv.id,
@@ -328,6 +328,23 @@ def _conv_to_dict(conv, brief=True):
         else:
             d["assigned_user_name"] = None
     return d
+
+
+def _safe_conversation_tags(raw_tags):
+    """Return conversation tags as a normalized list for JSON/null/string values."""
+    if raw_tags is None:
+        return []
+    if isinstance(raw_tags, list):
+        return raw_tags
+    if isinstance(raw_tags, tuple):
+        return list(raw_tags)
+    if isinstance(raw_tags, str):
+        return [tag.strip() for tag in raw_tags.split(",") if tag.strip()]
+    return []
+
+
+def _is_archived_conversation(conv):
+    return "archived" in _safe_conversation_tags(getattr(conv, "tags", None))
 
 
 def _msg_to_dict(m):
@@ -656,15 +673,16 @@ def list_conversations():
 
     convs = q.order_by(TwilioConversation.last_message_at.desc()).all()
     if filter_by == "archived":
-        convs = [c for c in convs if "archived" in (c.tags or [])]
+        convs = [c for c in convs if _is_archived_conversation(c)]
     else:
-        convs = [c for c in convs if "archived" not in (c.tags or [])]
+        convs = [c for c in convs if not _is_archived_conversation(c)]
 
     total = len(convs)
     per_page = 50
     convs = convs[(page - 1) * per_page:page * per_page]
 
     return jsonify({
+        "success":       True,
         "conversations": [_conv_to_dict(c) for c in convs],
         "unread_count":  unread_count,
         "total":         total,
@@ -855,7 +873,7 @@ def archive_conversation(conv_id):
     conv = TwilioConversation.query.filter_by(id=conv_id, company_id=company.id).first_or_404()
     payload  = request.get_json() or {}
     archive  = payload.get("archived", True)
-    tags     = list(conv.tags or [])
+    tags     = _safe_conversation_tags(conv.tags)
     if archive and "archived" not in tags:
         tags.append("archived")
     elif not archive and "archived" in tags:

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -970,6 +970,7 @@
 ═══════════════════════════════════════════════════════════════ */
 const CSRF        = '{{ csrf_token() }}';
 const VAPID_PUBLIC = document.documentElement.dataset.vapid ?? '';
+const CONV_CACHE_KEY = 'luxitInboxConversations';
 
 let state = {
   filter:        'all',
@@ -1205,10 +1206,47 @@ async function apiFetch(url, method = 'GET', body = null) {
 async function loadConversations() {
   const qs   = `?filter=${state.filter}&q=${encodeURIComponent(state.search)}`;
   const data = await apiFetch('/api/inbox/conversations' + qs);
-  if (!data) return;
-  state.conversations = data.conversations;
-  renderConvList(data.conversations);
+  if (!data || data.error || data.success === false || !Array.isArray(data.conversations)) {
+    const cached = loadCachedConversations();
+    if (state.conversations.length) {
+      renderConvList(state.conversations);
+    } else if (cached.length) {
+      state.conversations = cached;
+      renderConvList(cached);
+    }
+    toast(data?.error || 'Could not refresh conversations. Showing saved conversations.', 'error');
+    return;
+  }
+  state.conversations = (state.filter === 'all' && !state.search)
+    ? mergeConversations(state.conversations, data.conversations)
+    : data.conversations;
+  renderConvList(state.conversations);
+  cacheConversations(state.conversations);
   updateUnreadBadge(data.unread_count);
+}
+
+function mergeConversations(current, incoming) {
+  if (!incoming.length) return [];
+  const byId = new Map();
+  [...current, ...incoming].forEach(c => { if (c && c.id) byId.set(c.id, c); });
+  return Array.from(byId.values()).sort((a, b) => new Date(b.last_message_at || 0) - new Date(a.last_message_at || 0));
+}
+
+function cacheConversations(convs) {
+  try {
+    if (state.filter === 'all' && !state.search && Array.isArray(convs)) {
+      localStorage.setItem(CONV_CACHE_KEY, JSON.stringify(convs));
+    }
+  } catch {}
+}
+
+function loadCachedConversations() {
+  try {
+    const cached = JSON.parse(localStorage.getItem(CONV_CACHE_KEY) || '[]');
+    return Array.isArray(cached) ? cached : [];
+  } catch {
+    return [];
+  }
 }
 
 function renderConvList(convs) {
@@ -1794,7 +1832,12 @@ async function sendNewMsg() {
 async function markCurrentRead(isRead = true) {
   if (!state.activeConvId) return;
   const data = await apiFetch(`/api/inbox/conversations/${state.activeConvId}/read`, 'PATCH', { is_read: isRead });
-  if (data?.success) { toast(isRead ? 'Marked as read.' : 'Marked as unread.'); loadConversations(); }
+  if (data?.success) {
+    state.conversations = state.conversations.map(c => c.id === state.activeConvId ? { ...c, is_read: isRead } : c);
+    renderConvList(state.conversations);
+    toast(isRead ? 'Marked as read.' : 'Marked as unread.');
+    loadConversations();
+  }
 }
 
 function openRename() {

--- a/tests/test_pwa_phone_system.py
+++ b/tests/test_pwa_phone_system.py
@@ -17,6 +17,7 @@ from models import (
     UserCompanyAccess,
     VoiceVoicemailMessage,
     TwilioConversation,
+    TwilioMessage,
 )
 
 
@@ -298,6 +299,95 @@ def test_inbox_conversations_all_excludes_archived_json_tags(client, app, world)
     assert "Archived SMS" not in names
 
 
+def test_inbox_conversations_all_includes_read_and_unread_non_archived(client, app, world):
+    with app.app_context():
+        rows = [
+            TwilioConversation(
+                company_id=world["co_a"],
+                from_number="+15551001001",
+                to_number="+15550001000",
+                contact_name="Unread Persistent SMS",
+                is_read=False,
+                tags=[],
+                last_message_at=datetime(2026, 1, 5),
+            ),
+            TwilioConversation(
+                company_id=world["co_a"],
+                from_number="+15551001002",
+                to_number="+15550001000",
+                contact_name="Read Persistent SMS",
+                is_read=True,
+                tags=[],
+                last_message_at=datetime(2026, 1, 4),
+            ),
+            TwilioConversation(
+                company_id=world["co_a"],
+                from_number="+15551001003",
+                to_number="+15550001000",
+                contact_name="Archived Persistent SMS",
+                is_read=False,
+                tags=["archived"],
+                last_message_at=datetime(2026, 1, 6),
+            ),
+        ]
+        db.session.add_all(rows)
+        db.session.commit()
+    login(client, world["alice"])
+
+    resp = client.get("/api/inbox/conversations?filter=all")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    names = {c["contact_name"] for c in body["conversations"]}
+    assert "Unread Persistent SMS" in names
+    assert "Read Persistent SMS" in names
+    assert "Archived Persistent SMS" not in names
+
+
+def test_opening_and_marking_conversation_read_keeps_it_in_all(client, app, world):
+    with app.app_context():
+        conv = TwilioConversation(
+            company_id=world["co_a"],
+            from_number="+15551001004",
+            to_number="+15550001000",
+            contact_name="Read Stable SMS",
+            is_read=False,
+            tags=["lead"],
+            last_message_at=datetime(2026, 1, 7),
+        )
+        db.session.add(conv)
+        db.session.flush()
+        db.session.add(TwilioMessage(
+            conversation_id=conv.id,
+            company_id=world["co_a"],
+            direction="inbound",
+            from_number="+15551001004",
+            to_number="+15550001000",
+            body="hello",
+            status="received",
+            created_at=datetime(2026, 1, 7),
+        ))
+        db.session.commit()
+        conv_id = conv.id
+    login(client, world["alice"])
+
+    opened = client.get(f"/api/inbox/conversations/{conv_id}")
+    marked = client.patch(f"/api/inbox/conversations/{conv_id}/read", json={"is_read": True})
+    again = client.get("/api/inbox/conversations?filter=all")
+
+    assert opened.status_code == 200
+    assert marked.status_code == 200
+    names = {c["contact_name"] for c in again.get_json()["conversations"]}
+    assert "Read Stable SMS" in names
+    with app.app_context():
+        persisted = db.session.get(TwilioConversation, conv_id)
+        assert persisted.is_read is True
+        assert persisted.tags == ["lead"]
+        assert persisted.company_id == world["co_a"]
+        assert persisted.assigned_user_id is None
+        assert TwilioMessage.query.filter_by(conversation_id=conv_id).count() == 1
+
+
 def test_inbox_conversations_archived_filter_uses_python_json_tag_check(client, app, world):
     with app.app_context():
         visible = TwilioConversation(
@@ -406,6 +496,17 @@ def test_inbox_conversations_non_archived_filters_still_work(
     names = {c["contact_name"] for c in resp.get_json()["conversations"]}
     assert expected in names
     assert excluded not in names
+
+
+def test_inbox_pwa_fetch_failure_does_not_clear_conversation_state():
+    html = open("templates/inbox_pwa/index.html", encoding="utf-8").read()
+
+    assert "Could not refresh conversations. Showing saved conversations." in html
+    assert "state.conversations = data.conversations" not in html
+    assert "localStorage.clear()" not in html
+    assert "sessionStorage.clear()" not in html
+    assert "indexedDB.deleteDatabase" not in html
+    assert "mergeConversations(state.conversations, data.conversations)" in html
 
 
 def add_phone_number(company_id, number, **overrides):


### PR DESCRIPTION
### Motivation
- Prevent conversations from disappearing from the PWA inbox after opening/reading or after app restart by ensuring read operations do not remove or archive threads and by fixing tag handling. 
- Make archived filtering robust against different `tags` representations (JSON/list/string/null) to avoid accidental exclusion of valid conversations. 
- Ensure the PWA does not wipe local UI state when the `/api/inbox/conversations` call fails and provide an offline/cached fallback.

### Description
- Added `_safe_conversation_tags` and `_is_archived_conversation` helpers and used them in `_conv_to_dict`, archived filtering, and the archive/unarchive code path to normalize `tags` values and avoid brittle SQL JSON operators. 
- Ensured `list_conversations()` starts from `company_id` and filters out only archived conversations for `filter=all`, added an explicit `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a32c0c51c188322b15aec56bceab7ea)