### PR TITLE
Fix auto reply rules in Communications Hub

### DIFF
--- a/templates/twilio/comms_hub.html
+++ b/templates/twilio/comms_hub.html
@@ -147,7 +147,27 @@
     <input type="hidden" name="action" value="reply">
   </form>
   {% endif %}
-  <div class="card" style="background:#0f1117;border:1px solid #1e2535;">{% for rule in rules %}<form method="POST" action="{{ url_for('twilio.edit_rule', rule_id=rule.id) }}" class="p-3" style="border-bottom:1px solid #1e2535;"><input type="hidden" name="csrf_token" value="{{ csrf_token() }}"><input type="hidden" name="phone_number_id" value="{{ selected_number.id if selected_number else '' }}"><input type="hidden" name="action" value="reply"><div class="row g-2 align-items-end"><div class="col-md-2"><label class="form-label small text-muted">Name</label><input class="form-control" name="name" value="{{ rule.name }}"></div><div class="col-md-2"><label class="form-label small text-muted">Match type</label><select class="form-select" name="trigger_type">{% for v,l in [('keyword_contains','Keyword contains'),('keyword_exact','Keyword exact'),('first_contact','First contact'),('after_hours','After-hours'),('always','Always')] %}<option value="{{ v }}" {% if rule.trigger_type == v %}selected{% endif %}>{{ l }}</option>{% endfor %}</select></div><div class="col-md-2"><label class="form-label small text-muted">Keyword(s)</label><input class="form-control" name="keywords" value="{{ (rule.keywords or [])|join(', ') }}"></div><div class="col-md-1"><label class="form-label small text-muted">Priority</label><input class="form-control" type="number" name="priority" value="{{ rule.priority or 0 }}"></div><div class="col-md-3"><label class="form-label small text-muted">Reply text</label><textarea class="form-control" name="response" rows="1">{{ rule.response or '' }}</textarea></div><div class="col-md-1"><label class="form-check small"><input class="form-check-input" type="checkbox" name="is_active" value="1" {% if rule.is_active %}checked{% endif %}> Active</label></div><div class="col-md-1 d-flex gap-1"><button class="btn btn-sm btn-primary" type="submit">Save</button><button class="btn btn-sm btn-outline-danger" type="submit" form="delete-rule-{{ rule.id }}">Delete</button></div></div></form><form id="delete-rule-{{ rule.id }}" method="POST" action="{{ url_for('twilio.delete_rule', rule_id=rule.id) }}"><input type="hidden" name="csrf_token" value="{{ csrf_token() }}"></form>{% else %}<div class="p-4 text-muted">No auto-reply rules yet. Create one above.</div>{% endfor %}</div>
+  <div class="card" style="background:#0f1117;border:1px solid #1e2535;">
+    {% for rule in rules %}
+      <form method="POST" action="{{ url_for('twilio.edit_rule', rule_id=rule.id) }}" class="p-3" style="border-bottom:1px solid #1e2535;">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="phone_number_id" value="{{ rule.phone_number_id if rule.phone_number_id is not none else '' }}">
+        <input type="hidden" name="return_number_id" value="{{ selected_number.id if selected_number else '' }}">
+        <input type="hidden" name="action" value="reply">
+        <div class="row g-2 align-items-end">
+          <div class="col-md-2"><label class="form-label small text-muted">Name</label><input class="form-control" name="name" value="{{ rule.name }}"></div>
+          <div class="col-md-2"><label class="form-label small text-muted">Match type</label><select class="form-select" name="trigger_type">{% for v,l in [('keyword_contains','Keyword contains'),('keyword_exact','Keyword exact'),('first_contact','First contact'),('after_hours','After-hours'),('always','Always')] %}<option value="{{ v }}" {% if rule.trigger_type == v %}selected{% endif %}>{{ l }}</option>{% endfor %}</select></div>
+          <div class="col-md-2"><label class="form-label small text-muted">Keyword(s)</label><input class="form-control" name="keywords" value="{{ (rule.keywords or [])|join(', ') }}"></div>
+          <div class="col-md-1"><label class="form-label small text-muted">Priority</label><input class="form-control" type="number" name="priority" value="{{ rule.priority or 0 }}"></div>
+          <div class="col-md-2"><label class="form-label small text-muted">Reply text</label><textarea class="form-control" name="response" rows="1">{{ rule.response or '' }}</textarea></div>
+          <div class="col-md-1"><span class="badge {% if rule.phone_number_id %}bg-primary{% else %}bg-secondary{% endif %}">{% if rule.phone_number_id %}Number-specific{% else %}Global{% endif %}</span><div class="small text-muted mt-1">{{ (rule.trigger_type or 'No match type') | replace('_', ' ') | title }}</div></div>
+          <div class="col-md-1"><label class="form-check small"><input class="form-check-input" type="checkbox" name="is_active" value="1" {% if rule.is_active %}checked{% endif %}> Active</label></div>
+          <div class="col-md-1 d-flex gap-1"><button class="btn btn-sm btn-primary" type="submit">Save</button><button class="btn btn-sm btn-outline-danger" type="submit" form="delete-rule-{{ rule.id }}">Delete</button></div>
+        </div>
+      </form>
+      <form id="delete-rule-{{ rule.id }}" method="POST" action="{{ url_for('twilio.delete_rule', rule_id=rule.id, number_id=selected_number.id if selected_number else None) }}"><input type="hidden" name="csrf_token" value="{{ csrf_token() }}"></form>
+    {% else %}<div class="p-4 text-muted">No auto-reply rules yet. Create one above.</div>{% endfor %}
+  </div>
 
   {% elif tab == 'users' %}
   <div class="d-flex mb-3"><h6 class="fw-semibold">Users & Permissions{% if selected_number %} — {{ selected_number.friendly_name or selected_number.phone_number }}{% endif %}</h6><a href="{{ url_for('main.manage_users') }}" class="btn btn-sm btn-outline-secondary ms-auto">Manage users</a></div>

--- a/tests/test_comms_permissions_architecture.py
+++ b/tests/test_comms_permissions_architecture.py
@@ -382,6 +382,11 @@ def test_comms_auto_replies_inline_crud(client, comms_world):
         follow_redirects=False,
     )
     assert create.status_code == 302
+    assert create.headers["Location"].endswith(f"/twilio/comms?tab=auto&number_id={comms_world['pn1']}")
+    reload_page = client.get(f"/twilio/comms?tab=auto&number_id={comms_world['pn1']}")
+    assert reload_page.status_code == 200
+    assert b"Booking Reply" in reload_page.data
+    assert b"Number-specific" in reload_page.data
     with client.application.app_context():
         rule = AutoReplyRule.query.filter_by(company_id=comms_world["co"], name="Booking Reply").one()
         assert rule.phone_number_id == comms_world["pn1"]
@@ -400,6 +405,7 @@ def test_comms_auto_replies_inline_crud(client, comms_world):
         follow_redirects=False,
     )
     assert edit.status_code == 302
+    assert edit.headers["Location"].endswith(f"/twilio/comms?tab=auto&number_id={comms_world['pn1']}")
     with client.application.app_context():
         rule = db.session.get(AutoReplyRule, rule_id)
         assert rule.name == "Booking Reply Updated"

--- a/twilio_sms.py
+++ b/twilio_sms.py
@@ -1989,18 +1989,22 @@ def comms_hub():
         pass
     rules = []
     try:
-        rules = (
-            AutoReplyRule.query
-            .filter_by(company_id=company.id)
-            .filter(db.or_(
+        selected_rule_number_id = selected_number.id if selected_number else None
+        rules_query = AutoReplyRule.query.filter_by(company_id=company.id)
+        if selected_rule_number_id is not None:
+            rules_query = rules_query.filter(db.or_(
+                AutoReplyRule.phone_number_id == selected_rule_number_id,
                 AutoReplyRule.phone_number_id.is_(None),
-                AutoReplyRule.phone_number_id == (selected_number.id if selected_number else None),
             ))
+        else:
+            rules_query = rules_query.filter(AutoReplyRule.phone_number_id.is_(None))
+        rules = (
+            rules_query
             .order_by(AutoReplyRule.priority.desc(), AutoReplyRule.id.asc())
             .all()
         )
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Could not load Communications Hub auto-reply rules: %s", exc)
     voicemails = []
     try:
         voicemails = VoiceVoicemailMessage.query.filter_by(company_id=company.id, is_deleted=False).order_by(VoiceVoicemailMessage.created_at.desc()).limit(100).all()
@@ -2499,7 +2503,8 @@ def edit_rule(rule_id):
     if request.headers.get("Accept") == "application/json" or request.is_json:
         return jsonify({"success": True, "name": rule.name})
     flash(f'Rule "{rule.name}" updated.', "success")
-    return redirect(url_for("twilio.comms_hub", tab="auto", number_id=rule.phone_number_id))
+    return_number_id = f.get("return_number_id", type=int) or rule.phone_number_id
+    return redirect(url_for("twilio.comms_hub", tab="auto", number_id=return_number_id))
 
 
 @twilio_bp.route("/rules/<int:rule_id>/toggle", methods=["POST"])
@@ -2523,7 +2528,8 @@ def delete_rule(rule_id):
     db.session.delete(rule)
     db.session.commit()
     flash(f'Rule "{name}" deleted.', "success")
-    return redirect(url_for("twilio.comms_hub", tab="auto"))
+    return_number_id = request.args.get("number_id", type=int) or request.form.get("return_number_id", type=int)
+    return redirect(url_for("twilio.comms_hub", tab="auto", number_id=return_number_id))
 
 
 @twilio_bp.route("/hours", methods=["GET", "POST"])


### PR DESCRIPTION
### Motivation
- Auto-reply rules were being saved to the DB but not always shown in the Communications Hub because the backend query and template logic did not consistently include number-specific plus global rules and redirects lost the selected number context.
- The inline rules UI also lacked visible indicators for number-scoped vs global rules and could hide rules with missing/empty trigger types.

### Description
- Scope the Communications Hub `rules` query to return rules matching the selected phone number plus global rules, and limit to globals when no number is selected, and log failures when loading rules (`twilio_sms.py`).
- Preserve the selected `number_id` when editing or deleting rules by reading a `return_number_id` form value or URL param and redirecting back to `/twilio/comms?tab=auto&number_id=...` (`twilio_sms.py`).
- Update the inline auto-reply template to render `Number-specific` / `Global` badges, include a `return_number_id` hidden input, and tolerate missing/empty `trigger_type` values so the displayed list matches the query (`templates/twilio/comms_hub.html`).
- Add regression assertions to the auto-reply CRUD test to verify the create redirect preserves `number_id`, reloading `/twilio/comms?tab=auto&number_id=...` shows the new rule, and the number-specific badge is visible (`tests/test_comms_permissions_architecture.py`).

### Testing
- Ran `pytest tests/test_comms_permissions_architecture.py::test_comms_auto_replies_inline_crud -q` and the test passed.
- Ran `pytest tests/test_comms_permissions_architecture.py -q` and the file's test suite passed (19 passed, warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33a4a6d5508322bd169d4f94d09370)