### PR TITLE
Segment management, membership provenance, and marketing suppression (API, UI, models, migration, tests)

### DIFF
--- a/app.py
+++ b/app.py
@@ -345,7 +345,7 @@ def create_app() -> Flask:
     from x_auth import x_bp, x_api_bp
     from twilio_sms import twilio_bp, api_twilio_bp
     from saas_mgmt import saas_bp, stripe_webhook_bp
-    from marketing_api import marketing_api_bp
+    from marketing_api import marketing_api_bp, segment_api_bp
 
     # IMPORTANT: Marketing first if it owns "/"
     app.register_blueprint(marketing_bp)
@@ -362,6 +362,7 @@ def create_app() -> Flask:
     app.register_blueprint(saas_bp)
     app.register_blueprint(stripe_webhook_bp)
     app.register_blueprint(marketing_api_bp)
+    app.register_blueprint(segment_api_bp)
     try:
         from feedback import feedback_bp
         app.register_blueprint(feedback_bp)

--- a/docs/marketing_segments.md
+++ b/docs/marketing_segments.md
@@ -1,0 +1,24 @@
+# Marketing Segments and Suppression
+
+Admins, managers, and editors can create, edit, copy, activate/deactivate, and manage segment contacts. Segment deletion removes segment memberships/rules for that segment only; contacts are preserved. Copying creates a new segment named with a `Copy` suffix and duplicates description, type, category, match mode, triggers, conditions, actions, dynamic/static state, and active state, but does not copy audit history or send campaigns.
+
+Segment contacts can be manually added/removed one at a time or in bulk. Membership rows store source (`manual`, `dynamic_rule`, `imported`, `woocommerce`, `sms_opt_in`, `email_opt_in`, `affiliate`, `lux_verified`), the user and timestamp that added or removed them, and permanent exclusion metadata. Dynamic segment refreshes must honor `is_excluded=true` so rules cannot immediately re-add permanently excluded contacts.
+
+## Do Not Market precedence
+
+Marketing suppression is contact-level and wins over segment membership, campaign enrollment, automation rules, AI suggestions, purchaser, affiliate, and LUX verified status:
+
+1. `do_not_market` blocks all marketing email and SMS.
+2. `do_not_email` blocks marketing email.
+3. `email_unsubscribed` blocks marketing email.
+4. `do_not_sms` blocks marketing SMS.
+5. `sms_opted_out` blocks marketing SMS.
+6. STOP/opt-out compliance always wins over segment membership.
+
+Transactional messages are not blocked unless a sender has not separated transactional from marketing delivery.
+
+Campaign send flows log skipped contacts with reasons: `do_not_market`, `do_not_email`, `email_unsubscribed`, `do_not_sms`, `sms_opted_out`, `missing_email`, `missing_phone`, `invalid_phone`, and `tenant_mismatch`.
+
+## Deployment migration note
+
+Production deploys run SQL files from `migrations/*.sql` in `.github/workflows/push-to-production.yml` when `psql` and `DATABASE_URL` are available. The segment suppression migration uses `ADD COLUMN IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS` so repeated deploys can safely re-run it while ensuring required schema columns exist.

--- a/marketing_api.py
+++ b/marketing_api.py
@@ -66,6 +66,8 @@ def _append_stop_language(message: str) -> str:
 
 
 def _contact_has_sms_consent(contact: Contact) -> bool:
+    if marketing_skip_reason(contact, "sms") if "marketing_skip_reason" in globals() else False:
+        return False
     if not contact.phone or not contact.is_active or not contact.is_subscribed:
         return False
     tags = (contact.tags or "").lower()
@@ -236,7 +238,14 @@ def api_sms_preview(cid):
 
 def _materialize_recipients(c: SMSCampaign):
     existing = {r.contact_id for r in c.recipients}
-    contacts = [x for x in _audience_query(c.company_id, c.segment).all() if _contact_has_sms_consent(x)]
+    contacts = []
+    for x in _audience_query(c.company_id, c.segment).all():
+        reason = marketing_skip_reason(x, "sms") if "marketing_skip_reason" in globals() else None
+        if reason:
+            _audit(c.company_id, "campaign_contact_skipped_suppression", "sms_campaign", c.id, {"contact_id": x.id, "reason": reason, "channel": "sms"}) if "_audit" in globals() else None
+            continue
+        if _contact_has_sms_consent(x):
+            contacts.append(x)
     for contact in contacts:
         if contact.id not in existing:
             db.session.add(SMSRecipient(company_id=c.company_id, campaign_id=c.id, contact_id=contact.id, status="queued"))
@@ -693,3 +702,345 @@ def ai_suggest_segment(): return jsonify(_ai_payload("suggest-segment", request.
 def ai_compliance_check(): return jsonify(_ai_payload("compliance-check", request.get_json(silent=True) or {}))
 
 csrf.exempt(marketing_api_bp)
+
+# ---------------------------------------------------------------------------
+# Segment management and marketing suppression APIs (/api/*)
+# ---------------------------------------------------------------------------
+from flask import Blueprint
+from sqlalchemy.exc import IntegrityError
+from models import Segment, SegmentMember, CampaignRecipient
+
+segment_api_bp = Blueprint("segment_api", __name__, url_prefix="/api")
+
+SEGMENT_FIELDS = ("name", "description", "segment_type", "category", "match_mode", "triggers", "conditions", "actions", "is_dynamic", "is_active")
+SKIP_REASONS = {"do_not_market", "do_not_email", "email_unsubscribed", "do_not_sms", "sms_opted_out", "missing_email", "missing_phone", "invalid_phone", "tenant_mismatch"}
+
+
+def _can_edit(cid):
+    return bool(cid and current_user.is_authenticated and current_user.can_edit_company(cid))
+
+
+def _can_admin(cid):
+    return bool(cid and current_user.is_authenticated and current_user.can_admin_company(cid))
+
+
+def _require_edit(cid):
+    if not _can_edit(cid):
+        return _json_error("admin, manager, or editor permission is required", 403)
+    return None
+
+
+def _require_admin(cid):
+    if not _can_admin(cid):
+        return _json_error("admin permission is required", 403)
+    return None
+
+
+def _audit(company_id, action, entity_type, entity_id=None, details=None):
+    db.session.add(MarketingAuditLog(
+        company_id=company_id,
+        created_by_user_id=getattr(current_user, "id", None),
+        entity_type=entity_type,
+        entity_id=entity_id,
+        action=action,
+        details=details or {},
+    ))
+
+
+def _segment_or_404(segment_id):
+    return Segment.query.filter_by(id=segment_id, company_id=tenant_id()).first_or_404()
+
+
+def _contact_or_404(contact_id, company_id):
+    return Contact.query.filter_by(id=contact_id, company_id=company_id).first_or_404()
+
+
+def _segment_json(s, include_rules=True):
+    data = {
+        "id": s.id, "name": s.name, "description": s.description, "segment_type": s.segment_type,
+        "category": s.category, "match_mode": s.match_mode, "is_dynamic": s.is_dynamic,
+        "is_active": s.is_active, "member_count": s.members.filter_by(is_excluded=False, removed_at=None).count(),
+        "created_at": s.created_at.isoformat() if s.created_at else None,
+        "updated_at": s.updated_at.isoformat() if s.updated_at else None,
+    }
+    if include_rules:
+        data.update({"triggers": s.triggers or [], "conditions": s.conditions or [], "actions": s.actions or []})
+    return data
+
+
+def _suppression_badges(c):
+    badges = []
+    if c.do_not_market: badges.append("Do Not Market")
+    if c.do_not_email: badges.append("Do Not Email")
+    if c.do_not_sms: badges.append("Do Not SMS")
+    if c.sms_opted_out or c.sms_opt_out_at: badges.append("SMS Opted Out")
+    if c.email_unsubscribed or not c.is_subscribed: badges.append("Email Unsubscribed")
+    return badges
+
+
+def _contact_json(c, membership=None):
+    data = {"id": c.id, "email": c.email, "phone": c.phone, "first_name": c.first_name, "last_name": c.last_name,
+            "do_not_market": c.do_not_market, "do_not_email": c.do_not_email, "do_not_sms": c.do_not_sms,
+            "email_unsubscribed": c.email_unsubscribed or not c.is_subscribed, "sms_opted_out": c.sms_opted_out or bool(c.sms_opt_out_at),
+            "suppression_badges": _suppression_badges(c)}
+    if membership:
+        data["membership"] = {"source": membership.source, "added_by_user_id": membership.added_by_user_id,
+            "added_at": membership.added_at.isoformat() if membership.added_at else None,
+            "removed_at": membership.removed_at.isoformat() if membership.removed_at else None,
+            "removed_by_user_id": membership.removed_by_user_id, "is_excluded": membership.is_excluded,
+            "exclusion_reason": membership.exclusion_reason}
+    return data
+
+
+def marketing_skip_reason(contact, channel):
+    if not contact:
+        return "tenant_mismatch"
+    if contact.do_not_market:
+        return "do_not_market"
+    if channel == "email":
+        if contact.do_not_email: return "do_not_email"
+        if contact.email_unsubscribed or not contact.is_subscribed: return "email_unsubscribed"
+        if not contact.email: return "missing_email"
+    if channel == "sms":
+        if contact.do_not_sms: return "do_not_sms"
+        if contact.sms_opted_out or contact.sms_opt_out_at: return "sms_opted_out"
+        if not contact.phone: return "missing_phone"
+        if "invalid_phone" in (contact.tags or "").lower(): return "invalid_phone"
+    return None
+
+
+def _matching_dynamic_contacts(segment):
+    q = _audience_query(segment.company_id, segment.name if segment.segment_type == "legacy_tag" else None)
+    conditions = segment.conditions or []
+    if isinstance(conditions, dict): conditions = [conditions]
+    for cond in conditions:
+        field, value = cond.get("field"), cond.get("value")
+        if field == "tag": q = q.filter(Contact.tags.ilike(f"%{value}%"))
+        elif field == "segment": q = q.filter(Contact.segment == value)
+        elif field == "source": q = q.filter(Contact.source == value)
+        elif field == "email_opt_in": q = q.filter(Contact.is_subscribed.is_(bool(value)))
+        elif field == "sms_opt_in": q = q.filter(Contact.sms_marketing_opt_in.is_(bool(value)))
+    return q.all()
+
+
+def refresh_dynamic_segment(segment):
+    if not segment.is_dynamic:
+        return 0
+    excluded = {m.contact_id for m in segment.members.filter_by(is_excluded=True).all()}
+    existing = {m.contact_id: m for m in segment.members.all()}
+    matched = 0
+    for contact in _matching_dynamic_contacts(segment):
+        if contact.id in excluded:
+            continue
+        matched += 1
+        member = existing.get(contact.id)
+        if member:
+            member.removed_at = None; member.removed_by_user_id = None; member.source = member.source or "dynamic_rule"
+        else:
+            db.session.add(SegmentMember(segment_id=segment.id, contact_id=contact.id, source="dynamic_rule"))
+    return matched
+
+
+
+
+@segment_api_bp.get("/contacts/search")
+@login_required
+def api_contacts_search_root():
+    """Tenant-scoped contact picker search for segment membership UX."""
+    cid = tenant_id()
+    if not cid:
+        return jsonify({"success": True, "contacts": []})
+    term = (request.args.get("q") or "").strip()
+    query = Contact.query.filter_by(company_id=cid)
+    if term:
+        like = f"%{term}%"
+        query = query.filter(or_(
+            Contact.first_name.ilike(like),
+            Contact.last_name.ilike(like),
+            Contact.email.ilike(like),
+            Contact.phone.ilike(like),
+            Contact.company.ilike(like),
+        ))
+    contacts = query.order_by(Contact.created_at.desc()).limit(25).all()
+    return jsonify({"success": True, "contacts": [_contact_json(c) for c in contacts]})
+
+
+@segment_api_bp.get("/segments")
+@login_required
+def api_segments_root():
+    cid = tenant_id()
+    return jsonify({"success": True, "segments": [_segment_json(s, False) for s in Segment.query.filter_by(company_id=cid).order_by(Segment.name).all()]})
+
+
+@segment_api_bp.post("/segments")
+@login_required
+def api_segment_create_root():
+    cid = tenant_id(); err = _require_edit(cid)
+    if err: return err
+    data = request.get_json(silent=True) or {}
+    s = Segment(company_id=cid, name=data.get("name") or "Untitled Segment")
+    for f in SEGMENT_FIELDS:
+        if f in data: setattr(s, f, data[f])
+    db.session.add(s); db.session.flush(); _audit(cid, "segment_created", "segment", s.id, _segment_json(s)); db.session.commit()
+    return jsonify({"success": True, "segment": _segment_json(s)}), 201
+
+
+@segment_api_bp.get("/segments/<int:sid>")
+@login_required
+def api_segment_get_root(sid):
+    s = _segment_or_404(sid)
+    refresh_dynamic_segment(s); db.session.commit()
+    return jsonify({"success": True, "segment": _segment_json(s)})
+
+
+@segment_api_bp.patch("/segments/<int:sid>")
+@login_required
+def api_segment_patch_root(sid):
+    s = _segment_or_404(sid); err = _require_edit(s.company_id)
+    if err: return err
+    data = request.get_json(silent=True) or {}; was_active = s.is_active
+    for f in SEGMENT_FIELDS:
+        if f in data: setattr(s, f, data[f])
+    action = "segment_updated"
+    if "is_active" in data and bool(data["is_active"]) != bool(was_active):
+        action = "segment_activated" if data["is_active"] else "segment_deactivated"
+    _audit(s.company_id, action, "segment", s.id, data); db.session.commit()
+    return jsonify({"success": True, "segment": _segment_json(s)})
+
+
+@segment_api_bp.post("/segments/<int:sid>/copy")
+@login_required
+def api_segment_copy_root(sid):
+    s = _segment_or_404(sid); err = _require_edit(s.company_id)
+    if err: return err
+    dup = Segment(company_id=s.company_id, name=f"{s.name} Copy", description=s.description, segment_type=s.segment_type,
+        category=s.category, match_mode=s.match_mode, triggers=s.triggers, conditions=s.conditions, actions=s.actions,
+        is_dynamic=s.is_dynamic, is_active=s.is_active)
+    db.session.add(dup); db.session.flush(); _audit(s.company_id, "segment_copied", "segment", dup.id, {"source_segment_id": s.id}); db.session.commit()
+    return jsonify({"success": True, "segment": _segment_json(dup)}), 201
+
+
+@segment_api_bp.delete("/segments/<int:sid>")
+@login_required
+def api_segment_delete_root(sid):
+    s = _segment_or_404(sid); err = _require_admin(s.company_id)
+    if err: return err
+    cid = s.company_id; details = {"name": s.name, "memberships_removed": s.members.count()}
+    db.session.delete(s); _audit(cid, "segment_deleted", "segment", sid, details); db.session.commit()
+    return jsonify({"success": True, "deleted": sid})
+
+
+@segment_api_bp.get("/segments/<int:sid>/contacts")
+@login_required
+def api_segment_contacts_root(sid):
+    s = _segment_or_404(sid); refresh_dynamic_segment(s); db.session.commit()
+    q = SegmentMember.query.filter_by(segment_id=s.id, removed_at=None)
+    if request.args.get("include_excluded") != "true": q = q.filter_by(is_excluded=False)
+    term = (request.args.get("q") or "").strip()
+    rows = q.join(Contact).filter(Contact.company_id == s.company_id)
+    if term: rows = rows.filter(or_(Contact.email.ilike(f"%{term}%"), Contact.first_name.ilike(f"%{term}%"), Contact.last_name.ilike(f"%{term}%"), Contact.phone.ilike(f"%{term}%")))
+    members = rows.order_by(SegmentMember.added_at.desc()).all()
+    return jsonify({"success": True, "contacts": [_contact_json(m.contact, m) for m in members]})
+
+
+def _add_contact_to_segment(s, contact_id, source="manual"):
+    c = _contact_or_404(contact_id, s.company_id)
+    member = SegmentMember.query.filter_by(segment_id=s.id, contact_id=c.id).first()
+    if member:
+        member.removed_at = None; member.is_excluded = False; member.exclusion_reason = None; member.source = source
+    else:
+        member = SegmentMember(segment_id=s.id, contact_id=c.id, source=source)
+        db.session.add(member)
+    member.added_by_user_id = current_user.id; member.added_at = datetime.utcnow()
+    return member
+
+
+@segment_api_bp.post("/segments/<int:sid>/contacts")
+@login_required
+def api_segment_add_contact_root(sid):
+    s = _segment_or_404(sid); err = _require_edit(s.company_id)
+    if err: return err
+    data = request.get_json(silent=True) or {}; m = _add_contact_to_segment(s, data.get("contact_id"), data.get("source") or "manual")
+    _audit(s.company_id, "segment_contact_added", "segment", s.id, {"contact_id": m.contact_id, "source": m.source}); db.session.commit()
+    return jsonify({"success": True, "contact": _contact_json(m.contact, m)}), 201
+
+
+@segment_api_bp.delete("/segments/<int:sid>/contacts/<int:contact_id>")
+@login_required
+def api_segment_remove_contact_root(sid, contact_id):
+    s = _segment_or_404(sid); err = _require_edit(s.company_id)
+    if err: return err
+    permanent = (request.get_json(silent=True) or {}).get("permanent_exclusion") or request.args.get("permanent_exclusion") == "true"
+    m = SegmentMember.query.filter_by(segment_id=s.id, contact_id=contact_id).first_or_404()
+    if permanent:
+        m.is_excluded = True; m.exclusion_reason = "permanent_exclusion"; m.source = m.source or "manual"
+    m.removed_at = datetime.utcnow(); m.removed_by_user_id = current_user.id
+    _audit(s.company_id, "segment_contact_excluded" if permanent else "segment_contact_removed", "segment", s.id, {"contact_id": contact_id}); db.session.commit()
+    return jsonify({"success": True})
+
+
+@segment_api_bp.post("/segments/<int:sid>/contacts/bulk-add")
+@login_required
+def api_segment_bulk_add_root(sid):
+    s = _segment_or_404(sid); err = _require_edit(s.company_id)
+    if err: return err
+    ids = (request.get_json(silent=True) or {}).get("contact_ids") or []
+    added = [_add_contact_to_segment(s, i) for i in ids]
+    _audit(s.company_id, "segment_contact_added", "segment", s.id, {"contact_ids": [m.contact_id for m in added], "bulk": True}); db.session.commit()
+    return jsonify({"success": True, "added": len(added)})
+
+
+@segment_api_bp.post("/segments/<int:sid>/contacts/bulk-remove")
+@login_required
+def api_segment_bulk_remove_root(sid):
+    s = _segment_or_404(sid); err = _require_edit(s.company_id)
+    if err: return err
+    ids = (request.get_json(silent=True) or {}).get("contact_ids") or []
+    now = datetime.utcnow(); count = 0
+    for m in SegmentMember.query.filter(SegmentMember.segment_id == s.id, SegmentMember.contact_id.in_(ids)).all():
+        m.removed_at = now; m.removed_by_user_id = current_user.id; count += 1
+    _audit(s.company_id, "segment_contact_removed", "segment", s.id, {"contact_ids": ids, "bulk": True}); db.session.commit()
+    return jsonify({"success": True, "removed": count})
+
+
+@segment_api_bp.post("/segments/<int:sid>/contacts/<int:contact_id>/exclude")
+@login_required
+def api_segment_exclude_contact_root(sid, contact_id):
+    s = _segment_or_404(sid); err = _require_edit(s.company_id)
+    if err: return err
+    data = request.get_json(silent=True) or {}; _contact_or_404(contact_id, s.company_id)
+    m = SegmentMember.query.filter_by(segment_id=s.id, contact_id=contact_id).first() or SegmentMember(segment_id=s.id, contact_id=contact_id, source="manual")
+    db.session.add(m); m.is_excluded = True; m.removed_at = datetime.utcnow(); m.removed_by_user_id = current_user.id; m.exclusion_reason = data.get("reason") or "permanent_exclusion"
+    _audit(s.company_id, "segment_contact_excluded", "segment", s.id, {"contact_id": contact_id, "reason": m.exclusion_reason}); db.session.commit()
+    return jsonify({"success": True})
+
+
+@segment_api_bp.patch("/contacts/<int:contact_id>/marketing-preferences")
+@login_required
+def api_contact_marketing_preferences(contact_id):
+    cid = tenant_id(); err = _require_edit(cid)
+    if err: return err
+    c = _contact_or_404(contact_id, cid); data = request.get_json(silent=True) or {}; old = {f: getattr(c, f) for f in ("do_not_market", "do_not_email", "do_not_sms")}
+    for f in ("do_not_market", "do_not_email", "do_not_sms", "email_unsubscribed", "sms_opted_out"):
+        if f in data: setattr(c, f, bool(data[f]))
+    c.marketing_preferences_reason = data.get("reason", c.marketing_preferences_reason); c.marketing_preferences_source = data.get("source", c.marketing_preferences_source)
+    c.marketing_preferences_updated_by_user_id = current_user.id; c.marketing_preferences_updated_at = datetime.utcnow()
+    for f, action in (("do_not_market", "contact_do_not_market"), ("do_not_email", "contact_do_not_email"), ("do_not_sms", "contact_do_not_sms")):
+        if f in data and bool(data[f]) != bool(old[f]): _audit(cid, f"{action}_{'enabled' if data[f] else 'disabled'}", "contact", c.id, {"reason": c.marketing_preferences_reason})
+    db.session.commit(); return jsonify({"success": True, "contact": _contact_json(c)})
+
+
+@marketing_api_bp.post("/campaigns/<int:campaign_id>/send")
+@login_required
+def api_email_campaign_send(campaign_id):
+    c = Campaign.query.filter_by(id=campaign_id, company_id=tenant_id()).first_or_404()
+    contacts = _audience_query(c.company_id).all(); sent = 0; skipped = []
+    for contact in contacts:
+        reason = marketing_skip_reason(contact, "email")
+        if reason:
+            skipped.append({"contact_id": contact.id, "reason": reason})
+            _audit(c.company_id, "campaign_contact_skipped_suppression", "campaign", c.id, {"contact_id": contact.id, "reason": reason, "channel": "email"})
+            continue
+        db.session.add(CampaignRecipient(campaign_id=c.id, contact_id=contact.id)); sent += 1
+    c.status = "sent"; c.sent_at = datetime.utcnow(); db.session.commit()
+    return jsonify({"success": True, "sent": sent, "skipped": skipped})

--- a/migrations/20260618_segment_management_suppression.sql
+++ b/migrations/20260618_segment_management_suppression.sql
@@ -1,0 +1,25 @@
+-- Segment administration, membership provenance, and marketing suppression fields.
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS do_not_market BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS do_not_email BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS do_not_sms BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS email_unsubscribed BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS sms_opted_out BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS marketing_preferences_reason VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS marketing_preferences_source VARCHAR(120);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS marketing_preferences_updated_by_user_id INTEGER REFERENCES "user"(id);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS marketing_preferences_updated_at TIMESTAMP;
+
+ALTER TABLE segment ADD COLUMN IF NOT EXISTS category VARCHAR(120);
+ALTER TABLE segment ADD COLUMN IF NOT EXISTS match_mode VARCHAR(20) NOT NULL DEFAULT 'all';
+ALTER TABLE segment ADD COLUMN IF NOT EXISTS triggers JSON;
+ALTER TABLE segment ADD COLUMN IF NOT EXISTS actions JSON;
+ALTER TABLE segment ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE;
+
+ALTER TABLE segment_member ADD COLUMN IF NOT EXISTS source VARCHAR(80) NOT NULL DEFAULT 'manual';
+ALTER TABLE segment_member ADD COLUMN IF NOT EXISTS added_by_user_id INTEGER REFERENCES "user"(id);
+ALTER TABLE segment_member ADD COLUMN IF NOT EXISTS removed_at TIMESTAMP;
+ALTER TABLE segment_member ADD COLUMN IF NOT EXISTS removed_by_user_id INTEGER REFERENCES "user"(id);
+ALTER TABLE segment_member ADD COLUMN IF NOT EXISTS exclusion_reason VARCHAR(255);
+ALTER TABLE segment_member ADD COLUMN IF NOT EXISTS is_excluded BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_segment_member_contact ON segment_member(segment_id, contact_id);
+CREATE INDEX IF NOT EXISTS ix_segment_member_segment_contact ON segment_member(segment_id, contact_id);

--- a/models.py
+++ b/models.py
@@ -727,6 +727,15 @@ class Contact(db.Model):
     sms_marketing_opt_in_source = db.Column(db.String(120))
     sms_opt_out_at = db.Column(db.DateTime)
     sms_consent_status = db.Column(db.String(30), default="unknown", nullable=False)
+    do_not_market = db.Column(db.Boolean, default=False, nullable=False)
+    do_not_email = db.Column(db.Boolean, default=False, nullable=False)
+    do_not_sms = db.Column(db.Boolean, default=False, nullable=False)
+    email_unsubscribed = db.Column(db.Boolean, default=False, nullable=False)
+    sms_opted_out = db.Column(db.Boolean, default=False, nullable=False)
+    marketing_preferences_reason = db.Column(db.String(255))
+    marketing_preferences_source = db.Column(db.String(120))
+    marketing_preferences_updated_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    marketing_preferences_updated_at = db.Column(db.DateTime)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
 
@@ -1013,8 +1022,13 @@ class Segment(db.Model):
     name = db.Column(db.String(255), nullable=False)
     description = db.Column(db.Text, nullable=True)
     segment_type = db.Column(db.String(100), default="behavioral")
+    category = db.Column(db.String(120), nullable=True)
+    match_mode = db.Column(db.String(20), default="all", nullable=False)
+    triggers = db.Column(db.JSON, nullable=True)
     conditions = db.Column(db.JSON, nullable=True)
+    actions = db.Column(db.JSON, nullable=True)
     is_dynamic = db.Column(db.Boolean, default=False)
+    is_active = db.Column(db.Boolean, default=True, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
@@ -1027,7 +1041,18 @@ class SegmentMember(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     segment_id = db.Column(db.Integer, db.ForeignKey("segment.id"), nullable=False)
     contact_id = db.Column(db.Integer, db.ForeignKey("contact.id"), nullable=False)
+    source = db.Column(db.String(80), default="manual", nullable=False)
+    added_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
     added_at = db.Column(db.DateTime, default=datetime.utcnow)
+    removed_at = db.Column(db.DateTime)
+    removed_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    exclusion_reason = db.Column(db.String(255))
+    is_excluded = db.Column(db.Boolean, default=False, nullable=False)
+
+    __table_args__ = (
+        db.UniqueConstraint("segment_id", "contact_id", name="uq_segment_member_contact"),
+        db.Index("ix_segment_member_segment_contact", "segment_id", "contact_id"),
+    )
 
     contact = db.relationship("Contact", backref="segment_memberships")
 

--- a/routes.py
+++ b/routes.py
@@ -21,7 +21,7 @@ try:
         AutomationTest, AutomationTriggerLibrary, AutomationABTest, Company, user_company,
         Deal, LeadScore, PersonalizationRule, KeywordResearch,
         Notification, InboxMessage, CampaignCost, CRMTask, Meeting, SalesStage,
-        TouchpointEvent,
+        TouchpointEvent, MarketingAuditLog, User,
     )
     MODELS_AVAILABLE = True
 except ImportError as exc:
@@ -40,6 +40,7 @@ except ImportError as exc:
     Deal = LeadScore = PersonalizationRule = KeywordResearch = None
     Notification = InboxMessage = CampaignCost = None
     CRMTask = Meeting = SalesStage = TouchpointEvent = None
+    MarketingAuditLog = User = None
 try:
     from email_service import EmailService
 except ImportError as exc:
@@ -2169,21 +2170,21 @@ def billing_cancel():
 @login_required
 def refresh_segment(segment_id):
     """Refresh/recompile a segment to update its members"""
-    segment = Segment.query.get_or_404(segment_id)
+    segment = Segment.query.filter_by(id=segment_id, company_id=getattr(current_user, "default_company_id", None)).first_or_404()
     
     try:
-        SegmentMember.query.filter_by(segment_id=segment_id).delete()
+        SegmentMember.query.filter_by(segment_id=segment_id, is_excluded=False).delete()
         
-        contacts = Contact.query.all()
+        contacts = Contact.query.filter_by(company_id=segment.company_id).all()
         matched = 0
         
         for contact in contacts:
             if segment.segment_type == 'newsletter' and 'newsletter' in (contact.tags or ''):
-                member = SegmentMember(segment_id=segment_id, contact_id=contact.id)
+                member = SegmentMember(segment_id=segment_id, contact_id=contact.id, source="dynamic_rule")
                 db.session.add(member)
                 matched += 1
             elif segment.segment_type == 'all':
-                member = SegmentMember(segment_id=segment_id, contact_id=contact.id)
+                member = SegmentMember(segment_id=segment_id, contact_id=contact.id, source="dynamic_rule")
                 db.session.add(member)
                 matched += 1
         
@@ -2199,12 +2200,107 @@ def refresh_segment(segment_id):
     
     return redirect(url_for('main.segments'))
 
+
+
+def _segment_detail_metrics(segment):
+    """Build segment detail counts without mutating campaign state."""
+    today = datetime.utcnow().date()
+    memberships = SegmentMember.query.filter_by(segment_id=segment.id).all()
+    active_members = [m for m in memberships if not m.removed_at and not m.is_excluded]
+    excluded_members = [m for m in memberships if m.is_excluded]
+    contacts = [m.contact for m in active_members if m.contact and m.contact.company_id == segment.company_id]
+    suppressed = [c for c in contacts if c.do_not_market or c.do_not_email or c.do_not_sms or c.email_unsubscribed or c.sms_opted_out or c.sms_opt_out_at or not c.is_subscribed]
+    email_eligible = [c for c in contacts if c.email and not c.do_not_market and not c.do_not_email and not c.email_unsubscribed and c.is_subscribed]
+    sms_eligible = [c for c in contacts if c.phone and not c.do_not_market and not c.do_not_sms and not c.sms_opted_out and not c.sms_opt_out_at]
+    return {
+        "total_contacts": len(contacts),
+        "excluded_contacts": len(excluded_members),
+        "suppressed_contacts": len(suppressed),
+        "email_eligible": len(email_eligible),
+        "sms_eligible": len(sms_eligible),
+        "email_unsubscribed": sum(1 for c in contacts if c.email_unsubscribed or not c.is_subscribed),
+        "sms_opted_out": sum(1 for c in contacts if c.sms_opted_out or c.sms_opt_out_at),
+        "last_refreshed": segment.updated_at,
+        "added_today": sum(1 for m in memberships if m.added_at and m.added_at.date() == today),
+        "removed_today": sum(1 for m in memberships if m.removed_at and m.removed_at.date() == today),
+    }
+
+
+def _segment_member_view(member):
+    contact = member.contact
+    source = (member.source or "manual").lower()
+    source_badges = {
+        "manual": "Manual",
+        "dynamic_rule": "Dynamic",
+        "imported": "Imported",
+        "woocommerce": "WooCommerce",
+        "sms_opt_in": "SMS Opt-In",
+        "email_opt_in": "Email Opt-In",
+        "affiliate": "Affiliate",
+        "lux_verified": "LUX Verified",
+    }
+    badges = [source_badges.get(source, source.replace("_", " ").title())]
+    if contact:
+        if contact.do_not_market or contact.do_not_email or contact.do_not_sms or contact.email_unsubscribed or contact.sms_opted_out or contact.sms_opt_out_at or not contact.is_subscribed:
+            badges.append("Suppressed")
+        if contact.do_not_market: badges.append("Do Not Market")
+        if contact.do_not_email: badges.append("Do Not Email")
+        if contact.do_not_sms: badges.append("Do Not SMS")
+        if contact.sms_opted_out or contact.sms_opt_out_at: badges.append("SMS Opted Out")
+        if contact.email_unsubscribed or not contact.is_subscribed: badges.append("Email Unsubscribed")
+    return {"membership": member, "contact": contact, "badges": badges}
+
+
+@main_bp.route('/segments/<int:segment_id>')
+@login_required
+def segment_detail(segment_id):
+    """HTML segment detail dashboard with rules, contacts, exclusions, suppression, campaigns, and audit tabs."""
+    company_id = getattr(current_user, "default_company_id", None)
+    segment = Segment.query.filter_by(id=segment_id, company_id=company_id).first_or_404()
+    q = (request.args.get('q') or '').strip()
+    member_query = SegmentMember.query.filter_by(segment_id=segment.id, removed_at=None, is_excluded=False).join(Contact).filter(Contact.company_id == segment.company_id)
+    if q:
+        like = f"%{q}%"
+        member_query = member_query.filter(or_(Contact.email.ilike(like), Contact.first_name.ilike(like), Contact.last_name.ilike(like), Contact.phone.ilike(like)))
+    members = [_segment_member_view(m) for m in member_query.order_by(SegmentMember.added_at.desc()).all()]
+    excluded = [_segment_member_view(m) for m in SegmentMember.query.filter_by(segment_id=segment.id, is_excluded=True).order_by(SegmentMember.removed_at.desc()).all()]
+    metrics = _segment_detail_metrics(segment)
+    preview = metrics.copy()
+    audits = []
+    if MarketingAuditLog is not None:
+        audits = MarketingAuditLog.query.filter_by(company_id=segment.company_id, entity_type='segment', entity_id=segment.id).order_by(MarketingAuditLog.created_at.desc()).limit(50).all()
+    campaigns = {
+        "email": Campaign.query.filter_by(company_id=segment.company_id).order_by(Campaign.created_at.desc()).limit(10).all() if Campaign else [],
+        "sms": SMSCampaign.query.filter_by(company_id=segment.company_id, segment=segment.name).order_by(SMSCampaign.created_at.desc()).limit(10).all() if SMSCampaign else [],
+    }
+    return render_template('segment_detail.html', segment=segment, metrics=metrics, preview=preview, members=members, excluded=excluded, audits=audits, campaigns=campaigns, q=q)
+
+
+@main_bp.route('/segments/<int:segment_id>/excluded/<int:contact_id>/restore', methods=['POST'])
+@login_required
+def restore_segment_exclusion(segment_id, contact_id):
+    company_id = getattr(current_user, "default_company_id", None)
+    segment = Segment.query.filter_by(id=segment_id, company_id=company_id).first_or_404()
+    if not current_user.can_edit_company(company_id):
+        flash('You do not have permission to restore segment contacts.', 'danger')
+        return redirect(url_for('main.segment_detail', segment_id=segment.id))
+    member = SegmentMember.query.filter_by(segment_id=segment.id, contact_id=contact_id).first_or_404()
+    member.is_excluded = False
+    member.exclusion_reason = None
+    member.removed_at = None
+    member.removed_by_user_id = None
+    member.added_at = datetime.utcnow()
+    member.added_by_user_id = current_user.id
+    db.session.commit()
+    flash('Contact restored to segment.', 'success')
+    return redirect(url_for('main.segment_detail', segment_id=segment.id) + '#excluded')
+
 # Contact Segmentation Routes
 @main_bp.route('/segments')
 @login_required
 def segments():
     """Contact segmentation management"""
-    segments = Segment.query.all()
+    segments = Segment.query.filter_by(company_id=getattr(current_user, "default_company_id", None)).all()
     return render_template('segments.html', segments=segments)
 
 @main_bp.route('/segments/create', methods=['POST'])
@@ -2223,6 +2319,10 @@ def create_segment():
         segment.description = description
         segment.segment_type = segment_type
         segment.conditions = json.loads(conditions) if conditions else {}
+        segment.company_id = getattr(current_user, "default_company_id", None)
+        segment.match_mode = request.form.get("match_mode", "all")
+        segment.triggers = json.loads(request.form.get("triggers") or "[]")
+        segment.actions = json.loads(request.form.get("actions") or "[]")
         segment.is_dynamic = is_dynamic
         
         db.session.add(segment)
@@ -3577,7 +3677,8 @@ def create_sms_campaign():
                          contacts=contacts,
                          tags=tags,
                          templates=templates,
-                         segments=segments)
+                         segments=segments,
+                         selected_segment=(request.args.get('segment') or '').strip())
 
 @main_bp.route('/sms/campaign/<int:campaign_id>/edit', methods=['GET', 'POST'])
 @login_required
@@ -7460,7 +7561,7 @@ def lux_crm():
     company = current_user.get_default_company()
     
     deals = Deal.query.filter_by(company_id=company.id).all()
-    all_contacts = Contact.query.all()
+    all_contacts = Contact.query.filter_by(company_id=segment.company_id).all()
     lead_scores = LeadScore.query.all()
     personalization_rules = PersonalizationRule.query.filter_by(company_id=company.id).all()
     keywords = KeywordResearch.query.filter_by(company_id=company.id).all()
@@ -10431,12 +10532,17 @@ def create_campaign():
     except Exception:
         pass
     contact_lists = []
+    selected_segment = (request.args.get('segment') or '').strip()
     try:
         if Segment is not None:
-            contact_lists = Segment.query.all()
+            contact_lists_query = Segment.query
+            company_id = getattr(current_user, 'default_company_id', None)
+            if company_id and hasattr(Segment, 'company_id'):
+                contact_lists_query = contact_lists_query.filter_by(company_id=company_id)
+            contact_lists = contact_lists_query.order_by(Segment.name.asc()).all()
     except Exception:
         pass
-    return render_template('campaign_create.html', templates=tpl_list, segments=contact_lists, contacts=[])
+    return render_template('campaign_create.html', templates=tpl_list, segments=contact_lists, contacts=[], selected_segment=selected_segment)
 
 
 @main_bp.route('/campaigns/<int:campaign_id>/edit', methods=['GET', 'POST'])

--- a/templates/campaign_create.html
+++ b/templates/campaign_create.html
@@ -57,7 +57,7 @@
                     
                     <div class="mb-4">
                         <label for="recipient_tags" class="form-label">Recipient Tags</label>
-                        <input type="text" class="form-control" id="recipient_tags" name="recipient_tags" placeholder="customer, newsletter, vip">
+                        <input type="text" class="form-control" id="recipient_tags" name="recipient_tags" placeholder="customer, newsletter, vip" value="{{ selected_segment or '' }}">
                         <div class="form-text">
                             Leave empty to send to all contacts, or specify tags to filter recipients (comma-separated)
                         </div>
@@ -77,7 +77,7 @@
                             Campaign Setup
                         </h6>
                         <ul class="mb-0">
-                            <li>Recipients are selected based on active contacts matching the specified tags</li>
+                            <li>Recipients are selected based on active contacts matching the specified tags{% if selected_segment %}; segment <strong>{{ selected_segment }}</strong> is preselected from the segment detail page{% endif %}</li>
                             <li>If no tags are specified, the campaign will be sent to all active contacts</li>
                             <li>Scheduled campaigns will be sent automatically at the specified time</li>
                             <li>Draft campaigns can be sent manually from the campaigns page</li>

--- a/templates/create_sms_campaign.html
+++ b/templates/create_sms_campaign.html
@@ -64,9 +64,9 @@
                     <div class="mb-3">
                         <label for="segment_tags" class="form-label">Target Segment</label>
                         <input type="text" class="form-control" id="segment_tags" name="segment_tags" 
-                               placeholder="all, vip, customers (comma-separated)">
+                               placeholder="all, vip, customers (comma-separated)" value="{{ selected_segment or '' }}">
                         <small class="text-muted">
-                            Leave empty to send to all contacts with phone numbers
+                            Leave empty to send to all contacts with phone numbers{% if selected_segment %}; segment <strong>{{ selected_segment }}</strong> is preselected from the segment detail page{% endif %}
                         </small>
                     </div>
                     

--- a/templates/segment_detail.html
+++ b/templates/segment_detail.html
@@ -1,0 +1,351 @@
+{% extends "base.html" %}
+
+{% block title %}{{ segment.name }} - Segment Detail{% endblock %}
+
+{% macro badge(label) -%}
+  {% set palette = {
+    'Manual': 'bg-primary', 'Dynamic': 'bg-success', 'WooCommerce': 'bg-warning text-dark',
+    'SMS Opt-In': 'bg-info text-dark', 'Email Opt-In': 'bg-info text-dark', 'Affiliate': 'bg-purple',
+    'LUX Verified': 'bg-dark', 'Suppressed': 'bg-danger', 'Do Not Market': 'bg-danger',
+    'Do Not Email': 'bg-danger', 'Do Not SMS': 'bg-danger', 'SMS Opted Out': 'bg-secondary',
+    'Email Unsubscribed': 'bg-secondary', 'Imported': 'bg-secondary'
+  } %}
+  <span class="badge {{ palette.get(label, 'bg-secondary') }} me-1">{{ label }}</span>
+{%- endmacro %}
+
+{% macro contact_name(contact) -%}
+  {% if contact %}
+    <strong>{{ (contact.first_name or '') ~ ' ' ~ (contact.last_name or '') }}</strong>
+    <div class="small text-muted">{{ contact.email or 'No email' }}{% if contact.phone %} · {{ contact.phone }}{% endif %}</div>
+  {% else %}
+    <span class="text-muted">Missing contact</span>
+  {% endif %}
+{%- endmacro %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-start mb-4">
+  <div>
+    <h1 class="mb-1"><i data-feather="filter"></i> {{ segment.name }}</h1>
+    <p class="text-muted mb-0">{{ segment.description or 'No description provided.' }}</p>
+  </div>
+  <div class="btn-toolbar gap-2">
+    <button type="button" class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#previewSegmentModal">
+      <i data-feather="eye"></i> Preview Segment
+    </button>
+    <form method="POST" action="{{ url_for('main.refresh_segment', segment_id=segment.id) }}" class="d-inline">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      <button type="submit" class="btn btn-outline-success"><i data-feather="refresh-cw"></i> Refresh Segment</button>
+    </form>
+    <button type="button" class="btn btn-outline-dark" disabled title="Coming soon">
+      <i data-feather="cpu"></i> Optimize Segment with AI <span class="badge bg-secondary">Coming soon</span>
+    </button>
+    <a class="btn btn-primary" href="{{ url_for('main.create_campaign') }}?segment={{ segment.name|urlencode }}">
+      <i data-feather="mail"></i> Create Email Campaign from Segment
+    </a>
+    <a class="btn btn-success" href="{{ url_for('main.create_sms_campaign') }}?segment={{ segment.name|urlencode }}">
+      <i data-feather="message-square"></i> Create SMS Campaign from Segment
+    </a>
+    <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#deleteSegmentModal">
+      <i data-feather="trash-2"></i> Delete Segment
+    </button>
+  </div>
+</div>
+
+<div class="row g-3 mb-4">
+  {% set cards = [
+    ('Total Contacts', metrics.total_contacts, 'users'),
+    ('Excluded Contacts', metrics.excluded_contacts, 'user-x'),
+    ('Suppressed Contacts', metrics.suppressed_contacts, 'slash'),
+    ('Email Eligible', metrics.email_eligible, 'mail'),
+    ('SMS Eligible', metrics.sms_eligible, 'message-square'),
+    ('Email Unsubscribed', metrics.email_unsubscribed, 'mail'),
+    ('SMS Opted Out', metrics.sms_opted_out, 'message-circle'),
+    ('Last Refreshed', metrics.last_refreshed.strftime('%Y-%m-%d %H:%M') if metrics.last_refreshed else '-', 'clock'),
+    ('Added Today', metrics.added_today, 'user-plus'),
+    ('Removed Today', metrics.removed_today, 'user-minus')
+  ] %}
+  {% for label, value, icon in cards %}
+  <div class="col-sm-6 col-lg-3 col-xl-2">
+    <div class="card h-100">
+      <div class="card-body">
+        <div class="text-muted small"><i data-feather="{{ icon }}"></i> {{ label }}</div>
+        <div class="fs-4 fw-bold">{{ value }}</div>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+<ul class="nav nav-tabs" id="segmentTabs" role="tablist">
+  {% for tab in ['Overview', 'Rules', 'Contacts', 'Excluded', 'Suppression', 'Campaigns', 'Audit'] %}
+  <li class="nav-item" role="presentation">
+    <button class="nav-link {% if loop.first %}active{% endif %}" id="{{ tab|lower }}-tab" data-bs-toggle="tab" data-bs-target="#{{ tab|lower }}" type="button" role="tab">{{ tab }}</button>
+  </li>
+  {% endfor %}
+</ul>
+
+<div class="tab-content border border-top-0 p-4 bg-body" id="segmentTabsContent">
+  <div class="tab-pane fade show active" id="overview" role="tabpanel">
+    <div class="row">
+      <div class="col-lg-8">
+        <h4>Segment Overview</h4>
+        <p>{{ segment.description or 'Use the tabs above to manage rules, contacts, exclusions, suppression, campaigns, and audit history.' }}</p>
+        <dl class="row">
+          <dt class="col-sm-3">Type</dt><dd class="col-sm-9">{{ segment.segment_type }}</dd>
+          <dt class="col-sm-3">Category</dt><dd class="col-sm-9">{{ segment.category or '-' }}</dd>
+          <dt class="col-sm-3">Status</dt><dd class="col-sm-9">{{ 'Active' if segment.is_active else 'Inactive' }}</dd>
+          <dt class="col-sm-3">Dynamic</dt><dd class="col-sm-9">{{ 'Yes' if segment.is_dynamic else 'No' }}</dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+
+  <div class="tab-pane fade" id="rules" role="tabpanel">
+    <div class="d-flex justify-content-between mb-3">
+      <h4>Rules</h4>
+      <button class="btn btn-outline-primary segment-edit" data-segment-id="{{ segment.id }}"><i data-feather="edit"></i> Edit Rules</button>
+    </div>
+    <div class="mb-3"><strong>Match Mode:</strong> {{ (segment.match_mode or 'all')|upper }}</div>
+    <div class="mb-3"><strong>State:</strong> <span class="badge {{ 'bg-success' if segment.is_active else 'bg-secondary' }}">{{ 'Active' if segment.is_active else 'Inactive' }}</span></div>
+    <div class="row">
+      <div class="col-md-4"><h5>Triggers</h5><pre class="bg-light p-3 rounded">{{ (segment.triggers or [])|tojson(indent=2) }}</pre></div>
+      <div class="col-md-4"><h5>Conditions</h5><pre class="bg-light p-3 rounded">{{ (segment.conditions or [])|tojson(indent=2) }}</pre></div>
+      <div class="col-md-4"><h5>Actions</h5><pre class="bg-light p-3 rounded">{{ (segment.actions or [])|tojson(indent=2) }}</pre></div>
+    </div>
+  </div>
+
+  <div class="tab-pane fade" id="contacts" role="tabpanel">
+    <div class="d-flex flex-wrap justify-content-between gap-2 mb-3">
+      <form method="GET" action="{{ url_for('main.segment_detail', segment_id=segment.id) }}" class="d-flex gap-2">
+        <input class="form-control" name="q" value="{{ q }}" placeholder="Search contacts by name, email, or phone">
+        <button class="btn btn-outline-secondary" type="submit">Search</button>
+      </form>
+      <div class="btn-group">
+        <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#addContactModal">Add Contact</button>
+        <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#bulkAddModal">Bulk Add</button>
+      </div>
+    </div>
+    <div class="mb-3">
+      <label class="form-label fw-bold">Bulk Actions</label>
+      <div class="btn-group flex-wrap" role="group">
+        <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#bulkAddModal">Add to Segment</button>
+        <button class="btn btn-sm btn-outline-secondary" id="bulkRemoveSelected">Remove from Segment</button>
+        <button class="btn btn-sm btn-outline-danger" id="bulkExcludeSelected">Permanently Exclude</button>
+        <button class="btn btn-sm btn-outline-secondary" disabled title="Coming soon">Add Tag <span class="badge bg-secondary">Coming soon</span></button>
+        <button class="btn btn-sm btn-outline-secondary" disabled title="Coming soon">Remove Tag <span class="badge bg-secondary">Coming soon</span></button>
+        <button class="btn btn-sm btn-outline-secondary" disabled title="Coming soon">Export <span class="badge bg-secondary">Coming soon</span></button>
+        <button class="btn btn-sm btn-outline-secondary" disabled title="Coming soon">Start Campaign <span class="badge bg-secondary">Coming soon</span></button>
+      </div>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-hover align-middle">
+        <thead><tr><th><input type="checkbox" aria-label="Select all contacts"></th><th>Contact</th><th>Badges</th><th>Membership Source</th><th>Added</th><th>Added By</th><th>Reason/Source</th><th>Actions</th></tr></thead>
+        <tbody>
+          {% for row in members %}
+          <tr>
+            <td><input class="segment-contact-checkbox" type="checkbox" value="{{ row.contact.id if row.contact else '' }}" aria-label="Select contact {{ row.contact.id if row.contact else '' }}"></td>
+            <td>{{ contact_name(row.contact) }}</td>
+            <td>{% for label in row.badges %}{{ badge(label) }}{% endfor %}</td>
+            <td>{{ row.membership.source }}</td>
+            <td>{{ row.membership.added_at.strftime('%Y-%m-%d') if row.membership.added_at else '-' }}</td>
+            <td>{{ row.membership.added_by_user_id or '-' }}</td>
+            <td>{{ row.contact.source if row.contact and row.contact.source else row.membership.exclusion_reason or '-' }}</td>
+            <td>
+              <div class="btn-group btn-group-sm">
+                <button class="btn btn-outline-secondary remove-contact" data-segment-id="{{ segment.id }}" data-contact-id="{{ row.contact.id if row.contact else '' }}">Remove Contact</button>
+                <button class="btn btn-outline-danger exclude-contact" data-segment-id="{{ segment.id }}" data-contact-id="{{ row.contact.id if row.contact else '' }}">Permanent Exclusion</button>
+              </div>
+            </td>
+          </tr>
+          {% else %}
+          <tr><td colspan="8" class="text-center text-muted py-4">No contacts in this segment.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="tab-pane fade" id="excluded" role="tabpanel">
+    <h4>Permanently Excluded Contacts</h4>
+    <div class="table-responsive">
+      <table class="table table-hover align-middle">
+        <thead><tr><th>Contact</th><th>Exclusion Reason</th><th>Excluded By</th><th>Excluded Date</th><th>Actions</th></tr></thead>
+        <tbody>
+          {% for row in excluded %}
+          <tr>
+            <td>{{ contact_name(row.contact) }}</td>
+            <td>{{ row.membership.exclusion_reason or '-' }}</td>
+            <td>{{ row.membership.removed_by_user_id or '-' }}</td>
+            <td>{{ row.membership.removed_at.strftime('%Y-%m-%d %H:%M') if row.membership.removed_at else '-' }}</td>
+            <td>
+              <form method="POST" action="{{ url_for('main.restore_segment_exclusion', segment_id=segment.id, contact_id=row.contact.id) if row.contact else '#' }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                <button class="btn btn-sm btn-outline-success" type="submit">Restore</button>
+              </form>
+            </td>
+          </tr>
+          {% else %}
+          <tr><td colspan="5" class="text-center text-muted py-4">No permanently excluded contacts.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="tab-pane fade" id="suppression" role="tabpanel">
+    <h4>Suppression Summary</h4>
+    <p class="text-muted">Campaign sends from this segment still enforce Do Not Market and channel opt-out precedence.</p>
+    <ul>
+      <li>Suppressed Contacts: {{ metrics.suppressed_contacts }}</li>
+      <li>Do Not Market / Email / SMS badges are shown in the Contacts tab.</li>
+      <li>Email Eligible: {{ metrics.email_eligible }}</li>
+      <li>SMS Eligible: {{ metrics.sms_eligible }}</li>
+      <li>Email Unsubscribed: {{ metrics.email_unsubscribed }}</li>
+      <li>SMS Opted Out: {{ metrics.sms_opted_out }}</li>
+    </ul>
+  </div>
+
+  <div class="tab-pane fade" id="campaigns" role="tabpanel">
+    <div class="mb-3">
+      <a class="btn btn-primary" href="{{ url_for('main.create_campaign') }}?segment={{ segment.name|urlencode }}">Create Email Campaign from Segment</a>
+      <a class="btn btn-success" href="{{ url_for('main.create_sms_campaign') }}?segment={{ segment.name|urlencode }}">Create SMS Campaign from Segment</a>
+    </div>
+    <h5>Recent Email Campaigns</h5>
+    <ul>{% for campaign in campaigns.email %}<li>{{ campaign.name }} — {{ campaign.status or 'draft' }}</li>{% else %}<li class="text-muted">No recent email campaigns.</li>{% endfor %}</ul>
+    <h5>Recent SMS Campaigns for this Segment</h5>
+    <ul>{% for campaign in campaigns.sms %}<li>{{ campaign.name }} — {{ campaign.status or 'draft' }}</li>{% else %}<li class="text-muted">No recent SMS campaigns.</li>{% endfor %}</ul>
+  </div>
+
+  <div class="tab-pane fade" id="audit" role="tabpanel">
+    <h4>Audit</h4>
+    <div class="table-responsive">
+      <table class="table table-sm"><thead><tr><th>Event</th><th>User</th><th>Date</th><th>Details</th></tr></thead><tbody>
+        {% for audit in audits %}
+        <tr><td>{{ audit.action }}</td><td>{{ audit.created_by_user_id or '-' }}</td><td>{{ audit.created_at.strftime('%Y-%m-%d %H:%M') if audit.created_at else '-' }}</td><td><code>{{ audit.details|tojson }}</code></td></tr>
+        {% else %}<tr><td colspan="4" class="text-muted text-center py-4">No audit events yet.</td></tr>{% endfor %}
+      </tbody></table>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="previewSegmentModal" tabindex="-1">
+  <div class="modal-dialog"><div class="modal-content">
+    <div class="modal-header"><h5 class="modal-title">Preview Segment</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+    <div class="modal-body">
+      <p class="text-muted">Preview only. This does not send campaigns.</p>
+      <ul class="list-group">
+        <li class="list-group-item d-flex justify-content-between"><span>Matched Contacts</span><strong>{{ preview.total_contacts }}</strong></li>
+        <li class="list-group-item d-flex justify-content-between"><span>Excluded Contacts</span><strong>{{ preview.excluded_contacts }}</strong></li>
+        <li class="list-group-item d-flex justify-content-between"><span>Suppressed Contacts</span><strong>{{ preview.suppressed_contacts }}</strong></li>
+        <li class="list-group-item d-flex justify-content-between"><span>Email Eligible</span><strong>{{ preview.email_eligible }}</strong></li>
+        <li class="list-group-item d-flex justify-content-between"><span>SMS Eligible</span><strong>{{ preview.sms_eligible }}</strong></li>
+      </ul>
+    </div>
+  </div></div>
+</div>
+
+<div class="modal fade" id="deleteSegmentModal" tabindex="-1">
+  <div class="modal-dialog"><div class="modal-content">
+    <div class="modal-header"><h5 class="modal-title">Delete Segment</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+    <div class="modal-body">
+      <p>Deleting this segment will remove segment membership links and rules, but will not delete contacts or campaign history.</p>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+      <button type="button" class="btn btn-danger segment-delete-confirm" data-segment-id="{{ segment.id }}">Delete Segment</button>
+    </div>
+  </div></div>
+</div>
+
+<div class="modal fade" id="addContactModal" tabindex="-1"><div class="modal-dialog modal-lg"><div class="modal-content">
+  <div class="modal-header"><h5 class="modal-title">Add Contact</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+  <div class="modal-body">
+    <label class="form-label" for="contactPickerSearch">Search by name, phone, email, or company</label>
+    <input class="form-control" id="contactPickerSearch" placeholder="Search contacts...">
+    <div class="list-group mt-3" id="contactPickerResults"></div>
+  </div>
+</div></div></div>
+
+<div class="modal fade" id="bulkAddModal" tabindex="-1"><div class="modal-dialog modal-lg"><div class="modal-content">
+  <div class="modal-header"><h5 class="modal-title">Bulk Add Contacts</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+  <div class="modal-body">
+    <label class="form-label" for="bulkContactSearch">Search by name, phone, email, or company</label>
+    <input class="form-control" id="bulkContactSearch" placeholder="Search contacts to bulk add...">
+    <div class="list-group mt-3" id="bulkContactResults"></div>
+  </div>
+  <div class="modal-footer"><button class="btn btn-primary" id="bulkAddButton">Bulk Add Selected</button></div>
+</div></div></div>
+
+<script>
+document.querySelectorAll('.segment-edit').forEach(el => el.addEventListener('click', async () => {
+  const name = prompt('Segment name', '{{ segment.name|e }}'); if (!name) return;
+  const description = prompt('Description', '{{ (segment.description or '')|e }}') || '';
+  await fetch(`/api/segments/${el.dataset.segmentId}`, {method: 'PATCH', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({name, description})});
+  window.location.reload();
+}));
+document.querySelector('.segment-delete-confirm')?.addEventListener('click', async (e) => {
+  const res = await fetch(`/api/segments/${e.target.dataset.segmentId}`, {method: 'DELETE'});
+  if (res.ok) window.location.href = '{{ url_for('main.segments') }}';
+});
+document.querySelectorAll('.remove-contact').forEach(el => el.addEventListener('click', async () => {
+  await fetch(`/api/segments/${el.dataset.segmentId}/contacts/${el.dataset.contactId}`, {method: 'DELETE'});
+  window.location.reload();
+}));
+document.querySelectorAll('.exclude-contact').forEach(el => el.addEventListener('click', async () => {
+  await fetch(`/api/segments/${el.dataset.segmentId}/contacts/${el.dataset.contactId}/exclude`, {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({reason: 'manual permanent exclusion'})});
+  window.location.reload();
+}));
+function selectedSegmentContactIds() {
+  return Array.from(document.querySelectorAll('.segment-contact-checkbox:checked')).map(el => Number(el.value)).filter(Boolean);
+}
+async function searchContacts(term, containerId, multi=false) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  if (!term || term.length < 2) { container.innerHTML = '<div class="text-muted small p-2">Type at least 2 characters to search.</div>'; return; }
+  const response = await fetch(`/api/contacts/search?q=${encodeURIComponent(term)}`);
+  const payload = await response.json();
+  const contacts = payload.contacts || [];
+  container.innerHTML = contacts.length ? contacts.map(contact => {
+    const label = `${contact.first_name || ''} ${contact.last_name || ''}`.trim() || contact.email || contact.phone || `Contact ${contact.id}`;
+    const meta = [contact.email, contact.phone].filter(Boolean).join(' · ');
+    if (multi) {
+      return `<label class="list-group-item d-flex gap-2 align-items-start"><input class="form-check-input bulk-contact-picker" type="checkbox" value="${contact.id}"><span><strong>${label}</strong><br><small class="text-muted">${meta}</small></span></label>`;
+    }
+    return `<button type="button" class="list-group-item list-group-item-action add-contact-result" data-contact-id="${contact.id}"><strong>${label}</strong><br><small class="text-muted">${meta}</small></button>`;
+  }).join('') : '<div class="text-muted small p-2">No contacts found.</div>';
+}
+let contactSearchTimer;
+document.getElementById('contactPickerSearch')?.addEventListener('input', (event) => {
+  clearTimeout(contactSearchTimer);
+  contactSearchTimer = setTimeout(() => searchContacts(event.target.value, 'contactPickerResults', false), 250);
+});
+document.getElementById('bulkContactSearch')?.addEventListener('input', (event) => {
+  clearTimeout(contactSearchTimer);
+  contactSearchTimer = setTimeout(() => searchContacts(event.target.value, 'bulkContactResults', true), 250);
+});
+document.getElementById('contactPickerResults')?.addEventListener('click', async (event) => {
+  const button = event.target.closest('.add-contact-result');
+  if (!button) return;
+  await fetch(`/api/segments/{{ segment.id }}/contacts`, {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({contact_id: Number(button.dataset.contactId)})});
+  window.location.reload();
+});
+document.getElementById('bulkAddButton')?.addEventListener('click', async () => {
+  const ids = Array.from(document.querySelectorAll('.bulk-contact-picker:checked')).map(el => Number(el.value)).filter(Boolean);
+  if (!ids.length) return;
+  await fetch(`/api/segments/{{ segment.id }}/contacts/bulk-add`, {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({contact_ids: ids})});
+  window.location.reload();
+});
+document.getElementById('bulkRemoveSelected')?.addEventListener('click', async () => {
+  const ids = selectedSegmentContactIds();
+  if (!ids.length) return alert('Select at least one contact.');
+  await fetch(`/api/segments/{{ segment.id }}/contacts/bulk-remove`, {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({contact_ids: ids})});
+  window.location.reload();
+});
+document.getElementById('bulkExcludeSelected')?.addEventListener('click', async () => {
+  const ids = selectedSegmentContactIds();
+  if (!ids.length) return alert('Select at least one contact.');
+  await Promise.all(ids.map(id => fetch(`/api/segments/{{ segment.id }}/contacts/${id}/exclude`, {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({reason: 'bulk permanent exclusion'})})));
+  window.location.reload();
+});
+</script>
+{% endblock %}

--- a/templates/segments.html
+++ b/templates/segments.html
@@ -1,6 +1,28 @@
 {% extends "base.html" %}
 
-{% block title %}Contact Segmentation - Email Marketing Automation{% endblock %}
+{% block title %}Contact Segmentation - Email Marketing Automation<script>
+document.querySelectorAll('.segment-active-toggle').forEach(el => el.addEventListener('change', async (e) => {
+  await fetch(`/api/segments/${e.target.dataset.segmentId}`, {method: 'PATCH', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({is_active: e.target.checked})});
+  window.location.reload();
+}));
+document.querySelectorAll('.segment-copy').forEach(el => el.addEventListener('click', async () => { await fetch(`/api/segments/${el.dataset.segmentId}/copy`, {method: 'POST'}); window.location.reload(); }));
+document.querySelectorAll('.segment-delete').forEach(el => el.addEventListener('click', async () => { const modal = document.getElementById('deleteSegmentModal'); modal.dataset.segmentId = el.dataset.segmentId; new bootstrap.Modal(modal).show();}));
+document.querySelectorAll('.segment-edit').forEach(el => el.addEventListener('click', async () => {
+  const name = prompt('Rename segment'); if (!name) return;
+  await fetch(`/api/segments/${el.dataset.segmentId}`, {method: 'PATCH', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({name})}); window.location.reload();
+}));
+</script>
+<div class="modal fade" id="deleteSegmentModal" tabindex="-1">
+  <div class="modal-dialog"><div class="modal-content">
+    <div class="modal-header"><h5 class="modal-title">Delete Segment</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+    <div class="modal-body">Deleting this segment will remove segment membership links and rules, but will not delete contacts or campaign history.</div>
+    <div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button><button type="button" class="btn btn-danger" id="confirmDeleteSegment">Delete Segment</button></div>
+  </div></div>
+</div>
+<script>
+document.getElementById('confirmDeleteSegment')?.addEventListener('click', async () => { const id = document.getElementById('deleteSegmentModal').dataset.segmentId; await fetch(`/api/segments/${id}`, {method: 'DELETE'}); window.location.reload(); });
+</script>
+{% endblock %}
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
@@ -22,6 +44,7 @@
                         <th>Type</th>
                         <th>Members</th>
                         <th>Dynamic</th>
+                        <th>Status</th>
                         <th>Created</th>
                         <th>Actions</th>
                     </tr>
@@ -47,12 +70,21 @@
                                 <span class="badge bg-secondary">Static</span>
                             {% endif %}
                         </td>
+                        <td>
+                            <label class="form-check form-switch mb-0" title="Active/Inactive">
+                                <input class="form-check-input segment-active-toggle" type="checkbox" data-segment-id="{{ segment.id }}" {% if segment.is_active %}checked{% endif %}>
+                                <span class="badge {% if segment.is_active %}bg-success{% else %}bg-secondary{% endif %}">{{ 'Active' if segment.is_active else 'Inactive' }}</span>
+                            </label>
+                        </td>
                         <td>{{ segment.created_at.strftime('%Y-%m-%d') if segment.created_at else '-' }}</td>
                         <td>
                             <div class="btn-group btn-group-sm">
-                                <button class="btn btn-outline-primary" title="View Members">
+                                <a href="{{ url_for('main.segment_detail', segment_id=segment.id) }}" class="btn btn-outline-primary" title="View Contacts">
                                     <i data-feather="users"></i>
-                                </button>
+                                </a>
+                                <button type="button" class="btn btn-outline-secondary segment-edit" data-segment-id="{{ segment.id }}" title="Edit"><i data-feather="edit"></i></button>
+                                <button type="button" class="btn btn-outline-info segment-copy" data-segment-id="{{ segment.id }}" title="Copy"><i data-feather="copy"></i></button>
+                                <button type="button" class="btn btn-outline-danger segment-delete" data-segment-id="{{ segment.id }}" title="Delete"><i data-feather="trash-2"></i></button>
                                 <form method="POST" action="{{ url_for('main.refresh_segment', segment_id=segment.id) }}" class="d-inline">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                                     <button type="submit" class="btn btn-outline-success" title="Refresh/Compile Segment">
@@ -140,9 +172,17 @@
                     </div>
                     
                     <div class="mb-3">
+                        <label for="match_mode" class="form-label">Match Mode</label>
+                        <select class="form-select mb-3" id="match_mode" name="match_mode"><option value="all">Match ALL</option><option value="any">Match ANY</option></select>
+                        <label for="triggers" class="form-label">Behavioral Triggers (JSON array)</label>
+                        <textarea class="form-control mb-3" id="triggers" name="triggers" rows="2" placeholder='[{"type":"purchase_completed"}]'></textarea>
                         <label for="conditions" class="form-label">Conditions (JSON)</label>
                         <textarea class="form-control" id="conditions" name="conditions" rows="4" placeholder='{"tag": "customer", "opened_emails": true}'></textarea>
                         <div class="form-text">Define segment criteria as JSON. Leave empty for manual selection.</div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="actions" class="form-label">Actions (JSON array)</label>
+                        <textarea class="form-control" id="actions" name="actions" rows="2" placeholder='[{"type":"add_to_campaign"}]'></textarea>
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -153,4 +193,26 @@
         </div>
     </div>
 </div>
+<script>
+document.querySelectorAll('.segment-active-toggle').forEach(el => el.addEventListener('change', async (e) => {
+  await fetch(`/api/segments/${e.target.dataset.segmentId}`, {method: 'PATCH', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({is_active: e.target.checked})});
+  window.location.reload();
+}));
+document.querySelectorAll('.segment-copy').forEach(el => el.addEventListener('click', async () => { await fetch(`/api/segments/${el.dataset.segmentId}/copy`, {method: 'POST'}); window.location.reload(); }));
+document.querySelectorAll('.segment-delete').forEach(el => el.addEventListener('click', async () => { const modal = document.getElementById('deleteSegmentModal'); modal.dataset.segmentId = el.dataset.segmentId; new bootstrap.Modal(modal).show();}));
+document.querySelectorAll('.segment-edit').forEach(el => el.addEventListener('click', async () => {
+  const name = prompt('Rename segment'); if (!name) return;
+  await fetch(`/api/segments/${el.dataset.segmentId}`, {method: 'PATCH', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({name})}); window.location.reload();
+}));
+</script>
+<div class="modal fade" id="deleteSegmentModal" tabindex="-1">
+  <div class="modal-dialog"><div class="modal-content">
+    <div class="modal-header"><h5 class="modal-title">Delete Segment</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+    <div class="modal-body">Deleting this segment will remove segment membership links and rules, but will not delete contacts or campaign history.</div>
+    <div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button><button type="button" class="btn btn-danger" id="confirmDeleteSegment">Delete Segment</button></div>
+  </div></div>
+</div>
+<script>
+document.getElementById('confirmDeleteSegment')?.addEventListener('click', async () => { const id = document.getElementById('deleteSegmentModal').dataset.segmentId; await fetch(`/api/segments/${id}`, {method: 'DELETE'}); window.location.reload(); });
+</script>
 {% endblock %}

--- a/tests/test_segment_management_suppression.py
+++ b/tests/test_segment_management_suppression.py
@@ -1,0 +1,229 @@
+import os
+from datetime import datetime
+import pytest
+
+from app import create_app
+from extensions import db
+from models import Campaign, CampaignRecipient, Company, Contact, MarketingAuditLog, Segment, SegmentMember, SMSCampaign, SMSRecipient, User, user_company
+
+
+@pytest.fixture
+def app():
+    os.environ["FLASK_ENV"] = "testing"
+    app = create_app()
+    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def tenant_user(client):
+    company = Company(name="Segments Co")
+    user = User(username="admin", email="admin@example.com", default_company_id=None, is_admin=True)
+    user.password_hash = "testpass"
+    db.session.add_all([company, user]); db.session.flush()
+    user.default_company_id = company.id
+    db.session.execute(user_company.insert().values(user_id=user.id, company_id=company.id, is_default=True))
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id); sess["_fresh"] = True
+    return user, company
+
+
+def test_admin_can_edit_copy_delete_segment_without_deleting_contacts(client, tenant_user):
+    _, company = tenant_user
+    contact = Contact(company_id=company.id, email="a@example.com")
+    seg = Segment(company_id=company.id, name="VIP", description="old", segment_type="behavioral", category="buyers", match_mode="all", triggers=[{"t": 1}], conditions=[{"field": "tag", "value": "vip"}], actions=[{"a": 1}], is_active=True)
+    db.session.add_all([contact, seg]); db.session.flush()
+    db.session.add(SegmentMember(segment_id=seg.id, contact_id=contact.id, source="manual")); db.session.commit()
+
+    edit = client.patch(f"/api/segments/{seg.id}", json={"name": "VIP Renamed", "description": "new", "is_active": False})
+    assert edit.status_code == 200
+    assert edit.get_json()["segment"]["name"] == "VIP Renamed"
+
+    copy = client.post(f"/api/segments/{seg.id}/copy")
+    assert copy.status_code == 201
+    copied = Segment.query.get(copy.get_json()["segment"]["id"])
+    assert copied.name == "VIP Renamed Copy"
+    assert copied.description == "new"
+    assert copied.conditions == seg.conditions
+    assert copied.is_active is False
+    assert MarketingAuditLog.query.filter_by(entity_id=copied.id, action="segment_created").count() == 0
+
+    delete = client.delete(f"/api/segments/{seg.id}")
+    assert delete.status_code == 200
+    assert Contact.query.get(contact.id) is not None
+    assert SegmentMember.query.filter_by(segment_id=seg.id).count() == 0
+
+
+def test_manual_add_remove_and_bulk_contacts(client, tenant_user):
+    _, company = tenant_user
+    seg = Segment(company_id=company.id, name="Manual")
+    contacts = [Contact(company_id=company.id, email=f"c{i}@example.com") for i in range(3)]
+    db.session.add(seg); db.session.add_all(contacts); db.session.commit()
+
+    assert client.post(f"/api/segments/{seg.id}/contacts", json={"contact_id": contacts[0].id}).status_code == 201
+    assert client.post(f"/api/segments/{seg.id}/contacts/bulk-add", json={"contact_ids": [contacts[1].id, contacts[2].id]}).get_json()["added"] == 2
+    listed = client.get(f"/api/segments/{seg.id}/contacts?q=c1").get_json()["contacts"]
+    assert len(listed) == 1 and listed[0]["membership"]["source"] == "manual"
+    assert client.delete(f"/api/segments/{seg.id}/contacts/{contacts[1].id}").status_code == 200
+    assert client.post(f"/api/segments/{seg.id}/contacts/bulk-remove", json={"contact_ids": [contacts[0].id, contacts[2].id]}).get_json()["removed"] == 2
+
+
+def test_permanent_exclusion_prevents_dynamic_readd(client, tenant_user):
+    _, company = tenant_user
+    contact = Contact(company_id=company.id, email="vip@example.com", tags="vip", is_active=True)
+    seg = Segment(company_id=company.id, name="Dynamic", is_dynamic=True, conditions=[{"field": "tag", "value": "vip"}])
+    db.session.add_all([contact, seg]); db.session.commit()
+    assert len(client.get(f"/api/segments/{seg.id}/contacts").get_json()["contacts"]) == 1
+    assert client.post(f"/api/segments/{seg.id}/contacts/{contact.id}/exclude", json={"reason": "requested"}).status_code == 200
+    assert len(client.get(f"/api/segments/{seg.id}/contacts").get_json()["contacts"]) == 0
+
+
+def test_marketing_preferences_precedence_email_and_sms(client, tenant_user, monkeypatch):
+    _, company = tenant_user
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "ACtest"); monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token"); monkeypatch.setenv("TWILIO_PHONE_NUMBER", "+15559999999")
+    email_ok_sms_block = Contact(company_id=company.id, email="emailok@example.com", phone="+15550000001", tags="sms_consent", is_active=True, is_subscribed=True, do_not_sms=True)
+    sms_ok_email_block = Contact(company_id=company.id, email="smsok@example.com", phone="+15550000002", tags="sms_consent", is_active=True, is_subscribed=True, do_not_email=True)
+    all_block = Contact(company_id=company.id, email="all@example.com", phone="+15550000003", tags="sms_consent", is_active=True, is_subscribed=True, do_not_market=True)
+    sms_opted = Contact(company_id=company.id, email="optedsms@example.com", phone="+15550000004", tags="sms_consent", is_active=True, is_subscribed=True, sms_opted_out=True)
+    email_unsub = Contact(company_id=company.id, email="unsub@example.com", phone="+15550000005", tags="sms_consent", is_active=True, is_subscribed=True, email_unsubscribed=True)
+    db.session.add_all([email_ok_sms_block, sms_ok_email_block, all_block, sms_opted, email_unsub]); db.session.flush()
+    email_campaign = Campaign(company_id=company.id, name="Email", status="draft")
+    sms_campaign = SMSCampaign(company_id=company.id, name="SMS", message="Hi Reply STOP to opt out.", segment=None, status="draft")
+    db.session.add_all([email_campaign, sms_campaign]); db.session.commit()
+
+    e = client.post(f"/api/marketing/campaigns/{email_campaign.id}/send").get_json()
+    assert {s["reason"] for s in e["skipped"]} >= {"do_not_market", "do_not_email", "email_unsubscribed"}
+    assert CampaignRecipient.query.filter_by(campaign_id=email_campaign.id, contact_id=email_ok_sms_block.id).count() == 1
+
+    sms_campaign.segment = None
+    # Use legacy audience path by setting all contacts active and a segment value.
+    for c in [email_ok_sms_block, sms_ok_email_block, all_block, sms_opted, email_unsub]:
+        c.segment = "all"
+    sms_campaign.segment = "all"; db.session.commit()
+    s = client.post(f"/api/marketing/sms-campaigns/{sms_campaign.id}/send")
+    assert s.status_code == 200
+    assert SMSRecipient.query.filter_by(campaign_id=sms_campaign.id, contact_id=sms_ok_email_block.id).count() == 1
+    reasons = {a.details["reason"] for a in MarketingAuditLog.query.filter_by(action="campaign_contact_skipped_suppression", entity_type="sms_campaign").all()}
+    assert {"do_not_market", "do_not_sms", "sms_opted_out"} <= reasons
+
+
+def test_tenant_isolation_and_non_admin_delete(client, tenant_user):
+    user, company_a = tenant_user
+    company_b = Company(name="Tenant B")
+    seg_b = Segment(company_id=None, name="Hidden")
+    db.session.add_all([company_b, seg_b]); db.session.flush(); seg_b.company_id = company_b.id
+    seg_a = Segment(company_id=company_a.id, name="Visible")
+    db.session.add(seg_a); db.session.commit()
+    assert client.get(f"/api/segments/{seg_b.id}").status_code == 404
+    user.is_admin = False
+    db.session.commit()
+    assert client.delete(f"/api/segments/{seg_a.id}").status_code == 403
+
+
+def test_segment_detail_loads_html_tabs_contacts_exclusions_and_badges(client, tenant_user):
+    _, company = tenant_user
+    active = Contact(company_id=company.id, first_name="Active", last_name="Member", email="active@example.com", phone="+15550000101", tags="sms_consent", is_active=True, is_subscribed=True, source="import")
+    suppressed = Contact(company_id=company.id, first_name="No", last_name="Market", email="no@example.com", phone="+15550000102", tags="sms_consent", is_active=True, is_subscribed=True, do_not_market=True, do_not_email=True, do_not_sms=True, email_unsubscribed=True, sms_opted_out=True)
+    excluded = Contact(company_id=company.id, first_name="Excluded", last_name="User", email="excluded@example.com", tags="vip", is_active=True)
+    seg = Segment(company_id=company.id, name="Detail VIP", description="Detail dashboard", is_dynamic=True, match_mode="any", triggers=[{"type": "sms_opt_in"}], conditions=[{"field": "tag", "value": "vip"}], actions=[{"type": "tag"}], is_active=True)
+    db.session.add_all([active, suppressed, excluded, seg]); db.session.flush()
+    db.session.add_all([
+        SegmentMember(segment_id=seg.id, contact_id=active.id, source="manual", added_by_user_id=1),
+        SegmentMember(segment_id=seg.id, contact_id=suppressed.id, source="sms_opt_in", added_by_user_id=1),
+        SegmentMember(segment_id=seg.id, contact_id=excluded.id, source="dynamic_rule", is_excluded=True, exclusion_reason="requested", removed_by_user_id=1, removed_at=datetime.utcnow()),
+    ])
+    db.session.commit()
+
+    list_page = client.get("/segments")
+    assert list_page.status_code == 200
+    assert f"/segments/{seg.id}" in list_page.get_data(as_text=True)
+    assert f"/api/segments/{seg.id}/contacts" not in list_page.get_data(as_text=True)
+
+    detail = client.get(f"/segments/{seg.id}")
+    html = detail.get_data(as_text=True)
+    assert detail.status_code == 200
+    for tab in ("Overview", "Rules", "Contacts", "Excluded", "Suppression", "Campaigns", "Audit"):
+        assert tab in html
+    assert "Active Member" in html
+    assert "Excluded User" in html
+    assert "SMS Opt-In" in html
+    assert "Suppressed" in html
+    assert "Do Not Market" in html
+    assert "Do Not Email" in html
+    assert "Do Not SMS" in html
+    assert "SMS Opted Out" in html
+    assert "Email Unsubscribed" in html
+    assert "Preview Segment" in html
+    assert "Email Eligible" in html
+    assert "SMS Eligible" in html
+    assert "Deleting this segment will remove segment membership links and rules, but will not delete contacts or campaign history." in html
+    assert "Optimize Segment with AI" in html and "Coming soon" in html
+
+
+def test_segment_detail_refresh_honors_exclusions_delete_preserves_contacts_and_tenant_guard(client, tenant_user):
+    user, company_a = tenant_user
+    company_b = Company(name="Other Segment Tenant")
+    keep = Contact(company_id=company_a.id, email="keep@example.com", tags="vip", is_active=True)
+    excluded = Contact(company_id=company_a.id, email="excluded-refresh@example.com", tags="vip", is_active=True)
+    seg = Segment(company_id=company_a.id, name="Refreshable", segment_type="newsletter", is_dynamic=True, conditions=[{"field": "tag", "value": "vip"}])
+    other_seg = Segment(company_id=None, name="Other Hidden")
+    db.session.add_all([company_b, keep, excluded, seg, other_seg]); db.session.flush(); other_seg.company_id = company_b.id
+    db.session.add(SegmentMember(segment_id=seg.id, contact_id=excluded.id, source="dynamic_rule", is_excluded=True, exclusion_reason="manual", removed_at=datetime.utcnow(), removed_by_user_id=user.id))
+    db.session.commit()
+
+    assert client.get(f"/segments/{other_seg.id}").status_code == 404
+    refresh = client.post(f"/segments/{seg.id}/refresh", follow_redirects=True)
+    assert refresh.status_code == 200
+    excluded_member = SegmentMember.query.filter_by(segment_id=seg.id, contact_id=excluded.id).one()
+    assert excluded_member.is_excluded is True
+
+    user.is_admin = False
+    db.session.commit()
+    assert client.delete(f"/api/segments/{seg.id}").status_code == 403
+    user.is_admin = True
+    db.session.commit()
+    assert client.delete(f"/api/segments/{seg.id}").status_code == 200
+    assert Contact.query.filter_by(id=keep.id).count() == 1
+    assert Contact.query.filter_by(id=excluded.id).count() == 1
+
+
+def test_segment_contact_picker_search_and_campaign_links_preselect_segment(client, tenant_user):
+    _, company = tenant_user
+    contact = Contact(company_id=company.id, first_name="Picker", last_name="Person", email="picker@example.com", phone="+15550001999", company="Picker Co", is_active=True)
+    seg = Segment(company_id=company.id, name="Picker Segment")
+    db.session.add_all([contact, seg]); db.session.commit()
+
+    search_by_company = client.get("/api/contacts/search?q=Picker%20Co")
+    assert search_by_company.status_code == 200
+    payload = search_by_company.get_json()
+    assert payload["contacts"][0]["id"] == contact.id
+
+    detail = client.get(f"/segments/{seg.id}")
+    html = detail.get_data(as_text=True)
+    assert "/campaigns/create?segment=" in html and "Picker" in html
+    assert "/sms/create?segment=" in html and "Picker" in html
+    assert "Search by name, phone, email, or company" in html
+    assert "Add Tag <span class=\"badge bg-secondary\">Coming soon</span>" in html
+    assert "Start Campaign <span class=\"badge bg-secondary\">Coming soon</span>" in html
+
+    email_create = client.get("/campaigns/create?segment=Picker+Segment")
+    assert 'value="Picker Segment"' in email_create.get_data(as_text=True)
+    sms_create = client.get("/sms/create?segment=Picker+Segment")
+    assert 'value="Picker Segment"' in sms_create.get_data(as_text=True)
+
+
+def test_segment_suppression_migration_is_idempotent_for_production_workflow():
+    sql = open("migrations/20260618_segment_management_suppression.sql", encoding="utf-8").read()
+    assert "ADD COLUMN IF NOT EXISTS do_not_market" in sql
+    assert "ADD COLUMN IF NOT EXISTS source" in sql
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS uq_segment_member_contact" in sql


### PR DESCRIPTION
### Motivation

- Provide first-class segment administration (create/edit/copy/activate/delete) with membership provenance and permanent exclusions.  
- Enforce contact-level marketing suppression precedence so Do Not Market / channel opt-outs reliably block campaign sends.  
- Surface segment details in an HTML dashboard and allow creating campaigns preselected from a segment.  

### Description

- Add a new DB migration `migrations/20260618_segment_management_suppression.sql` to add contact marketing preference columns, segment metadata, and segment_member provenance/indexes.  
- Extend `models.py` with contact suppression fields (`do_not_market`, `do_not_email`, `do_not_sms`, `email_unsubscribed`, `sms_opted_out`, marketing preference metadata), `Segment` fields (`category`, `match_mode`, `triggers`, `actions`, `is_active`), and `SegmentMember` provenance (`source`, `added_by_user_id`, `removed_at`, `removed_by_user_id`, `exclusion_reason`, `is_excluded`) plus unique/index constraints.  
- Implement a new blueprint `segment_api_bp` (registered in `app.py`) that exposes tenant-scoped REST endpoints under `/api` for listing/creating/updating/deleting segments, managing segment membership (single and bulk add/remove, permanent exclusion/restore), contact marketing preference updates, and contact picker search.  
- Update `marketing_api.py` to consult `marketing_skip_reason(...)` when materializing recipients for email and SMS sends, audit skipped contacts with `campaign_contact_skipped_suppression`, and ensure SMS consent checks respect suppression.  
- Update server routes and UI templates (`routes.py`, `templates/segments.html`, `templates/segment_detail.html`, `templates/campaign_create.html`, `templates/create_sms_campaign.html`) to add a segment detail dashboard, membership/exclusion views, suppression badges, bulk actions, dynamic refresh behavior that honors `is_excluded`, and to preselect segments when creating campaigns.  
- Add `docs/marketing_segments.md` with behavioral notes and deployment/migration guidance.  
- Add comprehensive tests in `tests/test_segment_management_suppression.py` covering API flows, UI page loads, suppression precedence, tenant isolation, dynamic refresh behavior, and migration idempotency.  

### Testing

- Ran the new test module with `pytest tests/test_segment_management_suppression.py` and the tests completed successfully.  
- The migration SQL is exercised by a unit assertion in the test suite that verifies `IF NOT EXISTS` protections and index creation and that assertion passed.  
- API and HTML endpoints exercised by the tests validated tenant scoping, segment CRUD, membership add/remove/bulk flows, permanent exclusion behavior, suppression auditing, and campaign preselection and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3374ce896c8322a113273040522461)