### PR TITLE
Communications: per-number routing & permissions, PWA device/UX, and Comms Hub consolidation

### DIFF
--- a/COMMUNICATIONS_ARCHITECTURE_IMPLEMENTATION_NOTE.md
+++ b/COMMUNICATIONS_ARCHITECTURE_IMPLEMENTATION_NOTE.md
@@ -1,0 +1,81 @@
+# Communications / Phone / SMS Implementation Note
+
+Date: 2026-06-17
+
+## Current routes/pages found
+
+- Admin/desktop Communications: `/twilio/comms`, `/twilio/comms/settings`, `/twilio/numbers`, `/twilio/settings`, `/twilio/rules`, `/twilio/hours`, `/twilio/calls`, `/twilio/inbox`, `/twilio/inbox/<id>`.
+- PWA phone/inbox: `/app/inbox`, `/app/calls`, `/app/calls/settings`, `/api/inbox/*`, `/api/calls/*`, `/api/phone/*`.
+- Twilio webhooks: `/twilio/sms/inbound`, `/twilio/sms/status`, `/twilio/voice/inbound`, `/twilio/voice/no-answer`, `/twilio/voice/recording`, `/twilio/voice/status`, plus `/api/twilio/voice/*` aliases.
+- Google Contacts: `/twilio/google-contacts/connect`, `/callback`, `/sync`, `/status`, `/disconnect`.
+- SMS Campaigns: `/app/sms-campaigns`, legacy `/sms*` redirects, and `/api/marketing/sms-campaigns*`.
+
+## Duplicate pages/settings found
+
+- Left navigation exposed `Communications Hub`, `SMS & Calls Admin`, and `Phone Numbers` separately. The duplicate admin/number links are now hidden from the left menu; the routes remain for deep links/backward compatibility.
+- Business hours existed at tenant/global levels (`PhoneSettings`, `BusinessHours`) while `TwilioPhoneNumber` held per-number routing/forwarding/voicemail values. Per-number business-hours fields are now added to `TwilioPhoneNumber`; tenant-level hours remain as defaults.
+
+## Shared/global settings moved toward per-number
+
+- Added per-number fields on `TwilioPhoneNumber` for business hours, timezone, during/after-hours routes, browser/WiFi calling, cell callback, data-use controls, fallback behavior, and caller-ID display name.
+- Twilio inbound SMS/voice resolution already selects a `TwilioPhoneNumber`; business-hours checks now prefer the selected number’s hours before falling back to tenant defaults.
+
+## New/updated backend APIs
+
+- `GET /api/phone/numbers`: returns the signed-in user’s accessible phone lines for PWA selectors.
+- `GET/PUT /api/phone/numbers/<id>/settings`: reads/updates per-number routing, business hours, voicemail, forwarding, and calling options. Updates require owner/platform-admin/manage-users level permission.
+- Existing PWA conversation/call/voicemail APIs now filter server-side history by phone-number access instead of relying on device/session state.
+
+## Permissions behavior
+
+- `UserCompanyAccess` now normalizes role aliases (`super-admin`, `supervisor`, `user`, etc.) to canonical roles.
+- Tenant owner can manage users and roles.
+- Tenant admins require `manage_users_enabled=True` unless they are platform admins.
+- Unauthorized users receive 403.
+- Tenant isolation is preserved: non-platform admins cannot edit users outside their tenant membership.
+- Added `PhoneNumberUserPermission` for explicit per-line access to PWA, SMS, calls, voicemail, number management, and campaigns.
+
+## PWA complete-history behavior
+
+- Server APIs remain the source of truth; the PWA may cache locally, but conversation/call/voicemail lists are fetched from server APIs.
+- Owners/admins see all tenant line history.
+- Standard users with explicit number permission see all SMS/call/voicemail history for their assigned number(s), including read messages.
+- Unauthorized users cannot fetch restricted number history or detail endpoints.
+- The PWA now includes an assigned-number selector when the user has multiple accessible lines.
+
+## Tests added
+
+- Owner can edit tenant users and role aliases normalize correctly.
+- Admin with manage-users permission can manage users.
+- Unauthorized users are denied.
+- Tenant isolation is preserved for user-management APIs.
+- PWA read SMS remains visible across repeated loads.
+- Authorized users see shared number history; unauthorized users cannot fetch restricted history.
+- Voicemail listing includes playback metadata.
+- Per-number settings remain independent.
+- Left navigation no longer includes duplicate SMS/Text/Phone admin items.
+
+## Remaining risks / follow-up items
+
+- Communications Hub UI should be expanded further into the full tabbed editor described in the product brief; this change adds backend/API foundations and removes duplicate navigation without replacing existing pages.
+- SMS Campaign per-number sender selection is still routed through existing Twilio account defaults; next step is adding campaign `from_phone_number_id` selection and enforcing `can_send_campaigns`.
+- Full browser/WiFi calling runtime controls are represented in per-number settings; Twilio Voice SDK behavior should be wired to those settings in a follow-up UI pass.
+
+## Old-to-new settings map
+
+| Old page / setting | New Communications Hub tab | API / model used | Test coverage |
+| --- | --- | --- | --- |
+| `/twilio/numbers` number list | Numbers | `TwilioPhoneNumber` | `test_communications_hub_tabs_and_pwa_api_smoke` |
+| Twilio from/caller identity | Number Settings | `TwilioPhoneNumber.caller_id_display_name`, `friendly_name` | `test_number_settings_are_independent_per_number` |
+| `/twilio/hours` tenant hours | Business Hours | `TwilioPhoneNumber.business_hours`, fallback `PhoneSettings` / `BusinessHours` | `test_number_settings_are_independent_per_number`, existing after-hours tests |
+| SMS forwarding | Call Routing / Forwarding | `TwilioPhoneNumber.sms_forward_to`, `sms_forwarding_enabled` | smoke + form render coverage |
+| Voice forwarding/routing | Call Routing / Forwarding | `TwilioPhoneNumber.call_forward_to`, `voice_forwarding_enabled`, route fields | smoke + form render coverage |
+| `/twilio/rules` auto replies | Auto Replies | `AutoReplyRule`, `TwilioPhoneNumber.auto_reply_enabled`, `after_hours_text` | smoke + existing Twilio auto-reply tests |
+| Voicemail greeting/recordings | Voicemail / Number Settings | `VoiceVoicemailMessage`, `TwilioCallLog.voicemail_url`, `TwilioPhoneNumber.voicemail_*` | `test_authorized_admin_sees_all_number_history_and_voicemail_metadata` |
+| PWA install/access | PWA Phone App | `/app/inbox`, `/api/phone/numbers`, `PhoneNumberUserPermission` | `test_pwa_history_persists_and_is_scoped_to_assigned_number` |
+| Per-user Communications flags | Users & Permissions | `UserCompanyAccess`, `PhoneNumberUserPermission` | owner/admin/denied tests |
+| SMS inbox | SMS Conversations | `TwilioConversation`, `TwilioMessage` | PWA history tests + smoke tests |
+| Call log | Call Logs | `TwilioCallLog` | call-log scope tests + smoke tests |
+| Google Contacts | Integrations | `GoogleOAuthToken`, `Contact`, Google Contacts service | contact matching tests |
+| Marketing/audit activity | Reports / Activity | `MarketingAuditLog`, campaign analytics routes | smoke tests |
+| SMS campaign sending identity | SMS Campaigns page | `SMSCampaign.from_phone_number_id`, `from_phone_number`, `TwilioPhoneNumber` | sender permission logic smoke via route coverage |

--- a/COMMUNICATIONS_DEPLOYMENT_VERIFICATION.md
+++ b/COMMUNICATIONS_DEPLOYMENT_VERIFICATION.md
@@ -1,0 +1,183 @@
+# Communications Deployment Verification Note
+
+This feature is **not go-to-market complete** until the runtime checks below pass in staging with real Twilio numbers, real users, and the installed PWA. Automated tests cover permission, scoping, tab, campaign-calendar, and API smoke regressions, but live Twilio Voice, voicemail recording playback, and device networking must be proven outside unit tests.
+
+## Deployment commands
+
+### Apply migration
+
+```bash
+psql "$DATABASE_URL" -f migrations/20260617_comms_phone_number_permissions.sql
+```
+
+If your deployment uses the platform migration runner instead of direct `psql`, run the equivalent migration command for `migrations/20260617_comms_phone_number_permissions.sql` during the release step.
+
+### Rollback command
+
+Use only before the application writes production data to these fields/tables, or after exporting/backing up affected rows:
+
+```sql
+DROP INDEX IF EXISTS ix_sms_campaign_from_phone_number_id;
+ALTER TABLE sms_campaign DROP COLUMN IF EXISTS from_phone_number;
+ALTER TABLE sms_campaign DROP COLUMN IF EXISTS from_phone_number_id;
+DROP TABLE IF EXISTS phone_number_user_permission;
+ALTER TABLE user_company_access DROP COLUMN IF EXISTS manage_users_enabled;
+ALTER TABLE twilio_phone_number DROP COLUMN IF EXISTS caller_id_display_name;
+ALTER TABLE twilio_phone_number DROP COLUMN IF EXISTS fallback_behavior;
+ALTER TABLE twilio_phone_number DROP COLUMN IF EXISTS wifi_only;
+ALTER TABLE twilio_phone_number DROP COLUMN IF EXISTS mobile_data_allowed;
+ALTER TABLE twilio_phone_number DROP COLUMN IF EXISTS cell_callback_enabled;
+ALTER TABLE twilio_phone_number DROP COLUMN IF EXISTS browser_calling_enabled;
+ALTER TABLE twilio_phone_number DROP COLUMN IF EXISTS after_hours_route;
+ALTER TABLE twilio_phone_number DROP COLUMN IF EXISTS during_hours_route;
+ALTER TABLE twilio_phone_number DROP COLUMN IF EXISTS timezone;
+ALTER TABLE twilio_phone_number DROP COLUMN IF EXISTS business_hours;
+```
+
+## Required Twilio settings
+
+Configure each purchased or connected Twilio number independently:
+
+| Twilio setting | Required value |
+| --- | --- |
+| Messaging webhook | `https://<app-host>/twilio/sms` |
+| Messaging status callback | `https://<app-host>/twilio/status` |
+| Voice webhook | `https://<app-host>/twilio/voice` |
+| Voice fallback/no-answer callback | `https://<app-host>/twilio/voice/no-answer` if configured in Twilio console |
+| Recording status callback | `https://<app-host>/twilio/voice/recording` |
+| Transcription callback | `https://<app-host>/twilio/voice/transcription` or `https://<app-host>/twilio/voice/voicemail` |
+| Voice SDK / browser calling | Confirm Twilio Voice application credentials, token endpoint, and caller-ID restrictions are configured for the staging tenant before enabling browser calling. |
+
+## Required feature/license flags
+
+Do not enable for general users until these are confirmed for the tenant/company:
+
+- Communications / SMS feature access is enabled for the tenant.
+- PWA inbox/phone access is enabled only for assigned users or owner/admin testers.
+- SMS Campaigns access is enabled for marketing users who have at least one permitted sending number.
+- Browser/WiFi calling and cell-callback calling remain disabled by default for a number until live Voice SDK and callback tests pass.
+- Development/staging admins may retain access during verification, but production rollout should use tenant/license checks plus per-number permissions.
+
+## Post-deploy staging smoke checklist
+
+### 1. User-management permissions
+
+- Log in as the tenant owner and confirm `/user/manage-users` loads.
+- As owner, edit another user role and save successfully.
+- Log in as `info@adiken.com` or an equivalent admin with `manage_users_enabled=true`.
+- Confirm the admin can open `/user/manage-users` and edit allowed user settings without “Access denied”.
+- Log in as a non-authorized standard/viewer user and confirm user-management edit attempts return 403.
+- Attempt cross-tenant user edits and confirm they are denied.
+
+### 2. Multi-number isolation
+
+Use two staging numbers:
+
+| Scenario | Number A | Number B | Expected result |
+| --- | --- | --- | --- |
+| Business hours | Open schedule | Closed/different schedule | After-hours logic follows the receiving number only. |
+| Auto replies | Rule/text A | Rule/text B | Replies do not leak between numbers. |
+| Voicemail | Greeting A | Greeting B | Caller hears the selected number’s greeting. |
+| Forwarding/routing | Destination A | Destination B | Calls/SMS route to the configured destination for that number. |
+| Caller ID/display name | Identity A | Identity B | Outbound workflows show/send the selected business number. |
+| Campaign sender identity | Permitted A | Permitted B | Campaign sender persists the chosen permitted number. |
+
+### 3. PWA history persistence
+
+- Send an SMS to an assigned number.
+- Mark it read in the PWA.
+- Close/reopen the PWA and confirm the conversation remains visible.
+- Log in as another authorized user assigned to the same number and confirm the same SMS/call/voicemail history appears.
+- Log in as an unauthorized user and confirm the restricted number and its history are hidden.
+- Confirm server data remains the source of truth even if local/device cache is cleared.
+
+### 4. Voicemail runtime
+
+- Place an inbound call and leave voicemail.
+- Confirm the Twilio recording callback succeeds.
+- Confirm the recording URL appears in the Communications Hub Voicemail tab.
+- Confirm the voicemail appears in the PWA visual voicemail list.
+- Play the recording from admin and PWA.
+- If transcription is enabled/returned by Twilio, confirm transcript text is stored and shown.
+- Mark voicemail read/unread and confirm state persists after refresh and across authorized users.
+- Confirm unauthorized users cannot list or play restricted-number voicemail.
+
+### 5. Outbound calling runtime
+
+This release is not production-ready for live calling until all of these pass:
+
+- Browser/WiFi calling works from a no-cell-service device when enabled for the selected number.
+- Cell callback calling works when enabled for the selected number.
+- Browser/WiFi calling is blocked when disabled for the selected number.
+- Cell callback calling is blocked when disabled for the selected number.
+- WiFi-only/data-usage settings are respected in the PWA/device workflow.
+- If browser calling fails, the configured fallback behavior is used.
+- Outbound calls display the selected assigned business number as caller ID.
+
+### 6. SMS Campaign integration
+
+- Create a campaign and choose a permitted sending number.
+- Confirm users without permission for a number cannot send from it.
+- Schedule an SMS campaign and confirm it appears on `/marketing-calendar` and `/api/calendar/events`.
+- Send a small test campaign and confirm delivery analytics/reporting update.
+- Confirm STOP, START, and HELP inbound compliance handling still works.
+- Confirm opt-out recipients are excluded from campaign sends.
+
+### 7. UI and navigation
+
+- Verify Communications Hub tabs on desktop and mobile widths.
+- Verify SMS Campaigns page on desktop and mobile widths.
+- Confirm only Communications Hub and SMS Campaigns appear as communications-related left-nav items.
+- Confirm legacy deep links still resolve or redirect cleanly.
+
+## Known follow-up items
+
+- QR-code rendering remains a follow-up because no existing QR-code helper was confirmed in this pass. The PWA tab should continue linking to `/app/inbox` until a QR helper is added.
+- Live Twilio Voice SDK/device behavior must be verified in staging before claiming outbound calling is go-to-market complete.
+- Staging screenshots should be attached to the release ticket after completing the desktop/mobile UI checklist.
+
+## Final hardening additions for staging certification
+
+### Devices tab and APIs
+
+The Communications Hub now includes `/twilio/comms?tab=devices` for registered PWA/work-phone telemetry. Staging should verify that each device row shows user, default/assigned line, browser/device type, online status, last seen, push status, microphone permission, installed-PWA status, WiFi-only, cell callback, mobile data calling, and default calling method.
+
+Device APIs to validate:
+
+- `GET /api/pwa/devices`
+- `POST /api/pwa/devices/register`
+- `POST /api/pwa/devices/heartbeat`
+- `PATCH /api/pwa/devices/<id>/settings`
+
+Tenant isolation and line permissions must be verified by registering a device for one assigned number and confirming unauthorized users cannot view or reassign it to a restricted line.
+
+### PWA palette persistence
+
+Palette selection is server-backed per user and mirrored locally for fast/offline rendering. Staging should verify that `lux`, `ocean`, `forest`, and `sunset` persist after logout/login, PWA reinstall, and cross-device login. The server-side source of truth is loaded through the PWA preferences/device registration flow.
+
+### Voicemail transcription and read state
+
+Voicemail certification must verify these metadata fields flow end-to-end when Twilio returns them: recording URL, recording duration, transcription text, transcription status, transcription provider, transcription error, transcribed timestamp, read timestamp, and read-by user. Admin Hub and PWA visual voicemail should show playback, transcription status/text, and read/unread state.
+
+### Call-log schema and UX readiness
+
+Call-log API responses should include direction, from/to number, contact/caller name, assigned business number, status, missed/incoming/outbound label, duration, started/ended timestamps, voicemail indicator, recording URL, transcription preview/status, read/unread metadata, and callback target. PWA mobile checks should confirm selected-number filtering and callback/message options from call rows.
+
+### Twilio Voice runtime checklist
+
+Before production enablement, validate browser/WiFi calling and cell callback with real Twilio Voice credentials and real devices. Disabled methods must be blocked by API, WiFi-only/data restrictions must be respected, failed/reconnect states must be visible, and selected business number must be used as outbound caller ID.
+
+### Final staging certification checklist
+
+- Devices tab registers and updates real work-phone devices.
+- Palette persistence survives logout/login, reinstall, and another device.
+- Voicemail recording and transcription metadata appear in Admin and PWA.
+- Call logs show contact names, duration, direction labels, voicemail indicators, and callback targets.
+- PWA search finds CRM/Google contacts, companies, emails, recent SMS conversations, and recent call-log numbers.
+- Browser/WiFi and cell-callback calling obey per-number settings.
+- SMS Campaign sender number, marketing calendar visibility, analytics, and STOP/START/HELP compliance remain intact.
+- Communications Hub, Devices tab, SMS Campaigns, and PWA have no horizontal overflow at mobile widths.
+
+## Staging credential handling
+
+A separate staging certification plan now exists in `COMMUNICATIONS_STAGING_CERTIFICATION_PLAN.md`. Do not commit login passwords, Twilio auth tokens, API secrets, or other live staging credentials. Supply those through the staging secret manager or an uncommitted operator handoff only.

--- a/COMMUNICATIONS_STAGING_CERTIFICATION_PLAN.md
+++ b/COMMUNICATIONS_STAGING_CERTIFICATION_PLAN.md
@@ -1,0 +1,158 @@
+# Communications / PWA Phone Staging Certification Plan
+
+This plan turns the staging requirements into a safe, repeatable UAT checklist. It intentionally **does not store passwords, Twilio auth tokens, API secrets, or other live credentials**. Those values must be supplied through the staging secret manager or a local, uncommitted operator note.
+
+## Safety rules
+
+- Do not send bulk real SMS.
+- Only send SMS/calls to approved test numbers.
+- Do not use production contacts or production customer segments.
+- Do not use production Twilio numbers unless explicitly authorized for this staging certification.
+- Do not mark Communications / PWA Phone go-to-market complete unless real staging device tests pass.
+- Do not commit staging passwords, Twilio auth tokens, API keys, API secrets, or personal device numbers to the repository.
+
+## Required staging inputs
+
+| Input | Required value / handling |
+| --- | --- |
+| Owner account | Use the provided owner email in the staging credential handoff; keep password out of git. |
+| Admin/manage-users account | Use `info@adiken.com`; keep password out of git. |
+| Restricted standard user | Use the provided restricted-user email in the staging credential handoff; keep password out of git. |
+| Number A | `+18302591310` |
+| Number B | `+19165989519` |
+| Public app URL | Use the deployed staging URL, or the approved public URL when staging is mapped there. |
+| Twilio credentials | Provide via environment/secret manager only: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_API_KEY_SID` or `TWILIO_API_KEY`, `TWILIO_API_KEY_SECRET`, `TWILIO_TWIML_APP_SID`, `TWILIO_MESSAGING_SERVICE_SID`, and voice app SID if separate. |
+| Webhook base URL | Public HTTPS URL reachable by Twilio. |
+| Devices | iPhone Safari PWA, Android Chrome PWA if available, and Desktop Chrome. |
+| Test contacts | Internal CRM/contact table and Google Contacts test-only records. |
+| SMS Campaign data | Test-only segment, opted-in recipients, opted-out recipient, scheduled campaigns for Number A and Number B. |
+
+## Twilio staging configuration checklist
+
+Configure both staging numbers independently in Twilio:
+
+| Twilio setting | Expected staging URL pattern |
+| --- | --- |
+| Messaging request URL | `<PUBLIC_BASE_URL>/twilio/sms/inbound` or the deployed equivalent used by the app |
+| Messaging fallback URL | `<PUBLIC_BASE_URL>/twilio/fallback` |
+| Messaging status callback | `<PUBLIC_BASE_URL>/twilio/sms/status` |
+| Voice request URL | `<PUBLIC_BASE_URL>/twilio/voice/inbound` or the deployed equivalent used by the app |
+| Voice recording callback | `<PUBLIC_BASE_URL>/twilio/voice/recording` |
+| Voice transcription callback | `<PUBLIC_BASE_URL>/twilio/voice/transcription` or `<PUBLIC_BASE_URL>/twilio/voice/voicemail` |
+| Voice application SID | Must match the staging TwiML app configured for browser/WiFi calling. |
+
+Before running live tests, confirm the app route aliases match the Twilio console URLs. If Twilio is configured to `/twilio/sms/inbound` or `/twilio/voice/inbound`, those routes must resolve or redirect to the canonical handlers without 404/500.
+
+## Staging account tests
+
+### Owner
+
+- Log in as the owner account from the credential handoff.
+- Open `/user/manage-users`.
+- Edit a user role and save.
+- Grant/revoke Communications permissions for a test user.
+- Confirm no Access Denied error appears.
+
+### Admin/manage-users
+
+- Log in as `info@adiken.com` using the staging credential handoff.
+- Open `/user/manage-users`.
+- Edit allowed user settings and save.
+- Confirm role normalization works for owner/admin/super-admin/supervisor/user aliases.
+- Confirm tenant isolation prevents editing users outside the tenant.
+
+### Restricted user
+
+- Log in as the restricted standard user from the credential handoff.
+- Confirm user-management edits are denied.
+- Confirm restricted phone numbers, SMS history, call logs, and voicemails are hidden.
+- Confirm any allowed assigned line still shows complete server history for that line.
+
+## Multi-number staging matrix
+
+Configure Number A and Number B with intentionally different settings:
+
+| Area | Number A | Number B | Expected result |
+| --- | --- | --- | --- |
+| Business hours | Schedule A | Schedule B | After-hours auto replies and routing follow the receiving number. |
+| Voicemail | Greeting/settings A | Greeting/settings B | Caller hears/stores voicemail on the called number. |
+| Forwarding | Forwarding/routing A | Forwarding/routing B | Calls/SMS route independently. |
+| Auto replies | Auto reply A | Auto reply B | Replies do not leak across numbers. |
+| Assigned users | User set A | User set B | PWA history is scoped by assigned line permission. |
+| Caller ID | Number A | Number B | Outbound call/SMS/campaign identity matches selected line. |
+| Campaign sender | Campaign A uses Number A | Campaign B uses Number B | Campaign sender identity and permissions remain separate. |
+
+## Real-device PWA tests
+
+Run on iPhone Safari PWA, Android Chrome PWA if available, and Desktop Chrome:
+
+- Install/open the PWA.
+- Confirm device appears in Communications Hub → Devices.
+- Confirm device name, browser/device type, online status, last seen, push status, microphone permission, installed status, WiFi-only/cell-callback/mobile-data settings, and default calling method are shown.
+- Select assigned Number A and Number B where permitted.
+- Confirm restricted users cannot select restricted numbers.
+- Send/read SMS, close/reopen PWA, and confirm conversations remain visible.
+- Log in as another authorized user and confirm the same server-backed line history appears.
+- Confirm unauthorized users cannot see restricted line history.
+- Change all 4 palettes and confirm the selected palette persists after logout/login, reinstall, and another device.
+
+## Voice and voicemail runtime tests
+
+Do not certify live Voice until all pass:
+
+- Browser/WiFi call succeeds from an enabled line.
+- Browser/WiFi call is blocked from a disabled line.
+- Cell callback succeeds from an enabled line.
+- Cell callback is blocked from a disabled line.
+- WiFi-only and mobile-data restrictions are respected.
+- Outbound caller ID shows the selected business number.
+- Inbound call rings/reroutes according to the called number.
+- No-answer/fallback voicemail records successfully.
+- Recording appears in Communications Hub and PWA visual voicemail.
+- Playback works on admin desktop and PWA devices.
+- Transcription displays when Twilio returns transcription data.
+- Voicemail read/unread state persists and is permission-filtered.
+
+## Contacts and dialer matching tests
+
+Create test-only records in Google Contacts and the internal CRM/contact table with:
+
+- Name
+- Company
+- Email
+- Mobile number
+
+Verify:
+
+- PWA search finds by contact name.
+- PWA search finds by company.
+- PWA search finds by email.
+- PWA search finds by phone number.
+- Dial pad live-matches normalized numbers while typing.
+- Incoming SMS resolves the Google/CRM contact name.
+- Recent SMS conversations and recent call-log numbers appear in search.
+
+## SMS Campaign staging tests
+
+- Create a test-only contact segment.
+- Include opted-in contacts.
+- Include one opted-out contact.
+- Create a scheduled SMS campaign using Number A.
+- Create a scheduled SMS campaign using Number B.
+- Confirm unauthorized users cannot send from restricted numbers.
+- Confirm scheduled campaigns appear on the marketing calendar.
+- Send only to approved test recipients.
+- Confirm analytics/reporting update after send/status callback.
+- Confirm STOP/START/HELP compliance remains unchanged.
+
+## Final sign-off criteria
+
+Communications / PWA Phone may be certified for staging only after:
+
+- Owner/admin/restricted account tests pass.
+- Number A/B isolation passes across hours, routing, voicemail, forwarding, auto replies, assigned users, caller ID, and campaigns.
+- PWA persistence passes across close/reopen, logout/login, reinstall, and multiple authorized users.
+- Real-device Voice and voicemail tests pass.
+- SMS Campaign scheduling, sending-number permissions, analytics, and compliance pass.
+- Mobile UI checks pass for Communications Hub, Devices, SMS Campaigns, and PWA.
+- No duplicate SMS/Text/Phone/Twilio/Inbox/Call Settings left-nav items are visible.

--- a/SMS_CALLING_SYSTEM_AUDIT_REPORT.md
+++ b/SMS_CALLING_SYSTEM_AUDIT_REPORT.md
@@ -1,0 +1,59 @@
+# SMS and Calling System Audit Report
+
+Date: 2026-06-17
+
+## Root causes identified
+
+1. **Conversation-thread replies**
+   - The PWA thread API already accepts a plain `body` from the active conversation, but the desktop `/twilio/send` API still required both `to` and `body` even when a `conversation_id` was supplied.
+   - This made the backend less tolerant than the UI and kept command-style workflows (`reply +1... message`) embedded in forwarded SMS instructions.
+
+2. **Per-character message rendering**
+   - The PWA renderer had a defensive JavaScript normalizer for payloads that arrive as one character per line, but message bubbles still allowed aggressive wrapping in narrow/flex layouts.
+   - The bubble CSS now preserves message text while avoiding character-by-character wrapping.
+
+3. **Google Contacts integration**
+   - OAuth/token helpers and sync endpoints existed.
+   - Sync only upserted contacts when a Google number matched an existing Twilio conversation, so PWA contact search and future inbound SMS lookup did not benefit from the full Google contact cache.
+   - Existing conversations also did not refresh their display names when a matching contact was added later.
+
+4. **Phone icon/calling workflow**
+   - The PWA already included a native dial pad, manual number entry, native contact picker support, recent/missed/voicemail call lists, and Twilio outbound call endpoints.
+   - Remaining risk was clarity: outbound calls must always use the tenant Twilio `from_phone` as caller ID and should not push users toward external apps.
+
+5. **Outbound calling**
+   - The native PWA call paths create Twilio calls using the configured business number (`from_=ta.from_phone`).
+   - If a forwarding number is configured, Twilio calls the employee first and then bridges to the customer; otherwise Twilio calls the customer directly. In both cases, the business number is the caller ID.
+
+6. **SMS send pipeline**
+   - Thread lookup existed, but desktop send updated conversation metadata before Twilio dispatch. A failed Twilio send could make the thread look successful.
+   - Error handling/logging now keeps metadata updates behind a successful provider response and logs failed sends with company/conversation context.
+
+## Completed repairs
+
+- Allowed `/twilio/send` to send a plain message using only `conversation_id` + `body`, resolving the destination number from the thread when `to` is omitted.
+- Moved desktop conversation metadata updates until after successful Twilio dispatch and added failure logging.
+- Normalized conversation lookup across phone-number variants so existing threads are reused regardless of phone formatting.
+- Refreshed existing conversations with CRM/Google contact names when a contact match is found after the thread already exists.
+- Populated the local Contact cache from all synced Google Contacts phone numbers, not only numbers with existing Twilio conversations.
+- Set cached Google contact display names on the Contact row to support PWA contact search.
+- Hardened PWA message bubble rendering to avoid one-character-per-line wrapping.
+
+## Affected files
+
+- `twilio_sms.py`
+  - Conversation lookup and contact-name resolution.
+  - Desktop SMS send API behavior, dispatch ordering, and error logging.
+- `services/google_contacts.py`
+  - Google Contacts cache population and contact upsert behavior.
+- `templates/inbox_pwa/index.html`
+  - Message bubble rendering and pathological SMS body normalization.
+
+## Verification notes
+
+- OAuth connection: `services/google_contacts.py` provides auth URL generation, code exchange, token storage, refresh, status helpers, and disconnect.
+- Sync job execution: PWA and Twilio settings routes call `sync_contacts(user_id, company_id)`; this now populates all Google phone contacts into the local Contact cache.
+- Contact cache population: all `phone_map` entries are upserted into `Contact` with `source="google_contacts"`.
+- Contact lookup in PWA: `/api/inbox/contacts/search` queries Contact rows and then conversations.
+- Incoming SMS name resolution: `_get_or_create_conversation()` now checks normalized phone variants, Contact rows, and previously synced conversation names for both new and existing conversations.
+- Outbound SMS: `_send_sms()` dispatches through Twilio, creates `TwilioMessage`, logs success/failure, and `/twilio/sms/status` updates delivery status by Twilio SID.

--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -153,6 +153,11 @@ def _get_twilio_account(company_id):
     return TwilioAccount.query.filter_by(company_id=company_id, is_active=True).first()
 
 
+def _accessible_numbers_for(user, company_id: int) -> list[str]:
+    from services.comms_permissions import accessible_phone_numbers
+    return accessible_phone_numbers(user, company_id)
+
+
 _UNICODE_REPLACEMENTS = str.maketrans({
     "\u2026": "...",   # …  ellipsis
     "\u2019": "'",     # '  right single quotation mark
@@ -404,6 +409,7 @@ def pwa_calls():
 
 
 def _call_to_dict(call):
+    voicemail_text = getattr(call, "transcription_text", None)
     return {
         "id": call.id,
         "twilio_call_sid": call.twilio_sid,
@@ -412,23 +418,220 @@ def _call_to_dict(call):
         "status": call.status,
         "from_number": call.from_number,
         "to_number": call.to_number,
+        "assigned_business_number": call.to_number if call.direction == "inbound" else call.from_number,
         "forwarded_to_number": getattr(call, "forwarded_to_number", None),
         "caller_name": call.caller_name or call.from_number,
+        "contact_name": call.caller_name or call.from_number,
+        "label": "Missed" if call.status in ("missed", "no-answer", "busy", "failed") else ("Outgoing" if call.direction == "outbound" else "Incoming"),
         "duration_seconds": call.duration or 0,
         "recording_url": getattr(call, "recording_url", None),
         "recording_sid": getattr(call, "recording_sid", None),
         "voicemail_url": getattr(call, "voicemail_url", None),
+        "voicemail_exists": bool(getattr(call, "voicemail_url", None) or call.status == "voicemail"),
         "voicemail_sid": getattr(call, "voicemail_sid", None),
-        "transcription_text": getattr(call, "transcription_text", None),
+        "transcription_text": voicemail_text,
+        "transcription_preview": (voicemail_text or "")[:160],
         "transcription_status": getattr(call, "transcription_status", None),
+        "transcription_provider": getattr(call, "transcription_provider", None),
+        "transcription_error": getattr(call, "transcription_error", None),
+        "transcribed_at": call.transcribed_at.isoformat() if getattr(call, "transcribed_at", None) else None,
         "answered_by_user_id": getattr(call, "answered_by_user_id", None),
         "answered_at": call.answered_at.isoformat() if getattr(call, "answered_at", None) else None,
+        "started_at": call.created_at.isoformat() if call.created_at else None,
         "ended_at": call.ended_at.isoformat() if getattr(call, "ended_at", None) else None,
         "is_read": getattr(call, "is_read", False),
+        "read_at": call.read_at.isoformat() if getattr(call, "read_at", None) else None,
+        "callback_target": getattr(call, "callback_target", None) or (call.from_number if call.direction == "inbound" else call.to_number),
         "is_archived": getattr(call, "is_archived", False),
         "created_at": call.created_at.isoformat() if call.created_at else None,
         "updated_at": call.updated_at.isoformat() if getattr(call, "updated_at", None) else None,
     }
+
+
+def _phone_number_for_payload(company_id, user, payload):
+    """Resolve and authorize a TwilioPhoneNumber from an API payload."""
+    from models import TwilioPhoneNumber
+    from services.comms_permissions import accessible_phone_numbers
+    allowed = set(accessible_phone_numbers(user, company_id))
+    number_id = payload.get("phone_number_id")
+    phone_number = payload.get("phone_number") or payload.get("selected_number")
+    q = TwilioPhoneNumber.query.filter_by(company_id=company_id, is_active=True)
+    if number_id:
+        pn = q.filter_by(id=number_id).first()
+    elif phone_number:
+        pn = q.filter_by(phone_number=phone_number).first()
+    else:
+        pn = None
+    if pn and pn.phone_number not in allowed:
+        abort(403, "No access to that phone number")
+    return pn
+
+
+def _device_to_dict(device):
+    pn = getattr(device, "phone_number", None)
+    user = getattr(device, "user", None)
+    return {
+        "id": device.id,
+        "device_name": device.device_name or "PWA Device",
+        "assigned_user": (user.email or user.username) if user else None,
+        "assigned_user_id": device.user_id,
+        "phone_number_id": device.phone_number_id,
+        "assigned_phone_number": pn.phone_number if pn else None,
+        "default_line": pn.friendly_name or pn.phone_number if pn else None,
+        "browser": device.browser,
+        "device_type": device.device_type,
+        "online_status": device.online_status,
+        "last_seen_at": device.last_seen_at.isoformat() if device.last_seen_at else None,
+        "push_enabled": bool(device.push_enabled),
+        "microphone_permission": device.microphone_permission or "unknown",
+        "pwa_installed": bool(device.pwa_installed),
+        "wifi_only": bool(device.wifi_only),
+        "cellular_callback_enabled": bool(device.cellular_callback_enabled),
+        "mobile_data_calling_allowed": bool(device.mobile_data_calling_allowed),
+        "default_calling_method": device.default_calling_method or "browser",
+    }
+
+
+def _upsert_pwa_device(user, company, payload):
+    from models import PWADevice
+    pn = _phone_number_for_payload(company.id, user, payload)
+    device_key = (payload.get("device_key") or payload.get("installation_id") or "").strip()
+    if not device_key:
+        abort(400, "device_key is required")
+    device = PWADevice.query.filter_by(company_id=company.id, user_id=user.id, device_key=device_key).first()
+    if not device:
+        device = PWADevice(company_id=company.id, user_id=user.id, device_key=device_key)
+        db.session.add(device)
+    device.phone_number_id = pn.id if pn else device.phone_number_id
+    for field in ("device_name", "browser", "device_type", "microphone_permission", "default_calling_method"):
+        if field in payload:
+            setattr(device, field, (payload.get(field) or "")[:120])
+    device.user_agent = request.headers.get("User-Agent", "")[:1000]
+    device.online_status = "online"
+    device.last_seen_at = datetime.utcnow()
+    device.push_enabled = bool(payload.get("push_enabled", device.push_enabled))
+    device.pwa_installed = bool(payload.get("pwa_installed", device.pwa_installed))
+    device.wifi_only = bool(payload.get("wifi_only", device.wifi_only))
+    device.cellular_callback_enabled = bool(payload.get("cellular_callback_enabled", device.cellular_callback_enabled))
+    device.mobile_data_calling_allowed = bool(payload.get("mobile_data_calling_allowed", device.mobile_data_calling_allowed))
+    return device
+
+
+# ── API: accessible phone numbers ───────────────────────────────────────────
+
+@inbox_pwa_bp.route("/api/phone/numbers")
+def api_phone_numbers():
+    user = _require_auth()
+    company = _require_company(user)
+    from models import TwilioPhoneNumber, TwilioAccount
+    numbers = _accessible_numbers_for(user, company.id)
+    rows = []
+    for pn in TwilioPhoneNumber.query.filter(TwilioPhoneNumber.company_id == company.id, TwilioPhoneNumber.phone_number.in_(numbers or ["__none__"])).all():
+        rows.append({
+            "id": pn.id,
+            "phone_number": pn.phone_number,
+            "friendly_name": pn.friendly_name or pn.phone_number,
+            "sms_enabled": bool(pn.sms_enabled),
+            "voice_enabled": bool(pn.voice_enabled),
+            "caller_id": pn.friendly_name or pn.phone_number,
+        })
+    known = {r["phone_number"] for r in rows}
+    for ta in TwilioAccount.query.filter_by(company_id=company.id).all():
+        if ta.from_phone in numbers and ta.from_phone not in known:
+            rows.append({"id": None, "phone_number": ta.from_phone, "friendly_name": ta.from_phone, "sms_enabled": True, "voice_enabled": True, "caller_id": ta.from_phone})
+    return jsonify({"success": True, "numbers": rows})
+
+
+@inbox_pwa_bp.route("/api/pwa/preferences", methods=["GET", "PATCH"])
+def api_pwa_preferences():
+    user = _require_auth()
+    _require_company(user)
+    if request.method == "PATCH":
+        data = request.get_json() or {}
+        palette = (data.get("palette_id") or data.get("palette") or "lux").strip()
+        if palette not in {"lux", "ocean", "forest", "sunset"}:
+            return jsonify({"success": False, "error": "Unsupported palette."}), 400
+        user.pwa_palette_id = palette
+        if data.get("theme_mode") in {"dark", "light", "system"}:
+            user.pwa_theme_mode = data.get("theme_mode")
+        user.pwa_preferences_updated_at = datetime.utcnow()
+        db.session.commit()
+    return jsonify({
+        "success": True,
+        "preferences": {
+            "palette_id": user.pwa_palette_id or "lux",
+            "theme_mode": user.pwa_theme_mode or "dark",
+            "updated_at": user.pwa_preferences_updated_at.isoformat() if user.pwa_preferences_updated_at else None,
+        }
+    })
+
+
+@inbox_pwa_bp.route("/api/pwa/devices")
+def api_pwa_devices():
+    user = _require_auth()
+    company = _require_company(user)
+    from models import PWADevice
+    from services.comms_permissions import accessible_phone_numbers, can_manage_users
+    allowed = set(accessible_phone_numbers(user, company.id))
+    q = PWADevice.query.filter_by(company_id=company.id)
+    if not can_manage_users(user, company.id):
+        q = q.filter(PWADevice.user_id == user.id)
+    devices = []
+    for device in q.order_by(PWADevice.last_seen_at.desc()).all():
+        pn = getattr(device, "phone_number", None)
+        if pn and pn.phone_number not in allowed:
+            continue
+        devices.append(_device_to_dict(device))
+    return jsonify({"success": True, "devices": devices})
+
+
+@inbox_pwa_bp.route("/api/pwa/devices/register", methods=["POST"])
+def api_pwa_device_register():
+    user = _require_auth()
+    company = _require_company(user)
+    device = _upsert_pwa_device(user, company, request.get_json() or {})
+    db.session.commit()
+    return jsonify({
+        "success": True,
+        "device": _device_to_dict(device),
+        "preferences": {
+            "palette_id": user.pwa_palette_id or "lux",
+            "theme_mode": user.pwa_theme_mode or "dark",
+        },
+    })
+
+
+@inbox_pwa_bp.route("/api/pwa/devices/heartbeat", methods=["POST"])
+def api_pwa_device_heartbeat():
+    user = _require_auth()
+    company = _require_company(user)
+    device = _upsert_pwa_device(user, company, request.get_json() or {})
+    db.session.commit()
+    return jsonify({"success": True, "device": _device_to_dict(device)})
+
+
+@inbox_pwa_bp.route("/api/pwa/devices/<int:device_id>/settings", methods=["PATCH"])
+def api_pwa_device_settings(device_id):
+    user = _require_auth()
+    company = _require_company(user)
+    from models import PWADevice
+    from services.comms_permissions import can_manage_users
+    device = PWADevice.query.filter_by(id=device_id, company_id=company.id).first_or_404()
+    if device.user_id != user.id and not can_manage_users(user, company.id):
+        abort(403)
+    data = request.get_json() or {}
+    if "phone_number_id" in data or "phone_number" in data or "selected_number" in data:
+        pn = _phone_number_for_payload(company.id, user, data)
+        device.phone_number_id = pn.id if pn else None
+    for field in ("device_name", "microphone_permission", "default_calling_method"):
+        if field in data:
+            setattr(device, field, (data.get(field) or "")[:120])
+    for field in ("push_enabled", "pwa_installed", "wifi_only", "cellular_callback_enabled", "mobile_data_calling_allowed"):
+        if field in data:
+            setattr(device, field, bool(data.get(field)))
+    device.last_seen_at = datetime.utcnow()
+    db.session.commit()
+    return jsonify({"success": True, "device": _device_to_dict(device)})
 
 
 # ── API: conversation list ────────────────────────────────────────────────────
@@ -439,7 +642,8 @@ def api_recent_calls():
     company = _require_company(user)
     from models import TwilioCallLog
     tab = request.args.get("tab", "all")
-    q = TwilioCallLog.query.filter_by(company_id=company.id, is_archived=False)
+    from services.comms_permissions import filter_calls_for_user
+    q = filter_calls_for_user(TwilioCallLog.query.filter_by(company_id=company.id, is_archived=False), user, company.id)
     if tab == "missed":
         q = q.filter(TwilioCallLog.status.in_(["missed", "no-answer", "busy", "failed"]))
     elif tab == "voicemail":
@@ -457,7 +661,8 @@ def api_call_detail(call_id):
     user = _require_auth()
     company = _require_company(user)
     from models import TwilioCallLog
-    call = TwilioCallLog.query.filter_by(id=call_id, company_id=company.id).first_or_404()
+    from services.comms_permissions import filter_calls_for_user
+    call = filter_calls_for_user(TwilioCallLog.query.filter_by(id=call_id, company_id=company.id), user, company.id).first_or_404()
     return jsonify({"call": _call_to_dict(call)})
 
 
@@ -466,11 +671,16 @@ def api_call_mark_read(call_id):
     user = _require_auth()
     company = _require_company(user)
     from models import TwilioCallLog, VoiceVoicemailMessage
-    call = TwilioCallLog.query.filter_by(id=call_id, company_id=company.id).first_or_404()
+    from services.comms_permissions import filter_calls_for_user
+    call = filter_calls_for_user(TwilioCallLog.query.filter_by(id=call_id, company_id=company.id), user, company.id).first_or_404()
     call.is_read = True
+    call.read_at = datetime.utcnow()
+    call.read_by_user_id = user.id
     vm = VoiceVoicemailMessage.query.filter_by(call_log_id=call.id, company_id=company.id).first()
     if vm:
         vm.is_read = True
+        vm.read_at = call.read_at
+        vm.read_by_user_id = user.id
     db.session.commit()
     return jsonify({"success": True, "call": _call_to_dict(call)})
 
@@ -480,7 +690,8 @@ def api_call_archive(call_id):
     user = _require_auth()
     company = _require_company(user)
     from models import TwilioCallLog, VoiceVoicemailMessage
-    call = TwilioCallLog.query.filter_by(id=call_id, company_id=company.id).first_or_404()
+    from services.comms_permissions import filter_calls_for_user
+    call = filter_calls_for_user(TwilioCallLog.query.filter_by(id=call_id, company_id=company.id), user, company.id).first_or_404()
     call.is_archived = True
     vm = VoiceVoicemailMessage.query.filter_by(call_log_id=call.id, company_id=company.id).first()
     if vm:
@@ -494,7 +705,11 @@ def api_voicemails():
     user = _require_auth()
     company = _require_company(user)
     from models import TwilioCallLog
-    calls = TwilioCallLog.query.filter_by(company_id=company.id, status="voicemail", is_archived=False).order_by(TwilioCallLog.created_at.desc()).limit(100).all()
+    from services.comms_permissions import filter_calls_for_user
+    calls = filter_calls_for_user(
+        TwilioCallLog.query.filter_by(company_id=company.id, status="voicemail", is_archived=False),
+        user, company.id,
+    ).order_by(TwilioCallLog.created_at.desc()).limit(100).all()
     return jsonify({"voicemails": [_call_to_dict(c) for c in calls]})
 
 
@@ -523,6 +738,65 @@ def _settings_to_dict(settings):
         "transcription_enabled": settings.transcription_enabled,
     }
 
+
+
+@inbox_pwa_bp.route("/api/phone/numbers/<int:number_id>/settings", methods=["GET", "PUT"])
+def api_phone_number_settings(number_id):
+    user = _require_auth()
+    company = _require_company(user)
+    from models import TwilioPhoneNumber
+    from services.comms_permissions import accessible_phone_numbers, can_manage_users
+    pn = TwilioPhoneNumber.query.filter_by(id=number_id, company_id=company.id, is_active=True).first_or_404()
+    if pn.phone_number not in accessible_phone_numbers(user, company.id):
+        abort(404)
+    editable = can_manage_users(user, company.id)
+    if request.method == "PUT":
+        if not editable:
+            return jsonify({"success": False, "error": "Permission denied."}), 403
+        data = request.get_json() or {}
+        allowed = {
+            "business_hours", "timezone", "during_hours_route", "after_hours_route",
+            "sms_forward_to", "sms_forwarding_enabled", "auto_reply_enabled",
+            "call_forward_to", "voice_forwarding_enabled", "ring_timeout",
+            "voicemail_greeting_text", "voicemail_greeting_audio_url",
+            "after_hours_text", "after_hours_sms_enabled", "after_hours_voicemail_enabled",
+            "browser_calling_enabled", "cell_callback_enabled", "wifi_only",
+            "mobile_data_allowed", "fallback_behavior", "caller_id_display_name",
+        }
+        for key in allowed:
+            if key in data:
+                setattr(pn, key, data[key])
+        db.session.commit()
+    return jsonify({
+        "success": True,
+        "editable": editable,
+        "settings": {
+            "id": pn.id,
+            "phone_number": pn.phone_number,
+            "friendly_name": pn.friendly_name or pn.phone_number,
+            "business_hours": pn.business_hours or _default_business_hours(),
+            "timezone": pn.timezone,
+            "during_hours_route": pn.during_hours_route,
+            "after_hours_route": pn.after_hours_route,
+            "sms_forward_to": pn.sms_forward_to,
+            "sms_forwarding_enabled": pn.sms_forwarding_enabled,
+            "auto_reply_enabled": pn.auto_reply_enabled,
+            "call_forward_to": pn.call_forward_to,
+            "voice_forwarding_enabled": pn.voice_forwarding_enabled,
+            "ring_timeout": pn.ring_timeout,
+            "voicemail_greeting_text": pn.voicemail_greeting_text,
+            "voicemail_greeting_audio_url": pn.voicemail_greeting_audio_url,
+            "after_hours_text": pn.after_hours_text,
+            "after_hours_sms_enabled": pn.after_hours_sms_enabled,
+            "after_hours_voicemail_enabled": pn.after_hours_voicemail_enabled,
+            "browser_calling_enabled": pn.browser_calling_enabled,
+            "cell_callback_enabled": pn.cell_callback_enabled,
+            "wifi_only": pn.wifi_only,
+            "mobile_data_allowed": pn.mobile_data_allowed,
+            "fallback_behavior": pn.fallback_behavior,
+            "caller_id_display_name": pn.caller_id_display_name,
+        }
+    })
 
 @inbox_pwa_bp.route("/api/phone/settings", methods=["GET", "PUT"])
 def api_phone_settings():
@@ -599,7 +873,8 @@ def _update_call_action(call_id: int, *, status: str, user_field: str | None = N
     user = _require_auth()
     company = _require_company(user)
     from models import TwilioCallLog, CallEvent
-    call = TwilioCallLog.query.filter_by(id=call_id, company_id=company.id).first_or_404()
+    from services.comms_permissions import filter_calls_for_user
+    call = filter_calls_for_user(TwilioCallLog.query.filter_by(id=call_id, company_id=company.id), user, company.id).first_or_404()
     call.status = status
     if user_field:
         setattr(call, user_field, user.id)
@@ -649,8 +924,10 @@ def list_conversations():
     filter_by = request.args.get("filter", "all")
     search    = request.args.get("q", "").strip()
     page      = int(request.args.get("page", 1))
+    number_filter = (request.args.get("number") or "").strip()
 
-    q = TwilioConversation.query.filter_by(company_id=company.id)
+    from services.comms_permissions import filter_conversations_for_user, accessible_phone_numbers
+    q = filter_conversations_for_user(TwilioConversation.query.filter_by(company_id=company.id), user, company.id)
 
     if filter_by == "unread":
         q = q.filter_by(is_read=False)
@@ -660,6 +937,13 @@ def list_conversations():
     if filter_by == "opted_out":
         q = q.filter_by(is_opted_out=True)
 
+    if number_filter:
+        allowed_numbers = accessible_phone_numbers(user, company.id)
+        if number_filter not in allowed_numbers:
+            q = q.filter(db.text("1=0"))
+        else:
+            q = q.filter(TwilioConversation.to_number == number_filter)
+
     if search:
         q = q.filter(db.or_(
             TwilioConversation.from_number.ilike(f"%{search}%"),
@@ -667,8 +951,9 @@ def list_conversations():
             TwilioConversation.last_message_preview.ilike(f"%{search}%"),
         ))
 
-    unread_count = TwilioConversation.query.filter_by(
-        company_id=company.id, is_read=False
+    unread_count = filter_conversations_for_user(
+        TwilioConversation.query.filter_by(company_id=company.id, is_read=False),
+        user, company.id,
     ).count()
 
     convs = q.order_by(TwilioConversation.last_message_at.desc()).all()
@@ -697,7 +982,10 @@ def get_conversation(conv_id):
     user    = _require_auth()
     company = _require_company(user)
     from models import TwilioConversation
-    conv = TwilioConversation.query.filter_by(id=conv_id, company_id=company.id).first_or_404()
+    from services.comms_permissions import filter_conversations_for_user
+    conv = filter_conversations_for_user(
+        TwilioConversation.query.filter_by(id=conv_id, company_id=company.id), user, company.id
+    ).first_or_404()
 
     # Mark as read when opened
     if not conv.is_read:
@@ -734,7 +1022,10 @@ def send_message(conv_id):
     user    = _require_auth()
     company = _require_company(user)
     from models import TwilioConversation
-    conv = TwilioConversation.query.filter_by(id=conv_id, company_id=company.id).first_or_404()
+    from services.comms_permissions import filter_conversations_for_user
+    conv = filter_conversations_for_user(
+        TwilioConversation.query.filter_by(id=conv_id, company_id=company.id), user, company.id
+    ).first_or_404()
 
     payload = request.get_json() or {}
     body    = (payload.get("body") or "").strip()
@@ -856,7 +1147,10 @@ def mark_read(conv_id):
     user    = _require_auth()
     company = _get_company(user)
     from models import TwilioConversation
-    conv = TwilioConversation.query.filter_by(id=conv_id, company_id=company.id).first_or_404()
+    from services.comms_permissions import filter_conversations_for_user
+    conv = filter_conversations_for_user(
+        TwilioConversation.query.filter_by(id=conv_id, company_id=company.id), user, company.id
+    ).first_or_404()
     payload  = request.get_json() or {}
     conv.is_read = payload.get("is_read", True)
     db.session.commit()
@@ -870,7 +1164,10 @@ def archive_conversation(conv_id):
     user    = _require_auth()
     company = _get_company(user)
     from models import TwilioConversation
-    conv = TwilioConversation.query.filter_by(id=conv_id, company_id=company.id).first_or_404()
+    from services.comms_permissions import filter_conversations_for_user
+    conv = filter_conversations_for_user(
+        TwilioConversation.query.filter_by(id=conv_id, company_id=company.id), user, company.id
+    ).first_or_404()
     payload  = request.get_json() or {}
     archive  = payload.get("archived", True)
     tags     = _safe_conversation_tags(conv.tags)
@@ -890,7 +1187,10 @@ def assign_conversation(conv_id):
     user    = _require_auth()
     company = _get_company(user)
     from models import TwilioConversation
-    conv = TwilioConversation.query.filter_by(id=conv_id, company_id=company.id).first_or_404()
+    from services.comms_permissions import filter_conversations_for_user
+    conv = filter_conversations_for_user(
+        TwilioConversation.query.filter_by(id=conv_id, company_id=company.id), user, company.id
+    ).first_or_404()
     payload = request.get_json() or {}
     assign_to = payload.get("user_id")  # null to unassign
     conv.assigned_user_id = assign_to
@@ -905,7 +1205,10 @@ def update_notes(conv_id):
     user    = _require_auth()
     company = _get_company(user)
     from models import TwilioConversation
-    conv = TwilioConversation.query.filter_by(id=conv_id, company_id=company.id).first_or_404()
+    from services.comms_permissions import filter_conversations_for_user
+    conv = filter_conversations_for_user(
+        TwilioConversation.query.filter_by(id=conv_id, company_id=company.id), user, company.id
+    ).first_or_404()
     payload  = request.get_json() or {}
     conv.notes = payload.get("notes", conv.notes or "")
     db.session.commit()
@@ -919,7 +1222,10 @@ def rename_contact(conv_id):
     user    = _require_auth()
     company = _get_company(user)
     from models import TwilioConversation
-    conv = TwilioConversation.query.filter_by(id=conv_id, company_id=company.id).first_or_404()
+    from services.comms_permissions import filter_conversations_for_user
+    conv = filter_conversations_for_user(
+        TwilioConversation.query.filter_by(id=conv_id, company_id=company.id), user, company.id
+    ).first_or_404()
     payload  = request.get_json() or {}
     name     = (payload.get("name") or "").strip()
     if name:
@@ -937,8 +1243,10 @@ def unread_count():
     if not company:
         return jsonify({"count": 0})
     from models import TwilioConversation
-    count = TwilioConversation.query.filter_by(
-        company_id=company.id, is_read=False
+    from services.comms_permissions import filter_conversations_for_user
+    count = filter_conversations_for_user(
+        TwilioConversation.query.filter_by(company_id=company.id, is_read=False),
+        user, company.id,
     ).count()
     return jsonify({"count": count})
 
@@ -1136,14 +1444,20 @@ def search_contacts():
     results = []
     try:
         from models import Contact
+        digits = "".join(ch for ch in q if ch.isdigit())
         like = f"%{q}%"
+        digit_like = f"%{digits}%" if digits else like
         contacts = (
             Contact.query
             .filter(
                 Contact.company_id == company.id,
                 db.or_(
-                    Contact.name.ilike(like),
+                    Contact.first_name.ilike(like),
+                    Contact.last_name.ilike(like),
+                    Contact.company.ilike(like),
+                    Contact.email.ilike(like),
                     Contact.phone.ilike(like),
+                    Contact.phone.ilike(digit_like),
                 ),
             )
             .limit(8)
@@ -1151,34 +1465,49 @@ def search_contacts():
         )
         for c in contacts:
             if c.phone:
-                results.append({"name": c.name or c.phone, "phone": c.phone})
+                name = " ".join([part for part in [c.first_name, c.last_name] if part]).strip()
+                results.append({"name": name or c.company or c.email or c.phone, "company": c.company, "email": c.email, "phone": c.phone, "source": "contact"})
     except Exception:
         pass
 
-    if not results:
-        try:
-            from models import TwilioConversation
-            like = f"%{q}%"
-            convs = (
-                TwilioConversation.query
-                .filter(
-                    TwilioConversation.company_id == company.id,
-                    db.or_(
-                        TwilioConversation.contact_name.ilike(like),
-                        TwilioConversation.from_number.ilike(like),
-                    ),
-                )
-                .limit(8)
-                .all()
-            )
-            seen = set()
-            for cv in convs:
-                phone = cv.from_number
-                if phone and phone not in seen:
-                    seen.add(phone)
-                    results.append({"name": cv.contact_name or phone, "phone": phone})
-        except Exception:
-            pass
+    try:
+        from models import TwilioConversation
+        from services.comms_permissions import filter_conversations_for_user
+        like = f"%{q}%"
+        convs = (
+            filter_conversations_for_user(TwilioConversation.query.filter_by(company_id=company.id), user, company.id)
+            .filter(db.or_(TwilioConversation.contact_name.ilike(like), TwilioConversation.from_number.ilike(like)))
+            .limit(8)
+            .all()
+        )
+        seen = {r["phone"] for r in results}
+        for cv in convs:
+            phone = cv.from_number
+            if phone and phone not in seen:
+                seen.add(phone)
+                results.append({"name": cv.contact_name or phone, "phone": phone, "source": "conversation"})
+    except Exception:
+        pass
+
+    try:
+        from models import TwilioCallLog
+        from services.comms_permissions import filter_calls_for_user
+        like = f"%{q}%"
+        calls = (
+            filter_calls_for_user(TwilioCallLog.query.filter_by(company_id=company.id), user, company.id)
+            .filter(db.or_(TwilioCallLog.caller_name.ilike(like), TwilioCallLog.from_number.ilike(like), TwilioCallLog.to_number.ilike(like)))
+            .order_by(TwilioCallLog.created_at.desc())
+            .limit(8)
+            .all()
+        )
+        seen = {r["phone"] for r in results}
+        for call in calls:
+            phone = call.from_number if call.direction == "inbound" else call.to_number
+            if phone and phone not in seen:
+                seen.add(phone)
+                results.append({"name": call.caller_name or phone, "phone": phone, "source": "call_log"})
+    except Exception:
+        pass
 
     return jsonify({"contacts": results})
 
@@ -1197,8 +1526,9 @@ def place_outbound_call(conv_id):
     company = _require_company(user)
 
     from models import TwilioConversation
-    conv = TwilioConversation.query.filter_by(
-        id=conv_id, company_id=company.id
+    from services.comms_permissions import filter_conversations_for_user
+    conv = filter_conversations_for_user(
+        TwilioConversation.query.filter_by(id=conv_id, company_id=company.id), user, company.id
     ).first_or_404()
 
     ta = _get_twilio_account(company.id)
@@ -1215,6 +1545,18 @@ def place_outbound_call(conv_id):
         client = Client(sid, tok)
 
         payload     = request.get_json() or {}
+        from models import TwilioPhoneNumber
+        from services.comms_permissions import accessible_phone_numbers
+        allowed_numbers = set(accessible_phone_numbers(user, company.id))
+        business_number = conv.to_number if conv.to_number in allowed_numbers else ta.from_phone
+        pn = TwilioPhoneNumber.query.filter_by(company_id=company.id, phone_number=business_number, is_active=True).first()
+        method = payload.get("calling_method") or "cell_callback"
+        if method == "browser" and pn and not pn.browser_calling_enabled:
+            return jsonify({"success": False, "error": "Browser/WiFi calling is disabled for this number."}), 403
+        if method == "cell_callback" and pn and not pn.cell_callback_enabled:
+            return jsonify({"success": False, "error": "Cell callback calling is disabled for this number."}), 403
+        if method == "browser" and pn and pn.wifi_only and payload.get("network_type") == "cellular":
+            return jsonify({"success": False, "error": "This line is WiFi-only for browser calling."}), 403
         forward_to  = payload.get("forward_to") or ta.call_forward_to
         customer_no = conv.from_number
 
@@ -1222,7 +1564,7 @@ def place_outbound_call(conv_id):
         twiml_url = url_for(
             "twilio.outbound_call_twiml",
             to=customer_no,
-            caller=ta.from_phone,
+            caller=business_number,
             _external=True,
         )
 
@@ -1230,7 +1572,7 @@ def place_outbound_call(conv_id):
             # Call the agent first; TwiML dials the customer when agent answers
             call = client.calls.create(
                 to=forward_to,
-                from_=ta.from_phone,
+                from_=business_number,
                 url=twiml_url,
             )
             msg = f"Calling your phone ({forward_to}). Answer to be connected to {customer_no}."
@@ -1238,7 +1580,7 @@ def place_outbound_call(conv_id):
             # Call the customer directly (e.g. to leave a voicemail / test)
             call = client.calls.create(
                 to=customer_no,
-                from_=ta.from_phone,
+                from_=business_number,
                 url=twiml_url,
             )
             msg = f"Outbound call initiated to {customer_no}."
@@ -1287,26 +1629,43 @@ def dial_number():
         tok    = ta.get_auth_token()  if hasattr(ta, "get_auth_token")  else ta._auth_token
         client = Client(sid, tok)
 
+        from models import TwilioPhoneNumber
+        from services.comms_permissions import accessible_phone_numbers
+        allowed_numbers = set(accessible_phone_numbers(user, company.id))
+        business_number = payload.get("from_phone_number") or payload.get("selected_number") or ta.from_phone
+        if business_number not in allowed_numbers:
+            return jsonify({"success": False, "error": "No access to the selected business number."}), 403
+        pn = TwilioPhoneNumber.query.filter_by(company_id=company.id, phone_number=business_number, is_active=True).first()
+        method = payload.get("calling_method") or "cell_callback"
+        if method == "browser" and pn and not pn.browser_calling_enabled:
+            return jsonify({"success": False, "error": "Browser/WiFi calling is disabled for this number."}), 403
+        if method == "cell_callback" and pn and not pn.cell_callback_enabled:
+            return jsonify({"success": False, "error": "Cell callback calling is disabled for this number."}), 403
+        if method == "browser" and pn and pn.wifi_only and payload.get("network_type") == "cellular":
+            return jsonify({"success": False, "error": "This line is WiFi-only for browser calling."}), 403
+        if method == "browser" and pn and not pn.mobile_data_allowed and payload.get("network_type") == "cellular":
+            return jsonify({"success": False, "error": "Mobile-data browser calling is blocked for this number."}), 403
+
         forward_to = payload.get("forward_to") or ta.call_forward_to
 
         twiml_url = _url_for(
             "twilio.outbound_call_twiml",
             to=to_number,
-            caller=ta.from_phone,
+            caller=business_number,
             _external=True,
         )
 
         if forward_to:
             call = client.calls.create(
                 to=forward_to,
-                from_=ta.from_phone,
+                from_=business_number,
                 url=twiml_url,
             )
             msg = f"Calling your phone ({forward_to}). Answer to be connected to {to_number}."
         else:
             call = client.calls.create(
                 to=to_number,
-                from_=ta.from_phone,
+                from_=business_number,
                 url=twiml_url,
             )
             msg = f"Outbound call initiated to {to_number}."

--- a/migrations/20260617_comms_phone_number_permissions.sql
+++ b/migrations/20260617_comms_phone_number_permissions.sql
@@ -1,0 +1,84 @@
+-- Communications phone-number permissions and per-line settings
+ALTER TABLE user_company_access ADD COLUMN IF NOT EXISTS manage_users_enabled BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS business_hours JSONB DEFAULT '{}'::jsonb;
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS timezone VARCHAR(80) DEFAULT 'America/Los_Angeles';
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS during_hours_route VARCHAR(30) DEFAULT 'ring_pwa';
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS after_hours_route VARCHAR(30) DEFAULT 'voicemail';
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS browser_calling_enabled BOOLEAN DEFAULT TRUE;
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS cell_callback_enabled BOOLEAN DEFAULT TRUE;
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS wifi_only BOOLEAN DEFAULT FALSE;
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS mobile_data_allowed BOOLEAN DEFAULT TRUE;
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS fallback_behavior VARCHAR(30) DEFAULT 'cell_callback';
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS caller_id_display_name VARCHAR(120);
+
+CREATE TABLE IF NOT EXISTS phone_number_user_permission (
+  id SERIAL PRIMARY KEY,
+  company_id INTEGER NOT NULL REFERENCES company(id),
+  phone_number_id INTEGER NOT NULL REFERENCES twilio_phone_number(id),
+  user_id INTEGER NOT NULL REFERENCES "user"(id),
+  can_access_pwa BOOLEAN DEFAULT TRUE,
+  can_view_sms BOOLEAN DEFAULT TRUE,
+  can_send_sms BOOLEAN DEFAULT TRUE,
+  can_view_calls BOOLEAN DEFAULT TRUE,
+  can_call BOOLEAN DEFAULT TRUE,
+  can_view_voicemail BOOLEAN DEFAULT TRUE,
+  can_manage_number BOOLEAN DEFAULT FALSE,
+  can_send_campaigns BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT uq_phone_number_user_permission UNIQUE (phone_number_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS ix_phone_number_user_permission_company_id ON phone_number_user_permission(company_id);
+CREATE INDEX IF NOT EXISTS ix_phone_number_user_permission_phone_number_id ON phone_number_user_permission(phone_number_id);
+CREATE INDEX IF NOT EXISTS ix_phone_number_user_permission_user_id ON phone_number_user_permission(user_id);
+
+
+ALTER TABLE sms_campaign ADD COLUMN IF NOT EXISTS from_phone_number_id INTEGER REFERENCES twilio_phone_number(id);
+ALTER TABLE sms_campaign ADD COLUMN IF NOT EXISTS from_phone_number VARCHAR(20);
+CREATE INDEX IF NOT EXISTS ix_sms_campaign_from_phone_number_id ON sms_campaign(from_phone_number_id);
+
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS pwa_palette_id VARCHAR(30) DEFAULT 'lux';
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS pwa_theme_mode VARCHAR(20) DEFAULT 'dark';
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS pwa_preferences_updated_at TIMESTAMP;
+
+ALTER TABLE twilio_call_log ADD COLUMN IF NOT EXISTS read_at TIMESTAMP;
+ALTER TABLE twilio_call_log ADD COLUMN IF NOT EXISTS read_by_user_id INTEGER REFERENCES "user"(id);
+ALTER TABLE twilio_call_log ADD COLUMN IF NOT EXISTS callback_target VARCHAR(20);
+ALTER TABLE twilio_call_log ADD COLUMN IF NOT EXISTS transcription_error TEXT;
+ALTER TABLE twilio_call_log ADD COLUMN IF NOT EXISTS transcribed_at TIMESTAMP;
+
+ALTER TABLE voice_voicemail_message ADD COLUMN IF NOT EXISTS transcription_text TEXT;
+ALTER TABLE voice_voicemail_message ADD COLUMN IF NOT EXISTS transcription_status VARCHAR(30) DEFAULT 'not_requested';
+ALTER TABLE voice_voicemail_message ADD COLUMN IF NOT EXISTS transcription_provider VARCHAR(80);
+ALTER TABLE voice_voicemail_message ADD COLUMN IF NOT EXISTS transcription_error TEXT;
+ALTER TABLE voice_voicemail_message ADD COLUMN IF NOT EXISTS transcribed_at TIMESTAMP;
+ALTER TABLE voice_voicemail_message ADD COLUMN IF NOT EXISTS read_at TIMESTAMP;
+ALTER TABLE voice_voicemail_message ADD COLUMN IF NOT EXISTS read_by_user_id INTEGER REFERENCES "user"(id);
+
+CREATE TABLE IF NOT EXISTS pwa_device (
+    id SERIAL PRIMARY KEY,
+    company_id INTEGER NOT NULL REFERENCES company(id),
+    user_id INTEGER NOT NULL REFERENCES "user"(id),
+    phone_number_id INTEGER REFERENCES twilio_phone_number(id),
+    device_key VARCHAR(120) NOT NULL,
+    device_name VARCHAR(120),
+    browser VARCHAR(120),
+    device_type VARCHAR(80),
+    user_agent TEXT,
+    online_status VARCHAR(20) DEFAULT 'online',
+    last_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    push_enabled BOOLEAN DEFAULT FALSE,
+    microphone_permission VARCHAR(30) DEFAULT 'unknown',
+    pwa_installed BOOLEAN DEFAULT FALSE,
+    wifi_only BOOLEAN DEFAULT FALSE,
+    cellular_callback_enabled BOOLEAN DEFAULT FALSE,
+    mobile_data_calling_allowed BOOLEAN DEFAULT FALSE,
+    default_calling_method VARCHAR(30) DEFAULT 'browser',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_pwa_device_user_key UNIQUE (company_id, user_id, device_key)
+);
+CREATE INDEX IF NOT EXISTS ix_pwa_device_company_id ON pwa_device(company_id);
+CREATE INDEX IF NOT EXISTS ix_pwa_device_user_id ON pwa_device(user_id);
+CREATE INDEX IF NOT EXISTS ix_pwa_device_phone_number_id ON pwa_device(phone_number_id);

--- a/models.py
+++ b/models.py
@@ -44,6 +44,7 @@ class UserCompanyAccess(db.Model):
     voicemail_enabled         = db.Column(db.Boolean, default=False)
     ai_comms_enabled          = db.Column(db.Boolean, default=False)
     forwarding_enabled        = db.Column(db.Boolean, default=False)
+    manage_users_enabled      = db.Column(db.Boolean, default=False)
     # License flag — admin explicitly marks user as having a comms license
     communications_license    = db.Column(db.Boolean, default=False)
     # Number assignment — 'shared' = company shared number, 'dedicated' = own DID
@@ -69,6 +70,18 @@ class UserCompanyAccess(db.Model):
     ROLE_STAFF      = "staff"
     ROLE_INBOX_ONLY = "inbox_only"
 
+    ROLE_ALIASES = {
+        "superadmin": ROLE_OWNER,
+        "super_admin": ROLE_OWNER,
+        "super-admin": ROLE_OWNER,
+        "administrator": ROLE_ADMIN,
+        "tenant_admin": ROLE_ADMIN,
+        "company_admin": ROLE_ADMIN,
+        "supervisor": ROLE_MANAGER,
+        "member": ROLE_STAFF,
+        "user": ROLE_VIEWER,
+    }
+
     ROLE_HIERARCHY = {
         ROLE_OWNER:      5,
         ROLE_ADMIN:      4,
@@ -87,14 +100,26 @@ class UserCompanyAccess(db.Model):
     def __repr__(self):
         return f"<UserCompanyAccess user={self.user_id} company={self.company_id} role={self.role}>"
 
+    @classmethod
+    def normalize_role(cls, role):
+        value = (role or cls.ROLE_VIEWER).strip().lower().replace(" ", "_")
+        return cls.ROLE_ALIASES.get(value, value)
+
+    @property
+    def normalized_role(self):
+        return self.normalize_role(self.role)
+
     def can_edit(self):
-        return self.role in {self.ROLE_OWNER, self.ROLE_ADMIN, self.ROLE_MANAGER, self.ROLE_EDITOR}
+        return self.normalized_role in {self.ROLE_OWNER, self.ROLE_ADMIN, self.ROLE_MANAGER, self.ROLE_EDITOR}
 
     def can_admin(self):
-        return self.role in {self.ROLE_OWNER, self.ROLE_ADMIN}
+        return self.normalized_role in {self.ROLE_OWNER, self.ROLE_ADMIN}
 
     def can_own(self):
-        return self.role == self.ROLE_OWNER
+        return self.normalized_role == self.ROLE_OWNER
+
+    def can_manage_users(self):
+        return self.normalized_role == self.ROLE_OWNER or bool(self.manage_users_enabled)
 
     def has_mobile_inbox_access(self) -> bool:
         """Mobile Inbox / PWA requires explicit admin approval.
@@ -105,7 +130,7 @@ class UserCompanyAccess(db.Model):
         - any role with can_access_mobile_inbox=True: allowed (legacy flag, backward compat)
         - all other roles: denied
         """
-        if self.role in (self.ROLE_OWNER, self.ROLE_ADMIN):
+        if self.normalized_role in (self.ROLE_OWNER, self.ROLE_ADMIN):
             return True
         if self.pwa_access_enabled:
             return True
@@ -118,7 +143,7 @@ class UserCompanyAccess(db.Model):
         - any role with comms_hub_enabled=True: allowed
         - any role with communications_license=True: allowed
         """
-        if self.role in (self.ROLE_OWNER, self.ROLE_ADMIN):
+        if self.normalized_role in (self.ROLE_OWNER, self.ROLE_ADMIN):
             return True
         if self.comms_hub_enabled:
             return True
@@ -126,7 +151,7 @@ class UserCompanyAccess(db.Model):
 
     def has_full_app_access(self) -> bool:
         """Inbox-only role never gets full app; all other roles default to True."""
-        if self.role == self.ROLE_INBOX_ONLY:
+        if self.normalized_role == self.ROLE_INBOX_ONLY:
             return False
         if self.can_access_full_app is None:
             return True
@@ -173,6 +198,9 @@ class User(UserMixin, db.Model):
     last_activity = db.Column(db.DateTime)
     bio = db.Column(db.Text)  # User bio/description
     preferred_hub = db.Column(db.String(20), default='marketing')  # 'marketing' or 'sales'
+    pwa_palette_id = db.Column(db.String(30), default='lux')
+    pwa_theme_mode = db.Column(db.String(20), default='dark')
+    pwa_preferences_updated_at = db.Column(db.DateTime)
     
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(
@@ -895,6 +923,8 @@ class SMSCampaign(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=True, index=True)
     created_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    from_phone_number_id = db.Column(db.Integer, db.ForeignKey("twilio_phone_number.id"), nullable=True)
+    from_phone_number = db.Column(db.String(20), nullable=True)
     name = db.Column(db.String(255))
     objective = db.Column(db.Text)
     message = db.Column(db.String(1000))
@@ -3082,12 +3112,17 @@ class TwilioCallLog(db.Model):
     transcription_text = db.Column(db.Text, nullable=True)
     transcription_status = db.Column(db.String(30), default="not_requested")
     transcription_provider = db.Column(db.String(80), nullable=True)
+    transcription_error = db.Column(db.Text, nullable=True)
+    transcribed_at = db.Column(db.DateTime, nullable=True)
     caller_name  = db.Column(db.String(200))
     notes        = db.Column(db.Text)
     missed_text_sent = db.Column(db.Boolean, default=False)
     raw_payload  = db.Column(JSON)
     metadata_json = db.Column(JSON)
     is_read      = db.Column(db.Boolean, default=False)
+    read_at      = db.Column(db.DateTime, nullable=True)
+    read_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    callback_target = db.Column(db.String(20), nullable=True)
     is_archived  = db.Column(db.Boolean, default=False)
     created_at   = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at   = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
@@ -3460,6 +3495,17 @@ class TwilioPhoneNumber(db.Model):
     voice_forwarding_enabled = db.Column(db.Boolean, default=True)
     ring_timeout             = db.Column(db.Integer, default=25)
 
+    business_hours           = db.Column(JSON, default=dict)
+    timezone                 = db.Column(db.String(80), default="America/Los_Angeles")
+    during_hours_route       = db.Column(db.String(30), default="ring_pwa")
+    after_hours_route        = db.Column(db.String(30), default="voicemail")
+    browser_calling_enabled  = db.Column(db.Boolean, default=True)
+    cell_callback_enabled    = db.Column(db.Boolean, default=True)
+    wifi_only                = db.Column(db.Boolean, default=False)
+    mobile_data_allowed      = db.Column(db.Boolean, default=True)
+    fallback_behavior        = db.Column(db.String(30), default="cell_callback")
+    caller_id_display_name   = db.Column(db.String(120))
+
     voicemail_greeting_text       = db.Column(db.Text)
     voicemail_greeting_audio_url  = db.Column(db.String(500))
     missed_call_text              = db.Column(db.Text)
@@ -3478,6 +3524,71 @@ class TwilioPhoneNumber(db.Model):
 
     def __repr__(self):
         return f"<TwilioPhoneNumber {self.phone_number} co={self.company_id}>"
+
+
+
+
+class PhoneNumberUserPermission(db.Model):
+    """Per-user permissions for a specific Twilio phone number/line."""
+    __tablename__ = "phone_number_user_permission"
+
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    phone_number_id = db.Column(db.Integer, db.ForeignKey("twilio_phone_number.id"), nullable=False, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False, index=True)
+
+    can_access_pwa = db.Column(db.Boolean, default=True)
+    can_view_sms = db.Column(db.Boolean, default=True)
+    can_send_sms = db.Column(db.Boolean, default=True)
+    can_view_calls = db.Column(db.Boolean, default=True)
+    can_call = db.Column(db.Boolean, default=True)
+    can_view_voicemail = db.Column(db.Boolean, default=True)
+    can_manage_number = db.Column(db.Boolean, default=False)
+    can_send_campaigns = db.Column(db.Boolean, default=False)
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    phone_number = db.relationship("TwilioPhoneNumber", backref="user_permissions")
+    user = db.relationship("User", backref="phone_number_permissions")
+    company = db.relationship("Company", backref="phone_number_user_permissions")
+
+    __table_args__ = (
+        db.UniqueConstraint("phone_number_id", "user_id", name="uq_phone_number_user_permission"),
+    )
+
+class PWADevice(db.Model):
+    """Registered PWA/work-phone device for Communications runtime readiness."""
+    __tablename__ = "pwa_device"
+
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False, index=True)
+    phone_number_id = db.Column(db.Integer, db.ForeignKey("twilio_phone_number.id"), nullable=True, index=True)
+    device_key = db.Column(db.String(120), nullable=False)
+    device_name = db.Column(db.String(120))
+    browser = db.Column(db.String(120))
+    device_type = db.Column(db.String(80))
+    user_agent = db.Column(db.Text)
+    online_status = db.Column(db.String(20), default="online")
+    last_seen_at = db.Column(db.DateTime, default=datetime.utcnow)
+    push_enabled = db.Column(db.Boolean, default=False)
+    microphone_permission = db.Column(db.String(30), default="unknown")
+    pwa_installed = db.Column(db.Boolean, default=False)
+    wifi_only = db.Column(db.Boolean, default=False)
+    cellular_callback_enabled = db.Column(db.Boolean, default=False)
+    mobile_data_calling_allowed = db.Column(db.Boolean, default=False)
+    default_calling_method = db.Column(db.String(30), default="browser")
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    user = db.relationship("User", backref=db.backref("pwa_devices", lazy="dynamic"))
+    company = db.relationship("Company", backref=db.backref("pwa_devices", lazy="dynamic"))
+    phone_number = db.relationship("TwilioPhoneNumber", backref=db.backref("pwa_devices", lazy="dynamic"))
+
+    __table_args__ = (
+        db.UniqueConstraint("company_id", "user_id", "device_key", name="uq_pwa_device_user_key"),
+    )
 
 
 class VoiceVoicemailBox(db.Model):
@@ -3648,6 +3759,13 @@ class VoiceVoicemailMessage(db.Model):
     recording_url = db.Column(db.String(500))
     duration_secs = db.Column(db.Integer, default=0)
     transcript    = db.Column(db.Text)
+    transcription_text = db.Column(db.Text)
+    transcription_status = db.Column(db.String(30), default="not_requested")
+    transcription_provider = db.Column(db.String(80))
+    transcription_error = db.Column(db.Text)
+    transcribed_at = db.Column(db.DateTime)
+    read_at       = db.Column(db.DateTime)
+    read_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
     is_read       = db.Column(db.Boolean, default=False)
     is_deleted    = db.Column(db.Boolean, default=False)
     created_at    = db.Column(db.DateTime, default=datetime.utcnow)

--- a/routes.py
+++ b/routes.py
@@ -6142,21 +6142,22 @@ def change_password():
 @main_bp.route('/user/manage-users')
 @login_required
 def manage_users():
-    """Manage users page — accessible to platform admins and company admins."""
+    """Manage users page — owner/admin/manage-users scoped by tenant."""
     from models import User, UserCompanyAccess
+    from services.comms_permissions import can_manage_users
     try:
+        company = current_user.get_default_company()
         if current_user.is_admin:
             users = User.query.order_by(User.username).all()
         else:
-            company = current_user.get_default_company()
-            if not company or not current_user.can_admin_company(company.id):
-                flash('Access denied. You need admin or company-admin privileges.', 'danger')
+            if not company or not can_manage_users(current_user, company.id):
+                flash('Access denied. You need owner or manage-users permission.', 'danger')
                 return redirect(url_for('main.dashboard'))
             user_ids = [a.user_id for a in UserCompanyAccess.query.filter_by(company_id=company.id).all()]
             users = User.query.filter(User.id.in_(user_ids)).order_by(User.username).all()
 
-        # Build per-user access map {user_id: access_row} (first row wins)
-        all_access = UserCompanyAccess.query.all()
+        # Build per-user access map {user_id: access_row} (tenant row first)
+        all_access = (UserCompanyAccess.query.filter_by(company_id=company.id).all() if company and not current_user.is_admin else UserCompanyAccess.query.all())
         access_by_user = {}
         for acc in all_access:
             access_by_user.setdefault(acc.user_id, acc)
@@ -6174,19 +6175,31 @@ def manage_users():
 @main_bp.route('/user/edit/<int:user_id>', methods=['GET', 'POST'])
 @login_required
 def edit_user(user_id):
-    """Edit a user (admin only)"""
-    if not current_user.is_admin:
-        flash('Access denied.', 'danger')
-        return redirect(url_for('main.dashboard'))
-    from models import User
+    """Edit a user when platform admin, tenant owner, or manage-users admin."""
+    from models import User, UserCompanyAccess
+    from services.comms_permissions import can_manage_users
     user = User.query.get_or_404(user_id)
+    company = current_user.get_default_company()
+    if not current_user.is_admin:
+        if not company or not can_manage_users(current_user, company.id):
+            flash('Access denied.', 'danger')
+            return redirect(url_for('main.dashboard'))
+        if not UserCompanyAccess.query.filter_by(user_id=user.id, company_id=company.id).first():
+            flash('Access denied for this tenant user.', 'danger')
+            return redirect(url_for('main.manage_users'))
     if request.method == 'POST':
         user.username = request.form.get('username', user.username)
         user.email = request.form.get('email', user.email)
         user.first_name = request.form.get('first_name', '')
         user.last_name = request.form.get('last_name', '')
-        user.role = request.form.get('role', user.role)
-        user.is_admin = request.form.get('is_admin') == 'on'
+        requested_role = request.form.get('role', user.role)
+        user.role = requested_role
+        if current_user.is_admin:
+            user.is_admin = request.form.get('is_admin') == 'on'
+        if company:
+            acc = UserCompanyAccess.query.filter_by(user_id=user.id, company_id=company.id).first()
+            if acc and requested_role:
+                acc.role = UserCompanyAccess.normalize_role(requested_role)
         user.updated_at = datetime.now()
         db.session.commit()
         flash(f'User {user.username} updated successfully!', 'success')
@@ -6196,7 +6209,7 @@ def edit_user(user_id):
 @main_bp.route('/user/delete/<int:user_id>', methods=['POST'])
 @login_required
 def delete_user(user_id):
-    """Delete a user (admin only)"""
+    """Delete a user (platform admin only)."""
     if not current_user.is_admin:
         flash('Access denied.', 'danger')
         return redirect(url_for('main.dashboard'))
@@ -6216,9 +6229,10 @@ def update_user_access(user_id):
     """Toggle per-user PWA / full-app access flags (platform admin or company admin only)."""
     from models import User, UserCompanyAccess
     try:
+        company = current_user.get_default_company()
         if not current_user.is_admin:
-            company = current_user.get_default_company()
-            if not company or not current_user.can_admin_company(company.id):
+            from services.comms_permissions import can_manage_users
+            if not company or not can_manage_users(current_user, company.id):
                 return jsonify({'success': False, 'error': 'Permission denied.'}), 403
 
         target = db.session.get(User, user_id)
@@ -6227,16 +6241,18 @@ def update_user_access(user_id):
 
         payload = request.get_json() or {}
 
-        acc = UserCompanyAccess.query.filter_by(user_id=target.id).first()
+        if not company:
+            return jsonify({'success': False, 'error': 'No company context.'}), 400
+        acc = UserCompanyAccess.query.filter_by(user_id=target.id, company_id=company.id).first()
         if not acc:
-            company = current_user.get_default_company()
-            if not company:
-                return jsonify({'success': False, 'error': 'No company context.'}), 400
+            if not current_user.is_admin:
+                return jsonify({'success': False, 'error': 'Target user is not in this tenant.'}), 403
             acc = UserCompanyAccess(user_id=target.id, company_id=company.id, role='viewer')
             db.session.add(acc)
 
         if 'role' in payload:
             new_role = payload['role']
+            new_role = UserCompanyAccess.normalize_role(new_role)
             valid_roles = ('owner', 'admin', 'manager', 'editor', 'viewer', 'staff', 'inbox_only')
             if new_role not in valid_roles:
                 return jsonify({'success': False, 'error': f'Invalid role. Choose from: {", ".join(valid_roles)}'}), 400
@@ -6245,6 +6261,8 @@ def update_user_access(user_id):
             acc.can_access_mobile_inbox = bool(payload['can_access_mobile_inbox'])
         if 'can_access_full_app' in payload:
             acc.can_access_full_app = bool(payload['can_access_full_app'])
+        if 'manage_users_enabled' in payload:
+            acc.manage_users_enabled = bool(payload['manage_users_enabled'])
 
         db.session.commit()
         return jsonify({
@@ -6253,6 +6271,7 @@ def update_user_access(user_id):
             'role': acc.role,
             'can_access_mobile_inbox': acc.can_access_mobile_inbox,
             'can_access_full_app': acc.can_access_full_app,
+            'manage_users_enabled': acc.manage_users_enabled,
             'has_mobile_inbox_access': acc.has_mobile_inbox_access(),
             'has_full_app_access': acc.has_full_app_access(),
         })
@@ -10912,15 +10931,17 @@ def sms_campaigns():
                 query = query.filter_by(company_id=company_id)
             campaigns_list = query.order_by(SMSCampaign.created_at.desc()).all()
             try:
-                from models import TwilioAccount
+                from models import TwilioAccount, TwilioPhoneNumber
                 ta = TwilioAccount.query.filter_by(company_id=company_id).first() if company_id else None
                 twilio_configured = bool(ta and ta.is_configured)
+                phone_numbers = TwilioPhoneNumber.query.filter_by(company_id=company_id, is_active=True, sms_enabled=True).all() if company_id else []
             except Exception:
                 twilio_configured = False
     except Exception:
         logger.exception("SMS campaigns page failed")
         campaigns_list = []
-    return render_template('sms_campaigns.html', campaigns=campaigns_list, sms_enabled=True, twilio_configured=twilio_configured, scheduled_count=sum(1 for c in campaigns_list if c.status == 'scheduled'))
+        phone_numbers = []
+    return render_template('sms_campaigns.html', campaigns=campaigns_list, sms_enabled=True, twilio_configured=twilio_configured, phone_numbers=locals().get('phone_numbers', []), scheduled_count=sum(1 for c in campaigns_list if c.status == 'scheduled'))
 
 
 @main_bp.route('/sms/campaign/<int:campaign_id>/send', methods=['POST'])
@@ -10933,6 +10954,18 @@ def send_sms_campaign(campaign_id):
             if not campaign:
                 flash('SMS Campaign not found.', 'danger')
                 return redirect(url_for('main.sms_campaigns'))
+            sender_number_id = request.form.get('from_phone_number_id', type=int)
+            if sender_number_id:
+                from models import TwilioPhoneNumber
+                from services.comms_permissions import accessible_phone_numbers
+                pn = TwilioPhoneNumber.query.filter_by(id=sender_number_id, company_id=company_id, sms_enabled=True, is_active=True).first()
+                allowed = accessible_phone_numbers(current_user, company_id)
+                if not pn or pn.phone_number not in allowed:
+                    flash('You do not have permission to send campaigns from that number.', 'danger')
+                    return redirect(url_for('main.sms_campaigns')), 403
+                campaign.from_phone_number_id = pn.id
+                campaign.from_phone_number = pn.phone_number
+                db.session.commit()
             recipient_count = SMSRecipient.query.filter_by(campaign_id=campaign_id, status='pending').count()
             if recipient_count > SMSService.ASYNC_RECIPIENT_THRESHOLD:
                 result = SMSService.queue_campaign_send(campaign_id, app=current_app._get_current_object()) if SMSService else {'success': False, 'error': 'SMS service unavailable'}

--- a/services/comms_permissions.py
+++ b/services/comms_permissions.py
@@ -1,0 +1,115 @@
+"""Communications/phone-number permission helpers.
+
+These helpers are intentionally additive: owners/admins keep existing access,
+while explicit per-number grants narrow standard-user PWA history to the lines
+assigned to them.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from extensions import db
+
+
+def normalize_role(role: str | None) -> str:
+    value = (role or "viewer").strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "superadmin": "owner",
+        "super_admin": "owner",
+        "super": "owner",
+        "administrator": "admin",
+        "tenant_admin": "admin",
+        "company_admin": "admin",
+        "supervisor": "manager",
+        "member": "staff",
+        "user": "viewer",
+        "inboxonly": "inbox_only",
+        "inbox_only_user": "inbox_only",
+    }
+    return aliases.get(value, value)
+
+
+def user_access_for_company(user, company_id: int):
+    from models import UserCompanyAccess
+    if not user or not company_id:
+        return None
+    return UserCompanyAccess.query.filter_by(user_id=user.id, company_id=company_id).first()
+
+
+def can_manage_users(user, company_id: int) -> bool:
+    if not user or not company_id:
+        return False
+    if getattr(user, "is_admin", False):
+        return True
+    acc = user_access_for_company(user, company_id)
+    return bool(acc and acc.can_manage_users())
+
+
+def accessible_phone_numbers(user, company_id: int) -> list[str]:
+    """Return E.164/business numbers a user may access, or all tenant numbers.
+
+    Backward compatibility rule: users with no explicit per-number grants and no
+    legacy assigned_number keep company-wide access if their role grants PWA/hub
+    access. Once explicit grants or assigned_number are present, history is
+    filtered to those numbers.
+    """
+    from models import PhoneNumberUserPermission, TwilioAccount, TwilioPhoneNumber
+
+    if not user or not company_id:
+        return []
+    acc = user_access_for_company(user, company_id)
+    role = normalize_role(getattr(acc, "role", None)) if acc else "viewer"
+
+    all_numbers = [
+        pn.phone_number for pn in TwilioPhoneNumber.query.filter_by(company_id=company_id, is_active=True).all()
+        if pn.phone_number
+    ]
+    for ta in TwilioAccount.query.filter_by(company_id=company_id).all():
+        if ta.from_phone and ta.from_phone not in all_numbers:
+            all_numbers.append(ta.from_phone)
+
+    if getattr(user, "is_admin", False) or role in {"owner", "admin"}:
+        return all_numbers
+
+    explicit = [
+        p.phone_number.phone_number for p in PhoneNumberUserPermission.query
+        .join(TwilioPhoneNumber, PhoneNumberUserPermission.phone_number_id == TwilioPhoneNumber.id)
+        .filter(
+            PhoneNumberUserPermission.company_id == company_id,
+            PhoneNumberUserPermission.user_id == user.id,
+            PhoneNumberUserPermission.can_access_pwa.is_(True),
+            TwilioPhoneNumber.is_active.is_(True),
+        ).all()
+        if p.phone_number and p.phone_number.phone_number
+    ]
+    if explicit:
+        return list(dict.fromkeys(explicit))
+
+    assigned = getattr(acc, "assigned_number", None) if acc else None
+    if assigned:
+        return [assigned]
+
+    if acc and (acc.has_mobile_inbox_access() or acc.has_comms_hub_access()):
+        return all_numbers
+    return []
+
+
+def filter_conversations_for_user(query, user, company_id: int):
+    from models import TwilioConversation
+    numbers = accessible_phone_numbers(user, company_id)
+    if not numbers:
+        return query.filter(db.text("1=0"))
+    return query.filter(TwilioConversation.to_number.in_(numbers))
+
+
+def filter_calls_for_user(query, user, company_id: int):
+    from models import TwilioCallLog
+    acc = user_access_for_company(user, company_id)
+    role = normalize_role(getattr(acc, "role", None)) if acc else "viewer"
+    if getattr(user, "is_admin", False) or role in {"owner", "admin"}:
+        return query
+    numbers = accessible_phone_numbers(user, company_id)
+    if not numbers:
+        return query.filter(db.text("1=0"))
+    return query.filter(db.or_(TwilioCallLog.to_number.in_(numbers), TwilioCallLog.from_number.in_(numbers)))

--- a/services/google_contacts.py
+++ b/services/google_contacts.py
@@ -330,6 +330,12 @@ def sync_contacts(user_id: int, company_id: int) -> dict:
             db.session.rollback()
         return {"synced": 0, "matched": 0, "error": err_msg}
 
+    # Populate the local Contact cache for every Google phone number, not only
+    # numbers that already have an SMS conversation. This makes PWA contact
+    # search and future inbound-SMS name resolution work immediately after sync.
+    for norm, name in phone_map.items():
+        _upsert_contact_from_google(db, company_id, norm, name, None)
+
     convs   = TwilioConversation.query.filter_by(company_id=company_id).all()
     matched = 0
 
@@ -342,12 +348,11 @@ def sync_contacts(user_id: int, company_id: int) -> dict:
             conv.id, conv.from_number, norm, name
         )
 
-        if name and conv.contact_name != name:
+        if name:
+            if conv.contact_name != name:
+                matched += 1
             conv.contact_name   = name
             conv.contact_source = "google"
-            matched += 1
-
-            # Upsert Contact table so future inbound convs link by name
             _upsert_contact_from_google(db, company_id, norm, name, conv)
 
     tok.last_sync_at    = datetime.utcnow()
@@ -384,13 +389,16 @@ def _upsert_contact_from_google(db, company_id: int, norm_phone: str,
         if not contact.first_name and not contact.last_name:
             contact.first_name = first_name
             contact.last_name  = last_name
-            contact.source     = contact.source or "google_contacts"
+        contact.name       = contact.name or name
+        contact.source     = contact.source or "google_contacts"
+        contact.is_active  = True
     else:
         contact = Contact(
             company_id = company_id,
             phone      = norm_phone,
             first_name = first_name,
             last_name  = last_name,
+            name       = name,
             source     = "google_contacts",
             is_active  = True,
             is_subscribed = False,

--- a/templates/base.html
+++ b/templates/base.html
@@ -546,16 +546,8 @@
                     <a href="{{ url_for('twilio.comms_hub') }}" class="sidebar-nav-item{% if _p.startswith('/twilio/comms') or _p.startswith('/twilio/inbox') or _p.startswith('/twilio/conversation') or _p.startswith('/app/inbox') %} active{% endif %}">
                         <i data-feather="phone-call"></i> Communications Hub
                     </a>
-                    {% if current_user.is_authenticated and (current_user.is_admin or current_user.is_platform_admin) %}
-                    <a href="{{ url_for('admin_communications.communications_admin') }}" class="sidebar-nav-item{% if _p.startswith('/admin/communications') %} active{% endif %}">
-                        <i data-feather="settings"></i> SMS &amp; Calls Admin
-                    </a>
-                    {% endif %}
-                    {% if current_user.is_authenticated and (current_user.is_admin or current_user.is_platform_admin) %}
-                    <a href="{{ url_for('twilio.number_management') }}" class="sidebar-nav-item{% if _p.startswith('/twilio/numbers') %} active{% endif %}">
-                        <i data-feather="hash"></i> Phone Numbers
-                    </a>
-                    {% endif %}
+                    {# Communications configuration is consolidated under Communications Hub.
+                       Legacy deep-link pages remain routed, but are hidden here to avoid duplicate menu items. #}
                     <a href="{{ url_for('main.social_media') }}" class="sidebar-nav-item{% if _p.startswith('/social') %} active{% endif %}">
                         <i data-feather="share-2"></i> Social
                     </a>

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -29,6 +29,10 @@
       --safe-top: env(safe-area-inset-top, 0px);
       --safe-bot: env(safe-area-inset-bottom, 0px);
     }
+    html[data-palette="ocean"] { --purple:#0891b2; --purple-l:#67e8f9; --cyan:#38bdf8; --pink:#22d3ee; }
+    html[data-palette="forest"] { --purple:#16a34a; --purple-l:#86efac; --cyan:#34d399; --pink:#84cc16; }
+    html[data-palette="sunset"] { --purple:#ea580c; --purple-l:#fdba74; --cyan:#f59e0b; --pink:#f43f5e; }
+    html[data-palette="mono"] { --purple:#64748b; --purple-l:#cbd5e1; --cyan:#94a3b8; --pink:#e2e8f0; }
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     html, body { height: 100%; background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; overflow: hidden; }
 
@@ -193,7 +197,7 @@
       display: inline-block;
       max-width: min(72vw, 420px); padding: 9px 14px; border-radius: 16px;
       font-size: .88rem; line-height: 1.45; word-break: normal;
-      overflow-wrap: break-word; white-space: pre-wrap;
+      overflow-wrap: normal; white-space: pre-wrap; min-width: 2.5rem;
     }
     .bubble.out { background: var(--purple); color: #fff; border-bottom-right-radius: 4px; }
     .bubble.in  { background: #1e2535; color: var(--text); border-bottom-left-radius: 4px; }
@@ -598,6 +602,7 @@
     <div class="sidebar-head">
       <h1>Messages</h1>
       <span class="badge-unread" id="unreadBadge">0</span>
+      <select id="numberSelector" title="Assigned number" onchange="onNumberSelect(this.value)" style="display:none;background:#111827;border:1px solid var(--border);color:var(--text);border-radius:8px;padding:4px 6px;font-size:.72rem;max-width:118px;"></select>
       <div class="live-dot" id="liveDot" title="Connecting..."></div>
       <div class="pwa-head-actions">
         <button class="pwa-head-icon" onclick="openDialPad()" title="Dial Pad">
@@ -842,6 +847,18 @@
       <div id="gcErrorBanner" style="display:none;width:100%;padding:6px 8px;border-radius:6px;background:rgba(239,68,68,.1);border:1px solid rgba(239,68,68,.25);color:#f87171;font-size:.75rem;"></div>
     </div>
 
+
+    <div class="settings-section-label" style="margin-top:20px;">Appearance</div>
+    <div class="settings-toggle-row" style="flex-direction:column;align-items:flex-start;gap:8px;">
+      <div class="settings-toggle-label"><div><span>Color Palette</span><small>Choose a phone-app theme for this device</small></div></div>
+      <div style="display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;width:100%;">
+        <button class="btn-small" onclick="setPalette('lux')">LUX Purple</button>
+        <button class="btn-small" onclick="setPalette('ocean')">Ocean</button>
+        <button class="btn-small" onclick="setPalette('forest')">Forest</button>
+        <button class="btn-small" onclick="setPalette('sunset')">Sunset</button>
+      </div>
+    </div>
+
     <!-- App -->
     <div class="settings-section-label" style="margin-top:20px;">App</div>
     <button class="settings-action-btn" onclick="refreshApp()">
@@ -879,7 +896,10 @@
     <div class="dial-handle"></div>
 
     <div class="dial-display-row">
-      <div class="dial-display empty" id="dialDisplay">Enter number</div>
+      <div style="flex:1;min-width:0;">
+        <div class="dial-display empty" id="dialDisplay">Enter number</div>
+        <div id="dialMatch" style="text-align:center;color:var(--cyan);font-size:.8rem;margin-top:4px;min-height:18px;"></div>
+      </div>
       <button class="dial-back" id="dialBack" onclick="dialBackspace()" style="display:none;">⌫</button>
     </div>
 
@@ -969,11 +989,69 @@
    LUXit Inbox PWA — Real-time SSE + full feature set
 ═══════════════════════════════════════════════════════════════ */
 const CSRF        = '{{ csrf_token() }}';
+const SERVER_PALETTE = {{ (user.pwa_palette_id or "lux")|tojson }};
+function applyPalette(name) {
+  const p = name || 'lux';
+  document.documentElement.dataset.palette = p === 'lux' ? '' : p;
+  localStorage.setItem('luxitPwaPalette', p);
+}
+async function setPalette(name) {
+  const p = name || 'lux';
+  applyPalette(p);
+  try { await apiFetch('/api/pwa/preferences', 'PATCH', { palette_id: p }); } catch (e) { console.warn('Palette preference will retry later', e); }
+}
+applyPalette(SERVER_PALETTE || localStorage.getItem('luxitPwaPalette') || 'lux');
 const VAPID_PUBLIC = document.documentElement.dataset.vapid ?? '';
 const CONV_CACHE_KEY = 'luxitInboxConversations';
 
+
+function pwaDeviceKey() {
+  let key = localStorage.getItem('luxitPwaDeviceKey');
+  if (!key) {
+    key = (window.crypto?.randomUUID ? window.crypto.randomUUID() : 'pwa-' + Date.now() + '-' + Math.random().toString(16).slice(2));
+    localStorage.setItem('luxitPwaDeviceKey', key);
+  }
+  return key;
+}
+function browserLabel() {
+  const ua = navigator.userAgent || '';
+  if (/CriOS|Chrome/i.test(ua)) return 'Chrome';
+  if (/Safari/i.test(ua) && !/Chrome/i.test(ua)) return 'Safari';
+  if (/Firefox/i.test(ua)) return 'Firefox';
+  if (/Edg/i.test(ua)) return 'Edge';
+  return 'Browser';
+}
+function deviceTypeLabel() {
+  const ua = navigator.userAgent || '';
+  if (/iPhone|Android.*Mobile/i.test(ua)) return 'phone';
+  if (/iPad|Tablet/i.test(ua)) return 'tablet';
+  return 'desktop';
+}
+async function registerPwaDevice(kind='register') {
+  const selected = state?.selectedNumber || localStorage.getItem('luxitPwaSelectedNumber') || '';
+  let mic = 'unknown';
+  try { if (navigator.permissions?.query) mic = (await navigator.permissions.query({name:'microphone'})).state; } catch (_) {}
+  const payload = {
+    device_key: pwaDeviceKey(),
+    device_name: localStorage.getItem('luxitPwaDeviceName') || `${browserLabel()} ${deviceTypeLabel()}`,
+    browser: browserLabel(),
+    device_type: deviceTypeLabel(),
+    selected_number: selected,
+    push_enabled: ('Notification' in window) && Notification.permission === 'granted',
+    microphone_permission: mic,
+    pwa_installed: window.matchMedia?.('(display-mode: standalone)').matches || window.navigator.standalone === true,
+    default_calling_method: localStorage.getItem('luxitDefaultCallingMethod') || 'browser'
+  };
+  const path = kind === 'heartbeat' ? '/api/pwa/devices/heartbeat' : '/api/pwa/devices/register';
+  try {
+    const data = await apiFetch(path, 'POST', payload);
+    if (data?.preferences?.palette_id) applyPalette(data.preferences.palette_id);
+  } catch (e) { console.warn('PWA device telemetry unavailable', e); }
+}
+
 let state = {
   filter:        'all',
+  selectedNumber: localStorage.getItem('luxitPwaSelectedNumber') || '',
   search:        '',
   activeConvId:  null,
   conversations: [],
@@ -991,8 +1069,11 @@ let state = {
 /* ── Init ─────────────────────────────────────────────────────── */
 window.addEventListener('DOMContentLoaded', () => {
   updateSoundBtn();
+  loadAssignedNumbers();
   loadConversations();
   loadBadgeCounts();
+  registerPwaDevice('register');
+  setInterval(() => registerPwaDevice('heartbeat'), 60000);
   connectSSE();
   registerSW();
   checkNotifPrompt();
@@ -1203,9 +1284,27 @@ async function apiFetch(url, method = 'GET', body = null) {
 }
 
 /* ── Conversation list ────────────────────────────────────────── */
+async function loadAssignedNumbers() {
+  try {
+    const data = await apiFetch('/api/phone/numbers');
+    const sel = document.getElementById('numberSelector');
+    const nums = data?.numbers || [];
+    if (!sel || nums.length <= 1) { if (sel) sel.style.display = 'none'; return; }
+    sel.innerHTML = '<option value="">All lines</option>' + nums.map(n => `<option value="${esc(n.phone_number)}">${esc(n.friendly_name || n.phone_number)}</option>`).join('');
+    sel.value = state.selectedNumber || '';
+    sel.style.display = '';
+  } catch (e) { console.warn('[PWA] number load failed', e); }
+}
+function onNumberSelect(value) {
+  state.selectedNumber = value || '';
+  localStorage.setItem('luxitPwaSelectedNumber', state.selectedNumber);
+  loadConversations();
+}
+
 async function loadConversations() {
-  const qs   = `?filter=${state.filter}&q=${encodeURIComponent(state.search)}`;
-  const data = await apiFetch('/api/inbox/conversations' + qs);
+  const params = new URLSearchParams({ filter: state.filter, q: state.search || '' });
+  if (state.selectedNumber) params.set('number', state.selectedNumber);
+  const data = await apiFetch('/api/inbox/conversations?' + params.toString());
   if (!data || data.error || data.success === false || !Array.isArray(data.conversations)) {
     const cached = loadCachedConversations();
     if (state.conversations.length) {
@@ -1909,7 +2008,7 @@ function formatTime(iso) {
 }
 
 function normalizeSmsBody(str) {
-  let text = String(str || '').replace(/\r\n/g, '\n');
+  let text = String(str || '').replace(/\r\n/g, '\n').replace(/[\u200B-\u200D\uFEFF]/g, '');
   const lines = text.split('\n');
   const nonEmpty = lines.filter(line => line.trim().length);
   // Some provider/webhook payloads arrive with one visible character per line.
@@ -1935,7 +2034,7 @@ document.querySelectorAll('.pwa-modal-overlay').forEach(el => {
 });
 
 /* ── Dial Pad ─────────────────────────────────────────────────── */
-let dialState = { number: '', isCalling: false };
+let dialState = { number: '', isCalling: false, lookupTimer: null };
 
 function openDialPad() {
   dialState.number = '';
@@ -1977,6 +2076,19 @@ function _dialRefresh() {
   // Enable call button when we have ≥7 digits
   const digits = n.replace(/\D/g, '');
   callBtn.disabled = digits.length < 7 || dialState.isCalling;
+  clearTimeout(dialState.lookupTimer);
+  dialState.lookupTimer = setTimeout(dialLookup, 250);
+}
+
+async function dialLookup() {
+  const match = document.getElementById('dialMatch');
+  const q = (dialState.number || '').replace(/[^\d+]/g, '');
+  if (!match || q.replace(/\D/g,'').length < 3) { if (match) match.textContent = ''; return; }
+  try {
+    const data = await apiFetch('/api/inbox/contacts/search?q=' + encodeURIComponent(q));
+    const hit = (data?.contacts || [])[0];
+    match.textContent = hit ? `${hit.name}${hit.company ? ' · ' + hit.company : ''} · ${hit.phone}` : 'New number — call or SMS';
+  } catch (e) { match.textContent = ''; }
 }
 
 function _dialFormat(n) {

--- a/templates/sms_campaigns.html
+++ b/templates/sms_campaigns.html
@@ -144,13 +144,19 @@
                                 {{ campaign.status }}
                             </span>
                         </td>
+                        <td><small>{{ campaign.from_phone_number or 'Default number' }}</small></td>
                         <td>{{ campaign.sent_at.strftime('%Y-%m-%d %H:%M') if campaign.sent_at else '-' }}</td>
                         <td>{{ campaign.created_at.strftime('%Y-%m-%d') }}</td>
                         <td>
                             <div class="btn-group btn-group-sm">
                                 {% if campaign.status == 'draft' %}
-                                <form method="POST" action="{{ url_for('main.send_sms_campaign', campaign_id=campaign.id) }}" style="display: inline;">
+                                <form method="POST" action="{{ url_for('main.send_sms_campaign', campaign_id=campaign.id) }}" class="d-inline-flex gap-1 align-items-center">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                                    {% if phone_numbers %}
+                                    <select name="from_phone_number_id" class="form-select form-select-sm" title="Sending number" style="width:150px;background:#0b0d14;border-color:#1e2535;color:#fff;">
+                                        {% for pn in phone_numbers %}<option value="{{ pn.id }}" {% if campaign.from_phone_number_id == pn.id %}selected{% endif %}>{{ pn.friendly_name or pn.phone_number }}</option>{% endfor %}
+                                    </select>
+                                    {% endif %}
                                     <button type="submit" class="btn btn-sm btn-success" onclick="return confirm('Send this SMS campaign to {{ campaign.recipients.count() }} recipients?')" title="Send">
                                         <i data-feather="send" style="width:14px;height:14px;"></i>
                                     </button>

--- a/templates/twilio/comms_hub.html
+++ b/templates/twilio/comms_hub.html
@@ -33,33 +33,130 @@
     </div>
   </div>
 
-  <!-- Tab bar -->
-  <div style="border-bottom:2px solid #1e2535;margin-bottom:1.25rem;display:flex;gap:2px;overflow-x:auto;white-space:nowrap;">
+  <!-- Productized Communications Hub tabs -->
+  <div class="comms-tabs" style="border-bottom:2px solid #1e2535;margin-bottom:1.25rem;display:flex;gap:2px;overflow-x:auto;white-space:nowrap;">
     {% for t_id, t_icon, t_label, t_badge in [
-      ('inbox',    'message-square', 'Inbox',       unread_count),
-      ('calls',    'phone',          'Calls',        missed_calls_count),
-      ('voicemail','mic',            'Voicemail',    0),
-      ('contacts', 'users',          'Contacts',     0),
-      ('team',     'message-circle', 'Team Chat',    0),
-      ('notes',    'file-text',      'Notes',        0),
-      ('ai',       'cpu',            'AI Assistant', 0),
+      ('overview', 'grid', 'Overview', 0),
+      ('numbers', 'hash', 'Numbers', 0),
+      ('settings', 'sliders', 'Number Settings', 0),
+      ('users', 'user-check', 'Users & Permissions', 0),
+      ('hours', 'clock', 'Business Hours', 0),
+      ('auto', 'message-circle', 'Auto Replies', 0),
+      ('routing', 'phone-forwarded', 'Call Routing / Forwarding', 0),
+      ('voicemail','mic', 'Voicemail', 0),
+      ('pwa', 'smartphone', 'PWA Phone App', 0),
+      ('devices', 'monitor', 'Devices', 0),
+      ('calls', 'phone', 'Call Logs', missed_calls_count),
+      ('inbox', 'message-square', 'SMS Conversations', unread_count),
+      ('integrations', 'link', 'Integrations', 0),
+      ('reports', 'bar-chart-2', 'Reports / Activity', 0),
     ] %}
-    <a href="?tab={{ t_id }}"
+    <a href="?tab={{ t_id }}{% if selected_number %}&number_id={{ selected_number.id }}{% endif %}"
        style="display:inline-flex;align-items:center;gap:5px;padding:.55rem .85rem;font-size:.84rem;
               color:{% if tab == t_id %}#7c3aed{% else %}#9ca3af{% endif %};
               border-bottom:2px solid {% if tab == t_id %}#7c3aed{% else %}transparent{% endif %};
               margin-bottom:-2px;text-decoration:none;transition:color .15s;flex-shrink:0;">
       <i data-feather="{{ t_icon }}" style="width:13px;height:13px;flex-shrink:0;"></i>
       {{ t_label }}
-      {% if t_badge > 0 %}
-      <span class="badge ms-1" style="background:#7c3aed;font-size:.6rem;padding:2px 5px;">{{ t_badge }}</span>
-      {% endif %}
+      {% if t_badge > 0 %}<span class="badge ms-1" style="background:#7c3aed;font-size:.6rem;padding:2px 5px;">{{ t_badge }}</span>{% endif %}
     </a>
     {% endfor %}
   </div>
 
+  {% if phone_numbers %}
+  <div class="d-flex align-items-center gap-2 mb-3 flex-wrap">
+    <small class="text-muted">Editing line:</small>
+    {% for pn in phone_numbers %}
+      <a class="btn btn-sm {% if selected_number and selected_number.id == pn.id %}btn-primary{% else %}btn-outline-secondary{% endif %}" href="?tab={{ tab }}&number_id={{ pn.id }}">{{ pn.friendly_name or pn.phone_number }}</a>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% macro toggle(name, checked, label) -%}
+  <label class="form-check form-switch mb-2">
+    <input class="form-check-input" type="checkbox" name="{{ name }}" value="1" {% if checked %}checked{% endif %}>
+    <span class="form-check-label">{{ label }}</span>
+  </label>
+  {%- endmacro %}
+
+  {% macro number_settings_form(active_section) -%}
+  {% if selected_number %}
+  <form method="POST" action="{{ url_for('twilio.number_edit', number_id=selected_number.id) }}" class="card p-3" style="background:#0f1117;border:1px solid #1e2535;">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <input type="hidden" name="return_to" value="comms">
+    <div class="row g-3">
+      <div class="col-md-4"><label class="form-label small text-muted">Display name / Caller ID</label><input class="form-control" name="caller_id_display_name" value="{{ selected_number.caller_id_display_name or '' }}" style="background:#0b0d14;border-color:#1e2535;color:#fff;"></div>
+      <div class="col-md-4"><label class="form-label small text-muted">Friendly name</label><input class="form-control" name="friendly_name" value="{{ selected_number.friendly_name or '' }}" style="background:#0b0d14;border-color:#1e2535;color:#fff;"></div>
+      <div class="col-md-4"><label class="form-label small text-muted">Timezone</label><input class="form-control" name="timezone" value="{{ selected_number.timezone or 'America/Los_Angeles' }}" style="background:#0b0d14;border-color:#1e2535;color:#fff;"></div>
+      <div class="col-md-6"><label class="form-label small text-muted">During-hours route</label><select class="form-select" name="during_hours_route" style="background:#0b0d14;border-color:#1e2535;color:#fff;">{% for v in ['ring_pwa','forward','voicemail','message_then_route'] %}<option value="{{ v }}" {% if selected_number.during_hours_route == v %}selected{% endif %}>{{ v.replace('_',' ')|title }}</option>{% endfor %}</select></div>
+      <div class="col-md-6"><label class="form-label small text-muted">After-hours route</label><select class="form-select" name="after_hours_route" style="background:#0b0d14;border-color:#1e2535;color:#fff;">{% for v in ['voicemail','forward','ring_pwa','message_then_route'] %}<option value="{{ v }}" {% if selected_number.after_hours_route == v %}selected{% endif %}>{{ v.replace('_',' ')|title }}</option>{% endfor %}</select></div>
+      <div class="col-md-6"><label class="form-label small text-muted">SMS forward to</label><input class="form-control" name="sms_forward_to" value="{{ selected_number.sms_forward_to or '' }}" style="background:#0b0d14;border-color:#1e2535;color:#fff;"></div>
+      <div class="col-md-6"><label class="form-label small text-muted">Call forward to</label><input class="form-control" name="call_forward_to" value="{{ selected_number.call_forward_to or '' }}" style="background:#0b0d14;border-color:#1e2535;color:#fff;"></div>
+      <div class="col-md-6"><label class="form-label small text-muted">Voicemail greeting</label><textarea class="form-control" name="voicemail_greeting_text" rows="3" style="background:#0b0d14;border-color:#1e2535;color:#fff;">{{ selected_number.voicemail_greeting_text or '' }}</textarea></div>
+      <div class="col-md-6"><label class="form-label small text-muted">After-hours SMS text</label><textarea class="form-control" name="after_hours_text" rows="3" style="background:#0b0d14;border-color:#1e2535;color:#fff;">{{ selected_number.after_hours_text or '' }}</textarea></div>
+      <div class="col-12"><div class="row g-2">{% for i,label in [(0,'Mon'),(1,'Tue'),(2,'Wed'),(3,'Thu'),(4,'Fri'),(5,'Sat'),(6,'Sun')] %}{% set cfg=(selected_number.business_hours or {}).get(i|string,{}) %}<div class="col-md-6 col-lg-4"><div class="p-2 rounded" style="background:#0b0d14;border:1px solid #1e2535;"><label class="form-check"><input class="form-check-input" type="checkbox" name="bh_{{ i }}_open" value="1" {% if cfg.get('is_open', i < 5) %}checked{% endif %}> {{ label }} open</label><div class="d-flex gap-2"><input type="time" class="form-control form-control-sm" name="bh_{{ i }}_start" value="{{ cfg.get('open','09:00') }}"><input type="time" class="form-control form-control-sm" name="bh_{{ i }}_end" value="{{ cfg.get('close','17:00') }}"></div></div></div>{% endfor %}</div></div>
+      <div class="col-md-4">{{ toggle('browser_calling_enabled', selected_number.browser_calling_enabled, 'Browser/WiFi calling') }}</div>
+      <div class="col-md-4">{{ toggle('cell_callback_enabled', selected_number.cell_callback_enabled, 'Cell callback calling') }}</div>
+      <div class="col-md-4">{{ toggle('mobile_data_allowed', selected_number.mobile_data_allowed, 'Allow mobile data') }}</div>
+      <div class="col-md-4">{{ toggle('wifi_only', selected_number.wifi_only, 'WiFi only') }}</div>
+      <div class="col-md-4">{{ toggle('sms_forwarding_enabled', selected_number.sms_forwarding_enabled, 'SMS forwarding') }}</div>
+      <div class="col-md-4">{{ toggle('voice_forwarding_enabled', selected_number.voice_forwarding_enabled, 'Voice forwarding') }}</div>
+      <div class="col-md-4">{{ toggle('auto_reply_enabled', selected_number.auto_reply_enabled, 'Auto replies') }}</div>
+      <div class="col-md-4">{{ toggle('after_hours_sms_enabled', selected_number.after_hours_sms_enabled, 'After-hours SMS') }}</div>
+      <div class="col-md-4">{{ toggle('after_hours_voicemail_enabled', selected_number.after_hours_voicemail_enabled, 'After-hours voicemail') }}</div>
+      <div class="col-md-4"><label class="form-label small text-muted">Fallback behavior</label><select class="form-select" name="fallback_behavior"><option value="cell_callback" {% if selected_number.fallback_behavior == 'cell_callback' %}selected{% endif %}>Cell callback</option><option value="voicemail" {% if selected_number.fallback_behavior == 'voicemail' %}selected{% endif %}>Voicemail</option><option value="none" {% if selected_number.fallback_behavior == 'none' %}selected{% endif %}>None</option></select></div>
+    </div>
+    <button class="btn btn-primary mt-3" type="submit">Save {{ active_section }} Settings</button>
+  </form>
+  {% else %}<div class="alert alert-warning">Add a phone number to configure this tab.</div>{% endif %}
+  {%- endmacro %}
+
+  <!-- ═══════════ OVERVIEW / CONFIG TABS ═══════════ -->
+  {% if tab == 'overview' %}
+  <div class="row g-3">
+    <div class="col-md-3"><div class="card p-3" style="background:#0f1117;border:1px solid #1e2535;"><small class="text-muted">Phone numbers</small><h3>{{ phone_numbers|length }}</h3></div></div>
+    <div class="col-md-3"><div class="card p-3" style="background:#0f1117;border:1px solid #1e2535;"><small class="text-muted">Unread SMS</small><h3>{{ unread_count }}</h3></div></div>
+    <div class="col-md-3"><div class="card p-3" style="background:#0f1117;border:1px solid #1e2535;"><small class="text-muted">Recent calls</small><h3>{{ calls|length }}</h3></div></div>
+    <div class="col-md-3"><div class="card p-3" style="background:#0f1117;border:1px solid #1e2535;"><small class="text-muted">Voicemails</small><h3>{{ voicemails|length }}</h3></div></div>
+  </div>
+  <div class="alert mt-3" style="background:#0f1117;border:1px solid #1e2535;color:#cbd5e1;">Use the tabs above to configure each line independently. Legacy settings pages remain available as deep links but this hub is the primary admin workflow.</div>
+
+  {% elif tab == 'numbers' %}
+  <div class="card" style="background:#0f1117;border:1px solid #1e2535;">
+    {% for pn in phone_numbers %}<div class="p-3 d-flex flex-wrap gap-2 align-items-center" style="border-bottom:1px solid #1e2535;"><strong>{{ pn.friendly_name or pn.phone_number }}</strong><code>{{ pn.phone_number }}</code><span class="badge bg-dark">{{ pn.number_type }}</span><span class="badge {% if pn.sms_enabled %}bg-success{% else %}bg-secondary{% endif %}">SMS</span><span class="badge {% if pn.voice_enabled %}bg-success{% else %}bg-secondary{% endif %}">Voice</span><a class="btn btn-sm btn-outline-secondary ms-auto" href="?tab=settings&number_id={{ pn.id }}">Configure</a></div>{% else %}<div class="p-4 text-muted">No phone numbers found. Use the legacy add flow to seed Twilio numbers.</div>{% endfor %}
+  </div>
+
+  {% elif tab in ['settings','hours','routing'] %}
+  <h6 class="fw-semibold mb-2">{{ tab|title if tab != 'routing' else 'Call Routing / Forwarding' }}</h6>
+  {{ number_settings_form(tab|title) }}
+
+  {% elif tab == 'auto' %}
+  <div class="d-flex mb-3"><h6 class="fw-semibold">Auto Replies</h6><a href="{{ url_for('twilio.rules') }}" class="btn btn-sm btn-outline-secondary ms-auto">Full rule editor</a></div>
+  <div class="card" style="background:#0f1117;border:1px solid #1e2535;">{% for rule in rules %}<div class="p-3" style="border-bottom:1px solid #1e2535;"><strong>{{ rule.name }}</strong><span class="badge bg-dark ms-2">{{ rule.trigger_type }}</span><div class="text-muted small">{{ (rule.response or '')[:140] }}</div></div>{% else %}<div class="p-4 text-muted">No auto-reply rules yet.</div>{% endfor %}</div>
+
+  {% elif tab == 'users' %}
+  <div class="d-flex mb-3"><h6 class="fw-semibold">Users & Permissions{% if selected_number %} — {{ selected_number.friendly_name or selected_number.phone_number }}{% endif %}</h6><a href="{{ url_for('main.manage_users') }}" class="btn btn-sm btn-outline-secondary ms-auto">Manage users</a></div>
+  {% if selected_number %}<div class="card" style="background:#0f1117;border:1px solid #1e2535;">{% for row in users_with_access %}<form method="POST" action="{{ url_for('twilio.comms_number_permissions', number_id=selected_number.id) }}" class="p-3" style="border-bottom:1px solid #1e2535;"><input type="hidden" name="csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="user_id" value="{{ row.user.id }}"><div class="d-flex flex-wrap gap-2 align-items-center"><strong>{{ row.user.email or row.user.username }}</strong><span class="badge bg-dark">{{ row.access.role }}</span>{% for f,l in [('can_access_pwa','PWA'),('can_view_sms','View SMS'),('can_send_sms','Send SMS'),('can_view_calls','Calls'),('can_call','Dial'),('can_view_voicemail','Voicemail'),('can_send_campaigns','Campaigns'),('can_manage_number','Manage')] %}<label class="form-check form-check-inline small"><input class="form-check-input" type="checkbox" name="{{ f }}" value="1" {% if row.access.role in ['owner','admin'] or row.access.assigned_number == selected_number.phone_number %}checked{% endif %}> {{ l }}</label>{% endfor %}<button class="btn btn-sm btn-primary ms-auto">Save</button></div></form>{% endfor %}</div>{% endif %}
+
+  {% elif tab == 'voicemail' %}
+  <div class="d-flex mb-3"><h6 class="fw-semibold">Visual Voicemail</h6><a href="?tab=settings{% if selected_number %}&number_id={{ selected_number.id }}{% endif %}" class="btn btn-sm btn-outline-secondary ms-auto">Greeting settings</a></div>
+  <div class="card" style="background:#0f1117;border:1px solid #1e2535;">{% for vm in voicemails %}<div class="p-3" style="border-bottom:1px solid #1e2535;"><div class="d-flex justify-content-between"><strong>{{ vm.from_number or 'Unknown caller' }}</strong><span class="badge {% if vm.is_read %}bg-secondary{% else %}bg-primary{% endif %}">{{ 'Read' if vm.is_read else 'Unread' }}</span></div><div class="small text-muted">{{ vm.created_at.strftime('%b %-d %H:%M') if vm.created_at else '' }} · {{ vm.duration_secs or 0 }}s</div>{% if vm.recording_url %}<audio controls src="{{ vm.recording_url }}" style="width:100%;margin-top:8px;"></audio>{% endif %}<div class="mt-2 small text-muted">Transcription: {{ vm.transcription_status or 'not requested' }}{% if vm.transcription_provider %} via {{ vm.transcription_provider }}{% endif %}{% if vm.transcribed_at %} · {{ vm.transcribed_at.strftime('%b %-d %H:%M') }}{% endif %}</div>{% if vm.transcription_text or vm.transcript %}<div class="mt-2 small">{{ vm.transcription_text or vm.transcript }}</div>{% endif %}{% if vm.transcription_error %}<div class="mt-2 small text-danger">{{ vm.transcription_error }}</div>{% endif %}</div>{% else %}<div class="p-4 text-muted">No voicemail messages yet.</div>{% endfor %}</div>
+
+  {% elif tab == 'pwa' %}
+  <div class="card p-4" style="background:#0f1117;border:1px solid #1e2535;"><h6>PWA Phone App</h6><p class="text-muted">Open this link on the work phone, then use Share → Add to Home Screen. Assigned numbers and permissions are enforced server-side.</p><a class="btn btn-primary" href="/app/inbox" target="_blank">Open PWA Phone App</a><div class="mt-3 small text-muted">Assigned users are managed in Users & Permissions. If QR support is enabled elsewhere, point it at <code>/app/inbox</code>.</div></div>
+
+  {% elif tab == 'devices' %}
+  <div class="d-flex mb-3 flex-wrap gap-2"><h6 class="fw-semibold">PWA / Work-Phone Devices</h6><span class="text-muted small ms-auto">Devices update through /api/pwa/devices/register and /api/pwa/devices/heartbeat.</span></div>
+  <div class="card" style="background:#0f1117;border:1px solid #1e2535;overflow-x:auto;"><table class="table table-dark table-sm align-middle mb-0"><thead><tr><th>Device</th><th>User</th><th>Default line</th><th>Browser/type</th><th>Status</th><th>Push</th><th>Mic</th><th>PWA</th><th>Calling controls</th></tr></thead><tbody>{% for d in devices %}<tr><td>{{ d.device_name or 'PWA Device' }}</td><td>{{ d.user.email if d.user else d.user_id }}</td><td>{{ d.phone_number.friendly_name if d.phone_number and d.phone_number.friendly_name else (d.phone_number.phone_number if d.phone_number else 'Not selected') }}</td><td>{{ d.browser or 'Unknown' }}<div class="small text-muted">{{ d.device_type or '' }}</div></td><td><span class="badge {% if d.online_status == 'online' %}bg-success{% else %}bg-secondary{% endif %}">{{ d.online_status or 'offline' }}</span><div class="small text-muted">{{ d.last_seen_at.strftime('%b %-d %H:%M') if d.last_seen_at else 'Never' }}</div></td><td>{{ 'Enabled' if d.push_enabled else 'Disabled' }}</td><td>{{ d.microphone_permission or 'unknown' }}</td><td>{{ 'Installed' if d.pwa_installed else 'Browser' }}</td><td><div class="small">WiFi-only: {{ 'Yes' if d.wifi_only else 'No' }}</div><div class="small">Cell callback: {{ 'Enabled' if d.cellular_callback_enabled else 'Disabled' }}</div><div class="small">Mobile data: {{ 'Allowed' if d.mobile_data_calling_allowed else 'Blocked' }}</div><div class="small">Default: {{ d.default_calling_method or 'browser' }}</div></td></tr>{% else %}<tr><td colspan="9" class="text-muted p-4">No PWA devices have registered yet. Open the PWA Phone App on a work phone to register device status.</td></tr>{% endfor %}</tbody></table></div>
+
+  {% elif tab == 'integrations' %}
+  <div class="card p-4" style="background:#0f1117;border:1px solid #1e2535;"><h6>Integrations</h6><p class="text-muted">Twilio webhooks, Google Contacts, SMS delivery callbacks, and provider health remain connected here.</p><a href="{{ url_for('twilio.google_contacts_connect') }}" class="btn btn-sm btn-outline-secondary">Google Contacts</a><a href="{{ url_for('twilio.settings') }}" class="btn btn-sm btn-outline-secondary ms-2">Twilio Webhooks</a></div>
+
+  {% elif tab == 'reports' %}
+  <div class="card" style="background:#0f1117;border:1px solid #1e2535;">{% for item in activity %}<div class="p-3" style="border-bottom:1px solid #1e2535;"><strong>{{ item.action }}</strong><div class="small text-muted">{{ item.created_at }}</div></div>{% else %}<div class="p-4 text-muted">No recent communications activity.</div>{% endfor %}</div>
+
   <!-- ═══════════ INBOX TAB ═══════════ -->
-  {% if tab == 'inbox' %}
+  {% elif tab == 'inbox' %}
 
   {% if not ta or not ta.is_configured %}
   <div class="alert alert-warning d-flex align-items-center gap-3">

--- a/tests/test_comms_permissions_architecture.py
+++ b/tests/test_comms_permissions_architecture.py
@@ -1,0 +1,207 @@
+from datetime import datetime, timedelta
+
+import os
+import pytest
+from werkzeug.security import generate_password_hash
+
+from app import create_app
+from extensions import db
+from models import (
+    Company,
+    PhoneNumberUserPermission,
+    TwilioAccount,
+    TwilioCallLog,
+    TwilioConversation,
+    TwilioMessage,
+    TwilioPhoneNumber,
+    SMSCampaign,
+    User,
+    UserCompanyAccess,
+)
+
+
+@pytest.fixture
+def app():
+    os.environ.setdefault("TWILIO_ACCOUNT_SID", "ACtest")
+    a = create_app()
+    a.config.update(TESTING=True, SERVER_NAME="localhost", WTF_CSRF_ENABLED=False)
+    yield a
+
+
+@pytest.fixture
+def client(app):
+    with app.test_client() as c:
+        yield c
+
+
+def login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user_id)
+        sess["_fresh"] = True
+
+
+@pytest.fixture
+def comms_world(app):
+    with app.app_context():
+        co = Company(name="Comms Perm Co", is_active=True)
+        other = Company(name="Other Comms Co", is_active=True)
+        db.session.add_all([co, other])
+        db.session.flush()
+        owner = User(username="perm_owner", email="owner@perms.test", password_hash=generate_password_hash("x"), default_company_id=co.id)
+        admin = User(username="perm_admin", email="info@adiken.com", password_hash=generate_password_hash("x"), default_company_id=co.id)
+        staff = User(username="perm_staff", email="staff@perms.test", password_hash=generate_password_hash("x"), default_company_id=co.id)
+        blocked = User(username="perm_blocked", email="blocked@perms.test", password_hash=generate_password_hash("x"), default_company_id=co.id)
+        outsider = User(username="perm_out", email="out@perms.test", password_hash=generate_password_hash("x"), default_company_id=other.id)
+        db.session.add_all([owner, admin, staff, blocked, outsider])
+        db.session.flush()
+        db.session.add_all([
+            UserCompanyAccess(user_id=owner.id, company_id=co.id, role="owner", is_default=True),
+            UserCompanyAccess(user_id=admin.id, company_id=co.id, role="admin", is_default=True, manage_users_enabled=True),
+            UserCompanyAccess(user_id=staff.id, company_id=co.id, role="staff", is_default=True, pwa_access_enabled=True),
+            UserCompanyAccess(user_id=blocked.id, company_id=co.id, role="viewer", is_default=True),
+            UserCompanyAccess(user_id=outsider.id, company_id=other.id, role="owner", is_default=True),
+            TwilioAccount(company_id=co.id, from_phone="+15550001111", _account_sid="ACtest", _auth_token="auth"),
+        ])
+        pn1 = TwilioPhoneNumber(company_id=co.id, phone_number="+15550001111", friendly_name="Sales", is_active=True, business_hours={str(i): {"is_open": True, "open": "00:00", "close": "23:59"} for i in range(7)})
+        pn2 = TwilioPhoneNumber(company_id=co.id, phone_number="+15550002222", friendly_name="Support", is_active=True, business_hours={str(i): {"is_open": False} for i in range(7)})
+        db.session.add_all([pn1, pn2])
+        db.session.flush()
+        db.session.add(PhoneNumberUserPermission(company_id=co.id, phone_number_id=pn1.id, user_id=staff.id, can_access_pwa=True))
+        c1 = TwilioConversation(company_id=co.id, from_number="+15551230001", to_number=pn1.phone_number, is_read=True, last_message_at=datetime.utcnow(), last_message_preview="read stays")
+        c2 = TwilioConversation(company_id=co.id, from_number="+15551230002", to_number=pn2.phone_number, is_read=False, last_message_at=datetime.utcnow(), last_message_preview="restricted")
+        db.session.add_all([c1, c2])
+        db.session.flush()
+        db.session.add_all([
+            TwilioMessage(conversation_id=c1.id, company_id=co.id, direction="inbound", from_number=c1.from_number, to_number=c1.to_number, body="read stays", status="received"),
+            TwilioMessage(conversation_id=c2.id, company_id=co.id, direction="inbound", from_number=c2.from_number, to_number=c2.to_number, body="restricted", status="received"),
+            TwilioCallLog(company_id=co.id, twilio_sid="CA1", direction="inbound", from_number="+15551230001", to_number=pn1.phone_number, status="completed", duration=12),
+            TwilioCallLog(company_id=co.id, twilio_sid="CA2", direction="inbound", from_number="+15551230002", to_number=pn2.phone_number, status="voicemail", voicemail_url="https://example.test/vm.mp3"),
+        ])
+        db.session.commit()
+        return {"co": co.id, "other": other.id, "owner": owner.id, "admin": admin.id, "staff": staff.id, "blocked": blocked.id, "outsider": outsider.id, "pn1": pn1.id, "pn2": pn2.id, "c1": c1.id, "c2": c2.id}
+
+
+def test_owner_can_edit_all_tenant_users_and_roles(client, comms_world):
+    login(client, comms_world["owner"])
+    resp = client.post(f"/api/user/{comms_world['staff']}/access", json={"role": "supervisor", "manage_users_enabled": True})
+    assert resp.status_code == 200
+    assert resp.json["success"] is True
+    assert resp.json["role"] == "manager"
+    assert resp.json["manage_users_enabled"] is True
+
+
+def test_admin_with_manage_users_can_manage_users(client, comms_world):
+    login(client, comms_world["admin"])
+    resp = client.post(f"/api/user/{comms_world['staff']}/access", json={"can_access_mobile_inbox": True})
+    assert resp.status_code == 200
+    assert resp.json["success"] is True
+
+
+def test_non_authorized_user_denied_and_tenant_isolation(client, comms_world):
+    login(client, comms_world["blocked"])
+    resp = client.post(f"/api/user/{comms_world['staff']}/access", json={"role": "admin"})
+    assert resp.status_code == 403
+
+    login(client, comms_world["owner"])
+    resp = client.post(f"/api/user/{comms_world['outsider']}/access", json={"role": "admin"})
+    assert resp.status_code == 403
+    assert UserCompanyAccess.query.filter_by(user_id=comms_world["outsider"], company_id=comms_world["co"]).first() is None
+    assert UserCompanyAccess.query.filter_by(user_id=comms_world["outsider"], company_id=comms_world["other"], role="owner").first() is not None
+
+
+def test_pwa_history_persists_and_is_scoped_to_assigned_number(client, comms_world):
+    login(client, comms_world["staff"])
+    first = client.get("/api/inbox/conversations").json["conversations"]
+    second = client.get("/api/inbox/conversations").json["conversations"]
+    assert [c["id"] for c in first] == [comms_world["c1"]]
+    assert [c["id"] for c in second] == [comms_world["c1"]]
+
+    detail = client.get(f"/api/inbox/conversations/{comms_world['c1']}")
+    assert detail.status_code == 200
+    assert client.get(f"/api/inbox/conversations/{comms_world['c2']}").status_code == 404
+
+
+def test_authorized_admin_sees_all_number_history_and_voicemail_metadata(client, comms_world):
+    login(client, comms_world["admin"])
+    convs = client.get("/api/inbox/conversations").json["conversations"]
+    assert {c["id"] for c in convs} == {comms_world["c1"], comms_world["c2"]}
+    calls = client.get("/api/calls/recent?tab=all").json["calls"]
+    assert {c["twilio_call_sid"] for c in calls} == {"CA1", "CA2"}
+    vms = client.get("/api/calls/voicemails").json["voicemails"]
+    assert len(vms) == 1
+    assert vms[0]["voicemail_url"] == "https://example.test/vm.mp3"
+
+
+def test_number_settings_are_independent_per_number(client, comms_world):
+    login(client, comms_world["owner"])
+    r1 = client.get(f"/api/phone/numbers/{comms_world['pn1']}/settings")
+    r2 = client.get(f"/api/phone/numbers/{comms_world['pn2']}/settings")
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r1.json["settings"]["business_hours"]["0"]["is_open"] is True
+    assert r2.json["settings"]["business_hours"]["0"]["is_open"] is False
+    upd = client.put(f"/api/phone/numbers/{comms_world['pn2']}/settings", json={"caller_id_display_name": "Support Line", "wifi_only": True})
+    assert upd.status_code == 200
+    assert upd.json["settings"]["caller_id_display_name"] == "Support Line"
+    assert client.get(f"/api/phone/numbers/{comms_world['pn1']}/settings").json["settings"]["caller_id_display_name"] is None
+
+
+def test_left_nav_consolidates_sms_phone_duplicates():
+    from pathlib import Path
+    html = Path("templates/base.html").read_text()
+    assert "Communications Hub" in html
+    assert "SMS Campaigns" in html
+    assert "SMS &amp; Calls Admin" not in html
+    assert "> Phone Numbers" not in html
+
+
+def test_info_adiken_admin_can_open_manage_users_and_edit(client, comms_world):
+    login(client, comms_world["admin"])
+    page = client.get("/user/manage-users")
+    assert page.status_code == 200
+    assert b"info@adiken.com" in page.data
+    resp = client.post(f"/api/user/{comms_world['staff']}/access", json={"role": "editor"})
+    assert resp.status_code == 200
+    assert resp.json["role"] == "editor"
+
+
+def test_sms_campaign_sender_number_permissions_and_calendar_visibility(client, comms_world):
+    with client.application.app_context():
+        campaign = SMSCampaign(
+            company_id=comms_world["co"],
+            created_by_user_id=comms_world["admin"],
+            name="Scheduled SMS Line Check",
+            message="Line-specific campaign",
+            status="scheduled",
+            scheduled_at=datetime.utcnow() + timedelta(days=1),
+        )
+        db.session.add(campaign)
+        db.session.commit()
+        campaign_id = campaign.id
+
+    login(client, comms_world["staff"])
+    blocked = client.post(
+        f"/sms/campaign/{campaign_id}/send",
+        data={"from_phone_number_id": comms_world["pn2"]},
+        follow_redirects=False,
+    )
+    assert blocked.status_code == 403
+
+    login(client, comms_world["admin"])
+    calendar = client.get("/api/calendar/events?types=sms&range=7")
+    assert calendar.status_code == 200
+    events = calendar.get_json()
+    assert any(e["id"] == f"sms_{campaign_id}" and e["content_type"] == "sms_campaign" for e in events)
+
+
+def test_communications_hub_tabs_and_pwa_api_smoke(client, comms_world):
+    login(client, comms_world["admin"])
+    tabs = ["overview", "numbers", "settings", "users", "hours", "auto", "routing", "voicemail", "pwa", "devices", "calls", "inbox", "integrations", "reports"]
+    for tab in tabs:
+        resp = client.get(f"/twilio/comms?tab={tab}&number_id={comms_world['pn1']}")
+        assert resp.status_code == 200, tab
+    assert client.get("/api/phone/numbers").status_code == 200
+    assert client.get(f"/api/phone/numbers/{comms_world['pn1']}/settings").status_code == 200
+    assert client.get("/api/calls/recent?tab=all").status_code == 200
+    assert client.get("/api/calls/voicemails").status_code == 200
+    assert client.get("/api/pwa/devices").status_code == 200

--- a/tests/test_pwa_phone_system.py
+++ b/tests/test_pwa_phone_system.py
@@ -8,11 +8,13 @@ from extensions import db
 from models import (
     CallEvent,
     Company,
+    Contact,
     PhoneSettings,
     AutoReplyRule,
     TwilioAccount,
     TwilioCallLog,
     TwilioPhoneNumber,
+    PWADevice,
     User,
     UserCompanyAccess,
     VoiceVoicemailMessage,
@@ -624,3 +626,105 @@ def test_inbound_sms_conversation_is_assigned_to_to_number_company(app, client, 
     with app.app_context():
         assert TwilioConversation.query.filter_by(company_id=world["co_b"], from_number="+15551119999").one()
         assert TwilioConversation.query.filter_by(company_id=world["co_a"], from_number="+15551119999").first() is None
+
+
+def test_pwa_palette_persists_server_side_across_sessions(client, app, world):
+    login(client, world["alice"])
+    resp = client.patch("/api/pwa/preferences", json={"palette_id": "forest"})
+    assert resp.status_code == 200
+    assert resp.get_json()["preferences"]["palette_id"] == "forest"
+    with client.session_transaction() as sess:
+        sess.clear()
+    login(client, world["alice"])
+    loaded = client.get("/api/pwa/preferences")
+    assert loaded.status_code == 200
+    assert loaded.get_json()["preferences"]["palette_id"] == "forest"
+    with app.app_context():
+        assert db.session.get(User, world["alice"]).pwa_palette_id == "forest"
+
+
+def test_pwa_device_registration_heartbeat_settings_and_tenant_isolation(client, app, world):
+    with app.app_context():
+        pn = TwilioPhoneNumber(company_id=world["co_a"], phone_number="+15550001000", friendly_name="Main A", is_active=True, browser_calling_enabled=False, cell_callback_enabled=False, mobile_data_allowed=False, wifi_only=True)
+        db.session.add(pn); db.session.commit(); pn_id = pn.id
+    login(client, world["alice"])
+    payload = {
+        "device_key": "device-a",
+        "device_name": "Alice Work iPhone",
+        "phone_number_id": pn_id,
+        "browser": "Safari",
+        "device_type": "phone",
+        "push_enabled": True,
+        "microphone_permission": "granted",
+        "pwa_installed": True,
+        "wifi_only": True,
+        "cellular_callback_enabled": False,
+        "mobile_data_calling_allowed": False,
+        "default_calling_method": "browser",
+    }
+    reg = client.post("/api/pwa/devices/register", json=payload)
+    assert reg.status_code == 200
+    device_id = reg.get_json()["device"]["id"]
+    listed = client.get("/api/pwa/devices").get_json()["devices"]
+    assert listed[0]["device_name"] == "Alice Work iPhone"
+    assert listed[0]["assigned_phone_number"] == "+15550001000"
+    hb = client.post("/api/pwa/devices/heartbeat", json={"device_key": "device-a", "phone_number_id": pn_id, "microphone_permission": "prompt"})
+    assert hb.status_code == 200
+    patch = client.patch(f"/api/pwa/devices/{device_id}/settings", json={"default_calling_method": "cell_callback", "mobile_data_calling_allowed": True})
+    assert patch.status_code == 200
+    assert patch.get_json()["device"]["default_calling_method"] == "cell_callback"
+    with app.app_context():
+        assert PWADevice.query.filter_by(company_id=world["co_a"]).count() == 1
+        assert PWADevice.query.filter_by(company_id=world["co_b"]).count() == 0
+
+
+def test_voicemail_transcription_metadata_and_read_state(client, app, world):
+    with app.app_context():
+        call = TwilioCallLog(company_id=world["co_a"], twilio_sid="CAvmmeta", direction="inbound", status="voicemail", from_number="+15551110000", to_number="+15550001000", voicemail_url="https://vm", duration=33)
+        db.session.add(call); db.session.flush()
+        vm = VoiceVoicemailMessage(company_id=world["co_a"], call_log_id=call.id, from_number=call.from_number, to_number=call.to_number, call_sid=call.twilio_sid, recording_sid="REvm", recording_url="https://vm", duration_secs=33)
+        db.session.add(vm); db.session.commit(); call_id = call.id
+    client.post("/api/twilio/voice/transcription", data={"To": "+15550001000", "CallSid": "CAvmmeta", "RecordingSid": "REvm", "TranscriptionSid": "TRvm", "TranscriptionStatus": "completed", "TranscriptionText": "Please call back"})
+    login(client, world["alice"])
+    data = client.get("/api/calls/voicemails").get_json()["voicemails"]
+    vm_row = next(c for c in data if c["id"] == call_id)
+    assert vm_row["voicemail_exists"] is True
+    assert vm_row["transcription_text"] == "Please call back"
+    assert vm_row["transcription_status"] == "complete"
+    read = client.post(f"/api/calls/{call_id}/mark-read")
+    assert read.status_code == 200
+    assert read.get_json()["call"]["is_read"] is True
+    with app.app_context():
+        call = db.session.get(TwilioCallLog, call_id)
+        vm = VoiceVoicemailMessage.query.filter_by(call_log_id=call_id).one()
+        assert call.read_by_user_id == world["alice"]
+        assert vm.read_by_user_id == world["alice"]
+        assert vm.transcription_text == "Please call back"
+
+
+def test_pwa_search_matches_contacts_conversations_and_call_logs(client, app, world):
+    with app.app_context():
+        db.session.add(Contact(company_id=world["co_a"], first_name="Jamie", last_name="Rivera", company="Rivera Spa", email="jamie@rivera.test", phone="+15558880000"))
+        db.session.add(TwilioConversation(company_id=world["co_a"], from_number="+15558881111", to_number="+15550001000", contact_name="Recent SMS Guest", last_message_at=datetime.utcnow()))
+        db.session.add(TwilioCallLog(company_id=world["co_a"], direction="inbound", status="missed", from_number="+15558882222", to_number="+15550001000", caller_name="Recent Caller"))
+        db.session.commit()
+    login(client, world["alice"])
+    by_company = client.get("/api/inbox/contacts/search?q=Rivera").get_json()["contacts"]
+    assert any(r["phone"] == "+15558880000" and r["company"] == "Rivera Spa" for r in by_company)
+    by_sms = client.get("/api/inbox/contacts/search?q=Guest").get_json()["contacts"]
+    assert any(r["phone"] == "+15558881111" and r["source"] == "conversation" for r in by_sms)
+    by_call = client.get("/api/inbox/contacts/search?q=Caller").get_json()["contacts"]
+    assert any(r["phone"] == "+15558882222" and r["source"] == "call_log" for r in by_call)
+
+
+def test_disabled_calling_methods_are_blocked_per_number(client, app, world):
+    with app.app_context():
+        pn = TwilioPhoneNumber(company_id=world["co_a"], phone_number="+15550001000", friendly_name="Main A", is_active=True, browser_calling_enabled=False, cell_callback_enabled=False, mobile_data_allowed=False, wifi_only=True)
+        db.session.add(pn); db.session.commit()
+    login(client, world["alice"])
+    browser = client.post("/api/inbox/call/dial", json={"to": "+15559990000", "selected_number": "+15550001000", "calling_method": "browser"})
+    assert browser.status_code == 403
+    assert "Browser/WiFi calling is disabled" in browser.get_json()["error"]
+    cell = client.post("/api/inbox/call/dial", json={"to": "+15559990000", "selected_number": "+15550001000", "calling_method": "cell_callback"})
+    assert cell.status_code == 403
+    assert "Cell callback calling is disabled" in cell.get_json()["error"]

--- a/twilio_sms.py
+++ b/twilio_sms.py
@@ -133,6 +133,16 @@ class _NumberScopedTwilioConfig:
         "after_hours_text",
         "after_hours_sms_enabled",
         "after_hours_voicemail_enabled",
+        "business_hours",
+        "timezone",
+        "during_hours_route",
+        "after_hours_route",
+        "browser_calling_enabled",
+        "cell_callback_enabled",
+        "wifi_only",
+        "mobile_data_allowed",
+        "fallback_behavior",
+        "caller_id_display_name",
     )
 
     def __init__(self, account, phone_number=None):
@@ -244,6 +254,15 @@ def _seed_phone_numbers_from_accounts():
                     call_forward_to         = ta.call_forward_to,
                     voice_forwarding_enabled = bool(ta.voice_forwarding_enabled),
                     ring_timeout            = 25,
+                    business_hours          = {},
+                    timezone                = "America/Los_Angeles",
+                    during_hours_route      = "ring_pwa",
+                    after_hours_route       = "voicemail",
+                    browser_calling_enabled = True,
+                    cell_callback_enabled   = True,
+                    wifi_only               = False,
+                    mobile_data_allowed     = True,
+                    fallback_behavior       = "cell_callback",
                     voicemail_greeting_text = ta.voicemail_greeting_text,
                     voicemail_greeting_audio_url = ta.voicemail_greeting_audio_url,
                     missed_call_text        = ta.missed_call_text,
@@ -391,15 +410,18 @@ def _validate_twilio_signature(ta, endpoint_path: str = "/twilio/sms/inbound") -
     return True
 
 
-def _is_business_hours(company_id: int, at_time=None) -> bool:
-    """Return True when *at_time* falls within the company's configured hours.
+def _is_business_hours(company_id: int, at_time=None, phone_config=None) -> bool:
+    """Return True when *at_time* falls within configured hours.
 
-    BusinessHours.timezone is honored per tenant; missing rows mean closed.
+    Prefer per-phone-number business hours when present. Tenant PhoneSettings and
+    legacy BusinessHours rows remain as defaults/backward compatibility.
     """
     from models import BusinessHours, PhoneSettings
 
     settings = PhoneSettings.query.filter_by(company_id=company_id).first()
-    tz_name = (
+    phone_hours = getattr(phone_config, "business_hours", None) if phone_config else None
+    phone_tz = getattr(phone_config, "timezone", None) if phone_config else None
+    tz_name = phone_tz or (
         settings.timezone
         if settings and getattr(settings, "timezone", None)
         else os.environ.get("DEFAULT_PHONE_TIMEZONE")
@@ -413,11 +435,12 @@ def _is_business_hours(company_id: int, at_time=None) -> bool:
     now_local = (at_time or datetime.now(timezone.utc)).astimezone(local_tz)
     day = now_local.weekday()   # 0=Mon … 6=Sun
 
-    if settings and getattr(settings, "business_hours", None):
+    hours_cfg = phone_hours if phone_hours else (settings.business_hours if settings and getattr(settings, "business_hours", None) else None)
+    if hours_cfg:
         day_key = str(day)
         day_cfg = (
-            settings.business_hours.get(day_key)
-            or settings.business_hours.get(DAYS[day].lower())
+            hours_cfg.get(day_key)
+            or hours_cfg.get(DAYS[day].lower())
         )
         if day_cfg:
             if day_cfg.get("closed") or day_cfg.get("is_open") is False:
@@ -461,9 +484,20 @@ def _pwa_voice_identity(company_id: int) -> str:
     return pwa_voice_identity(company_id)
 
 
+
+def _business_hours_from_form(form):
+    hours = {}
+    for i in range(7):
+        hours[str(i)] = {
+            "is_open": form.get(f"bh_{i}_open") == "1",
+            "open": form.get(f"bh_{i}_start") or "09:00",
+            "close": form.get(f"bh_{i}_end") or "17:00",
+        }
+    return hours
+
 def _can_send_call_auto_sms(company_id: int, to_number: str, *, cooldown_hours: int = 24) -> tuple[bool, str]:
     """Guard call-triggered automated SMS for opt-out compliance and cooldown."""
-    from models import TwilioConversation, TwilioCallLog
+    from models import TwilioConversation, TwilioCallLog, TwilioPhoneNumber, UserCompanyAccess, User, AutoReplyRule, VoiceVoicemailMessage, MarketingAuditLog, PWADevice
     if not to_number:
         return False, "missing_number"
     conv = TwilioConversation.query.filter_by(
@@ -486,43 +520,38 @@ def _can_send_call_auto_sms(company_id: int, to_number: str, *, cooldown_hours: 
 
 def _get_or_create_conversation(company_id: int, from_number: str, to_number: str):
     from models import TwilioConversation, Contact
-    from services.google_contacts import normalize_phone, _all_forms
+    from services.google_contacts import normalize_phone, _all_forms, lookup_contact_name
 
-    conv = TwilioConversation.query.filter_by(
-        company_id=company_id,
-        from_number=from_number,
+    forms = _all_forms(from_number)
+    conv = TwilioConversation.query.filter(
+        TwilioConversation.company_id == company_id,
+        TwilioConversation.from_number.in_(forms or [from_number]),
     ).first()
-    if not conv:
-        # Normalize the inbound number and try all common representations
-        norm  = normalize_phone(from_number)
-        forms = _all_forms(from_number)
 
-        contact = None
-        for form in forms:
-            contact = Contact.query.filter_by(
-                company_id=company_id,
-                phone=form,
-                is_active=True,
-            ).first()
-            if contact:
-                break
-
-        contact_name   = None
-        contact_source = None
+    contact = None
+    for form in forms:
+        contact = Contact.query.filter_by(
+            company_id=company_id,
+            phone=form,
+            is_active=True,
+        ).first()
         if contact:
-            contact_name   = f"{contact.first_name or ''} {contact.last_name or ''}".strip() or None
-            contact_source = "crm"
+            break
 
+    contact_name, contact_source = lookup_contact_name(company_id, from_number)
+    if contact and not contact_name:
+        contact_name = (contact.name or f"{contact.first_name or ''} {contact.last_name or ''}".strip() or None)
+        contact_source = contact.source or "crm"
+
+    if not conv:
+        norm = normalize_phone(from_number)
         logger.debug(
-            "_get_or_create_conversation: from=%s norm=%s company=%s "
-            "contact_match=%s name=%s source=%s",
-            from_number, norm, company_id,
-            contact.id if contact else None, contact_name, contact_source,
+            "_get_or_create_conversation: from=%s norm=%s company=%s contact_match=%s name=%s source=%s",
+            from_number, norm, company_id, contact.id if contact else None, contact_name, contact_source,
         )
-
         conv = TwilioConversation(
             company_id=company_id,
-            from_number=from_number,
+            from_number=normalize_phone(from_number) or from_number,
             to_number=to_number,
             contact_id=contact.id if contact else None,
             contact_name=contact_name,
@@ -531,6 +560,12 @@ def _get_or_create_conversation(company_id: int, from_number: str, to_number: st
         )
         db.session.add(conv)
         db.session.flush()
+    else:
+        if contact and not conv.contact_id:
+            conv.contact_id = contact.id
+        if contact_name and conv.contact_name != contact_name:
+            conv.contact_name = contact_name
+            conv.contact_source = contact_source
     return conv
 
 
@@ -723,7 +758,7 @@ def _apply_auto_reply_rules(conv, body: str, ta) -> bool:
 
     now_utc     = datetime.now(timezone.utc)
     reply_sent  = False
-    in_business = _is_business_hours(ta.company_id)
+    in_business = _is_business_hours(ta.company_id, phone_config=ta)
 
     logger.info("%s business_hours=%s first_contact=%s", _tag, in_business, conv.is_first_contact)
 
@@ -1382,7 +1417,7 @@ def inbound_call():
             db.session.commit()
 
     # Determine routing
-    in_hours = _is_business_hours(ta.company_id)
+    in_hours = _is_business_hours(ta.company_id, phone_config=ta)
     after_hours_sms_enabled = (
         getattr(ta, "after_hours_sms_enabled", False)
         if pn and getattr(pn, "after_hours_sms_enabled", None) is not None
@@ -1642,6 +1677,7 @@ def voice_recording():
                         recording_sid=recording_sid,
                         recording_url=recording_url,
                         duration_secs=int(recording_dur or 0),
+                        transcription_status="not_requested",
                     ))
             elif log.status != "voicemail":
                 log.status = log.status or "completed"
@@ -1722,9 +1758,16 @@ def voice_transcription():
         log.transcription_text = text or log.transcription_text
         log.transcription_status = "complete" if status == "completed" else status
         log.transcription_provider = "twilio"
+        log.transcription_error = data.get("TranscriptionError") or data.get("ErrorMessage")
+        log.transcribed_at = datetime.utcnow() if text or status in ("completed", "complete", "failed") else log.transcribed_at
         vm = VoiceVoicemailMessage.query.filter_by(call_log_id=log.id).first()
         if vm:
             vm.transcript = text or vm.transcript
+            vm.transcription_text = text or vm.transcription_text
+            vm.transcription_status = log.transcription_status
+            vm.transcription_provider = "twilio"
+            vm.transcription_error = log.transcription_error
+            vm.transcribed_at = log.transcribed_at
         event_id = transcription_sid or recording_sid or f"{call_sid}:transcription"
         if not CallEvent.query.filter_by(call_log_id=log.id, event_type="transcription", provider_event_id=event_id).first():
             db.session.add(CallEvent(call_log_id=log.id, event_type="transcription", provider_event_id=event_id, payload=dict(data)))
@@ -1813,6 +1856,12 @@ def inbox():
         conversations=conversations,
         unread_count=unread_count,
         ta=ta,
+        phone_numbers=phone_numbers,
+        selected_number=selected_number,
+        users_with_access=users_with_access,
+        rules=rules,
+        voicemails=voicemails,
+        activity=activity,
         status_filter=status_filter,
         search=search,
         gc_connected=gc_connected,
@@ -1826,7 +1875,7 @@ def inbox():
 def comms_hub():
     """Communications Hub — tabbed wrapper for SMS, Calls, Voicemail, Contacts, etc."""
     from flask_login import current_user
-    from models import TwilioConversation, TwilioCallLog
+    from models import TwilioConversation, TwilioCallLog, TwilioPhoneNumber, UserCompanyAccess, User, AutoReplyRule, VoiceVoicemailMessage, MarketingAuditLog
 
     company = _get_company()
     if not company:
@@ -1834,7 +1883,16 @@ def comms_hub():
         return redirect(url_for("main.dashboard"))
 
     ta           = _get_twilio_account(company.id)
-    tab          = request.args.get("tab", "inbox")
+    tab          = request.args.get("tab", "overview")
+    if tab == "sms":
+        tab = "inbox"
+    if tab == "logs":
+        tab = "calls"
+    phone_numbers = TwilioPhoneNumber.query.filter_by(company_id=company.id, is_active=True).order_by(TwilioPhoneNumber.is_primary.desc(), TwilioPhoneNumber.created_at.asc()).all()
+    selected_number_id = request.args.get("number_id", type=int)
+    selected_number = None
+    if phone_numbers:
+        selected_number = next((pn for pn in phone_numbers if pn.id == selected_number_id), None) or phone_numbers[0]
     status_filter = request.args.get("status", "all")
     search       = request.args.get("q", "").strip()
 
@@ -1886,6 +1944,34 @@ def comms_hub():
         pass
 
     is_admin = getattr(current_user, "is_admin", False) or getattr(current_user, "is_platform_admin", False)
+    users_with_access = []
+    try:
+        for acc in UserCompanyAccess.query.filter_by(company_id=company.id).all():
+            u = db.session.get(User, acc.user_id)
+            if u:
+                users_with_access.append({"user": u, "access": acc})
+    except Exception:
+        pass
+    rules = []
+    try:
+        rules = AutoReplyRule.query.filter_by(company_id=company.id).order_by(AutoReplyRule.priority.desc(), AutoReplyRule.id.asc()).all()
+    except Exception:
+        pass
+    voicemails = []
+    try:
+        voicemails = VoiceVoicemailMessage.query.filter_by(company_id=company.id, is_deleted=False).order_by(VoiceVoicemailMessage.created_at.desc()).limit(100).all()
+    except Exception:
+        pass
+    activity = []
+    try:
+        activity = MarketingAuditLog.query.filter_by(company_id=company.id).order_by(MarketingAuditLog.created_at.desc()).limit(25).all()
+    except Exception:
+        pass
+    devices = []
+    try:
+        devices = PWADevice.query.filter_by(company_id=company.id).order_by(PWADevice.last_seen_at.desc()).limit(100).all()
+    except Exception:
+        pass
 
     return render_template(
         "twilio/comms_hub.html",
@@ -1901,8 +1987,39 @@ def comms_hub():
         gc_last_sync=gc_last_sync,
         gc_contacts=gc_contacts,
         is_admin=is_admin,
+        phone_numbers=phone_numbers,
+        selected_number=selected_number,
+        users_with_access=users_with_access,
+        rules=rules,
+        voicemails=voicemails,
+        activity=activity,
+        devices=devices,
     )
 
+
+
+@twilio_bp.route("/comms/numbers/<int:number_id>/permissions", methods=["POST"])
+@login_required
+def comms_number_permissions(number_id):
+    from models import TwilioPhoneNumber, PhoneNumberUserPermission, UserCompanyAccess
+    from services.comms_permissions import can_manage_users
+    company = _get_company()
+    if not company or not can_manage_users(current_user, company.id):
+        abort(403)
+    pn = TwilioPhoneNumber.query.filter_by(id=number_id, company_id=company.id).first_or_404()
+    user_id = request.form.get("user_id", type=int)
+    if not user_id or not UserCompanyAccess.query.filter_by(user_id=user_id, company_id=company.id).first():
+        flash("Select a valid tenant user.", "error")
+        return redirect(url_for("twilio.comms_hub", tab="users", number_id=pn.id))
+    perm = PhoneNumberUserPermission.query.filter_by(phone_number_id=pn.id, user_id=user_id).first()
+    if not perm:
+        perm = PhoneNumberUserPermission(company_id=company.id, phone_number_id=pn.id, user_id=user_id)
+        db.session.add(perm)
+    for field in ("can_access_pwa", "can_view_sms", "can_send_sms", "can_view_calls", "can_call", "can_view_voicemail", "can_manage_number", "can_send_campaigns"):
+        setattr(perm, field, request.form.get(field) == "1")
+    db.session.commit()
+    flash(f"Permissions updated for {pn.phone_number}.", "success")
+    return redirect(url_for("twilio.comms_hub", tab="users", number_id=pn.id))
 
 @twilio_bp.route("/comms/settings")
 @login_required
@@ -2058,24 +2175,29 @@ def send_message():
     body      = (payload.get("body") or "").strip()
     conv_id   = payload.get("conversation_id")
 
-    if not to_number or not body:
-        return jsonify({"success": False, "error": "to and body are required."})
+    if not body:
+        return jsonify({"success": False, "error": "Message body is required."})
 
     conv = None
     if conv_id:
         from models import TwilioConversation
         conv = TwilioConversation.query.filter_by(id=conv_id, company_id=company.id).first()
 
+    if conv and not to_number:
+        to_number = conv.from_number
+    if not to_number:
+        return jsonify({"success": False, "error": "Recipient phone number is required."})
     if not conv:
         conv = _get_or_create_conversation(company.id, to_number, ta.from_phone or "")
 
-    # Update conversation preview
-    conv.last_message_at      = datetime.utcnow()
-    conv.last_message_preview = f"You: {body[:150]}"
-    conv.message_count        = (conv.message_count or 0) + 1
-    db.session.commit()
-
     result = _send_sms(ta, to_number, body, conversation_id=conv.id)
+    if result.get("success"):
+        conv.last_message_at      = datetime.utcnow()
+        conv.last_message_preview = f"You: {body[:150]}"
+        conv.message_count        = (conv.message_count or 0) + 1
+        db.session.commit()
+    else:
+        logger.error("/twilio/send failed company=%s conv=%s to=%s error=%s", company.id, conv.id, to_number, result.get("error"))
     return jsonify(result)
 
 
@@ -2783,6 +2905,17 @@ def number_edit(number_id):
     pn.voice_forwarding_enabled = request.form.get("voice_forwarding_enabled") == "1"
     pn.missed_call_text       = request.form.get("missed_call_text", "").strip() or None
     pn.voicemail_greeting_text = request.form.get("voicemail_greeting_text", "").strip() or None
+    pn.voicemail_greeting_audio_url = request.form.get("voicemail_greeting_audio_url", "").strip() or None
+    pn.business_hours = _business_hours_from_form(request.form) if any(k.startswith("bh_") for k in request.form.keys()) else (pn.business_hours or {})
+    pn.timezone = request.form.get("timezone", pn.timezone or "America/Los_Angeles").strip()
+    pn.during_hours_route = request.form.get("during_hours_route", pn.during_hours_route or "ring_pwa").strip()
+    pn.after_hours_route = request.form.get("after_hours_route", pn.after_hours_route or "voicemail").strip()
+    pn.browser_calling_enabled = request.form.get("browser_calling_enabled") == "1"
+    pn.cell_callback_enabled = request.form.get("cell_callback_enabled") == "1"
+    pn.wifi_only = request.form.get("wifi_only") == "1"
+    pn.mobile_data_allowed = request.form.get("mobile_data_allowed") == "1"
+    pn.fallback_behavior = request.form.get("fallback_behavior", pn.fallback_behavior or "cell_callback").strip()
+    pn.caller_id_display_name = request.form.get("caller_id_display_name", "").strip() or None
     pn.after_hours_sms_enabled = request.form.get("after_hours_sms_enabled") == "1"
     pn.after_hours_voicemail_enabled = request.form.get("after_hours_voicemail_enabled") == "1"
     pn.notes                  = request.form.get("notes", "").strip() or None
@@ -2794,6 +2927,8 @@ def number_edit(number_id):
 
     db.session.commit()
     flash(f"Number {pn.phone_number} updated.", "success")
+    if request.form.get("return_to") == "comms":
+        return redirect(url_for("twilio.comms_hub", tab="settings", number_id=pn.id))
     return redirect(url_for("twilio.number_management"))
 
 


### PR DESCRIPTION
### Motivation
- Move tenant-wide communications config toward per-phone-number controls and explicit per-line user permissions to support multi-number tenants and scoped PWA access.
- Consolidate legacy SMS/Phone admin navigation into a productized Communications Hub and surface per-number settings, devices, and runtime controls for browser/cell calling.
- Harden inbound/outbound Twilio flows, voicemail/transcription metadata, and Google Contacts sync so PWA search and conversation resolution work reliably.
- Add telemetry for PWA devices and server-backed palette/preferences so device behavior and appearance persist and can be audited.

### Description
- Database and models: add migration `migrations/20260617_comms_phone_number_permissions.sql` and new/extended models for per-number fields on `TwilioPhoneNumber`, `PhoneNumberUserPermission`, `PWADevice`, voicemail/call read/transcription fields, SMS campaign sender fields, and PWA preferences on `User` and `UserCompanyAccess` (`manage_users_enabled`).
- Permissions and services: add `services/comms_permissions.py` with role normalization, `accessible_phone_numbers`, and filtering helpers used across APIs to enforce tenant isolation and per-line access.
- APIs and handlers: add PWA APIs (`/api/phone/numbers`, `/api/phone/numbers/<id>/settings`, `/api/pwa/devices*`, `/api/pwa/preferences`), wire server-side filtering for conversations/calls/contacts by accessible numbers, and require per-number authorization for dialing/call placement.
- Twilio and comms logic: prefer per-number business hours/timezone when present, ensure outbound calls use the selected business number as caller ID, delay conversation metadata updates until after successful Twilio dispatch, enrich contact resolution by populating Contact cache from Google Contacts, and persist voicemail transcription/read metadata.
- UI and templates: consolidate left-nav entries (hide legacy duplicate admin links), implement Communications Hub tabs and per-number settings forms, add PWA palette selection and device telemetry in `inbox_pwa` template, fix message bubble wrapping, dialer lookup, and assigned-number selector.
- Misc: seed logic for TwilioPhoneNumber from TwilioAccount, new helpers for resolving/authorizing selected phone numbers, and admin endpoints to manage per-number permissions and save settings from the hub.

### Testing
- Ran unit/integration tests for the communications feature with `pytest tests/test_comms_permissions_architecture.py tests/test_pwa_phone_system.py` and the new test modules completed successfully.
- Executed the repository test suite paths covering the changed APIs and templates (`pytest tests/test_comms_permissions_architecture.py::test_*`, `pytest tests/test_pwa_phone_system.py::test_*`) and assertions for conversation/call scoping, device registration, voicemail transcription, per-number settings, and user-management passed.
- Note: staging runtime validation (Twilio webhooks, browser/WiFi calling, real-number voicemail playback) is documented in `COMMUNICATIONS_DEPLOYMENT_VERIFICATION.md` and must be run with real Twilio credentials and numbers; those live runtime checks are outside unit tests and remain as follow-up steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33188dc5b48322942d787a939bb0f9)