### PR TITLE
Gate PWA APIs to mobile-inbox users, add messages API, and improve Google Contacts & UI empty state

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -149,6 +149,13 @@ def _require_company(user):
     return company
 
 
+def _require_mobile_inbox_api_access(user, company):
+    """Gate PWA JSON APIs with the same permission as the PWA shell."""
+    if not _check_mobile_inbox_access(user, company):
+        return jsonify({"success": False, "error": "Mobile inbox access is not enabled for this account."}), 403
+    return None
+
+
 def _get_twilio_account(company_id):
     from models import TwilioAccount
     return TwilioAccount.query.filter_by(company_id=company_id, is_active=True).first()
@@ -378,8 +385,6 @@ def pwa_index():
     user = _current_user()
     if not user:
         return redirect("/auth/login?next=/app/inbox")
-    if not _is_mobile_request():
-        return redirect(url_for("twilio.inbox"))
     company = _get_company(user)
     # No company assigned → show setup page
     if not company:
@@ -550,7 +555,10 @@ def api_phone_numbers():
 @inbox_pwa_bp.route("/api/pwa/preferences", methods=["GET", "PATCH"])
 def api_pwa_preferences():
     user = _require_auth()
-    _require_company(user)
+    company = _require_company(user)
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
     if request.method == "PATCH":
         data = request.get_json() or {}
         palette = (data.get("palette_id") or data.get("palette") or "lux").strip()
@@ -578,6 +586,9 @@ def api_pwa_preferences():
 def api_pwa_devices():
     user = _require_auth()
     company = _require_company(user)
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
     from models import PWADevice
     from services.comms_permissions import accessible_phone_numbers, can_manage_users
     allowed = set(accessible_phone_numbers(user, company.id))
@@ -597,6 +608,9 @@ def api_pwa_devices():
 def api_pwa_device_register():
     user = _require_auth()
     company = _require_company(user)
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
     device = _upsert_pwa_device(user, company, request.get_json() or {})
     db.session.commit()
     return jsonify({
@@ -613,6 +627,9 @@ def api_pwa_device_register():
 def api_pwa_device_heartbeat():
     user = _require_auth()
     company = _require_company(user)
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
     device = _upsert_pwa_device(user, company, request.get_json() or {})
     db.session.commit()
     return jsonify({"success": True, "device": _device_to_dict(device)})
@@ -622,6 +639,9 @@ def api_pwa_device_heartbeat():
 def api_pwa_device_settings(device_id):
     user = _require_auth()
     company = _require_company(user)
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
     from models import PWADevice
     from services.comms_permissions import can_manage_users
     device = PWADevice.query.filter_by(id=device_id, company_id=company.id).first_or_404()
@@ -976,6 +996,9 @@ def list_conversations():
     company = _get_company(user)
     if not company:
         return jsonify({"conversations": [], "unread_count": 0, "total": 0})
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
 
     from models import TwilioConversation
     filter_by = request.args.get("filter", "all")
@@ -984,6 +1007,18 @@ def list_conversations():
     number_filter = (request.args.get("number") or "").strip()
 
     from services.comms_permissions import filter_conversations_for_user, accessible_phone_numbers
+    allowed_numbers = accessible_phone_numbers(user, company.id)
+    if not allowed_numbers:
+        return jsonify({
+            "success": True,
+            "conversations": [],
+            "unread_count": 0,
+            "total": 0,
+            "page": page,
+            "code": "NO_ASSIGNED_NUMBER",
+            "empty_title": "No phone number assigned",
+            "empty_message": "Ask an admin to assign a phone number before using the mobile inbox.",
+        })
     q = filter_conversations_for_user(TwilioConversation.query.filter_by(company_id=company.id), user, company.id)
 
     if filter_by == "unread":
@@ -997,7 +1032,6 @@ def list_conversations():
     if number_filter:
         digits = lambda value: re.sub(r"\D", "", value or "")
         requested_digits = digits(number_filter)
-        allowed_numbers = accessible_phone_numbers(user, company.id)
         matched_number = next((n for n in allowed_numbers if digits(n) == requested_digits), None)
         if not matched_number:
             q = q.filter(db.text("1=0"))
@@ -1035,12 +1069,51 @@ def list_conversations():
     })
 
 
+@inbox_pwa_bp.route("/api/inbox/messages")
+def list_messages():
+    """List recent messages scoped to conversations the PWA user may access."""
+    user = _require_auth()
+    company = _require_company(user)
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
+
+    from models import TwilioConversation, TwilioMessage
+    from services.comms_permissions import accessible_phone_numbers
+    allowed_numbers = accessible_phone_numbers(user, company.id)
+    if not allowed_numbers:
+        return jsonify({
+            "success": True,
+            "messages": [],
+            "total": 0,
+            "code": "NO_ASSIGNED_NUMBER",
+            "empty_title": "No phone number assigned",
+            "empty_message": "Ask an admin to assign a phone number before using the mobile inbox.",
+        })
+
+    limit = min(int(request.args.get("limit", 100)), 250)
+    rows = (TwilioMessage.query
+        .join(TwilioConversation, TwilioMessage.conversation_id == TwilioConversation.id)
+        .filter(
+            TwilioMessage.company_id == company.id,
+            TwilioConversation.company_id == company.id,
+            TwilioConversation.to_number.in_(allowed_numbers),
+        )
+        .order_by(TwilioMessage.created_at.desc())
+        .limit(limit)
+        .all())
+    return jsonify({"success": True, "messages": [_msg_to_dict(m) for m in rows], "total": len(rows)})
+
+
 # ── API: single conversation + messages ───────────────────────────────────────
 
 @inbox_pwa_bp.route("/api/inbox/conversations/<int:conv_id>")
 def get_conversation(conv_id):
     user    = _require_auth()
     company = _require_company(user)
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
     from models import TwilioConversation
     from services.comms_permissions import filter_conversations_for_user
     conv = filter_conversations_for_user(
@@ -1081,6 +1154,9 @@ def get_conversation(conv_id):
 def send_message(conv_id):
     user    = _require_auth()
     company = _require_company(user)
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
     from models import TwilioConversation
     from services.comms_permissions import filter_conversations_for_user
     conv = filter_conversations_for_user(
@@ -1388,6 +1464,9 @@ def pwa_notifications():
     company = _get_company(user)
     if not company:
         return jsonify({"success": True, "notifications": [], "unread_count": 0})
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
     from models import Notification
     unread_only = request.args.get("filter") == "unread" or request.args.get("unread") == "1"
     q = Notification.query.filter_by(user_id=user.id, company_id=company.id)
@@ -1404,6 +1483,9 @@ def pwa_notifications_read():
     company = _get_company(user)
     if not company:
         return jsonify({"success": False, "error": "No company"}), 400
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
     from models import Notification
     payload = request.get_json(silent=True) or request.form or {}
     notification_id = payload.get("notification_id") or payload.get("id")
@@ -1481,6 +1563,9 @@ def push_subscribe():
     company = _get_company(user)
     if not company:
         return jsonify({"success": False, "error": "No company"}), 400
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
 
     payload  = request.get_json() or {}
     endpoint = payload.get("endpoint", "")
@@ -1555,6 +1640,9 @@ def push_test():
     company = _get_company(user)
     if not company:
         return jsonify({"success": False, "error": "No company"}), 400
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
 
     from models import PushSubscription
     subs = PushSubscription.query.filter_by(user_id=user.id, company_id=company.id, is_active=True).all()

--- a/services/comms_permissions.py
+++ b/services/comms_permissions.py
@@ -90,7 +90,11 @@ def accessible_phone_numbers(user, company_id: int) -> list[str]:
     if assigned:
         return [assigned]
 
-    if acc and (acc.has_mobile_inbox_access() or acc.has_comms_hub_access()):
+    # Mobile-inbox-only staff must be assigned an explicit line; otherwise the
+    # PWA can render a clear no-number state instead of silently exposing every
+    # tenant conversation or looping on empty API results. Full Communications
+    # Hub users keep the legacy company-wide fallback.
+    if acc and acc.has_comms_hub_access():
         return all_numbers
     return []
 

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -1387,7 +1387,7 @@ async function loadConversations() {
   state.conversations = (state.filter === 'all' && !state.search)
     ? mergeConversations(state.conversations, data.conversations)
     : data.conversations;
-  renderConvList(state.conversations);
+  renderConvList(state.conversations, data);
   cacheConversations(state.conversations);
   updateUnreadBadge(data.unread_count);
 }
@@ -1416,10 +1416,12 @@ function loadCachedConversations() {
   }
 }
 
-function renderConvList(convs) {
+function renderConvList(convs, meta = {}) {
   const el = document.getElementById('convList');
   if (!convs.length) {
-    el.innerHTML = '<div id="convEmpty">No conversations found.</div>';
+    const title = meta.empty_title || 'No conversations found.';
+    const message = meta.empty_message ? `<p>${escapeHtml(meta.empty_message)}</p>` : '';
+    el.innerHTML = `<div id="convEmpty"><strong>${escapeHtml(title)}</strong>${message}</div>`;
     return;
   }
   el.innerHTML = convs.map(c => {

--- a/tests/test_pwa_phone_system.py
+++ b/tests/test_pwa_phone_system.py
@@ -858,3 +858,160 @@ def test_disabled_calling_methods_are_blocked_per_number(client, app, world):
     cell = client.post("/api/inbox/call/dial", json={"to": "+15559990000", "selected_number": "+15550001000", "calling_method": "cell_callback"})
     assert cell.status_code == 403
     assert "Cell callback calling is disabled" in cell.get_json()["error"]
+
+
+def _create_staff_mobile_inbox_user(app, company_id, *, with_number=True):
+    from werkzeug.security import generate_password_hash
+    with app.app_context():
+        user = User(
+            username=f"staff_mobile_{with_number}",
+            email=f"staff_mobile_{str(with_number).lower()}@test.com",
+            password_hash=generate_password_hash("secret"),
+            default_company_id=company_id,
+        )
+        db.session.add(user)
+        db.session.flush()
+        acc = UserCompanyAccess(
+            user_id=user.id,
+            company_id=company_id,
+            role=UserCompanyAccess.ROLE_STAFF,
+            is_default=True,
+            can_access_mobile_inbox=True,
+            pwa_access_enabled=True,
+            can_access_full_app=False,
+            comms_hub_enabled=False,
+            manage_users_enabled=False,
+        )
+        db.session.add(acc)
+        pn = TwilioPhoneNumber(company_id=company_id, phone_number="+15550007777", sms_enabled=True, voice_enabled=True, is_active=True)
+        db.session.add(pn)
+        db.session.flush()
+        if with_number:
+            db.session.add(PhoneNumberUserPermission(
+                company_id=company_id,
+                phone_number_id=pn.id,
+                user_id=user.id,
+                can_access_pwa=True,
+                can_view_sms=True,
+                can_send_sms=True,
+                can_view_calls=True,
+                can_call=True,
+            ))
+        conv = TwilioConversation(
+            company_id=company_id,
+            from_number="+15551110000",
+            to_number="+15550007777",
+            contact_name="Assigned Customer",
+            last_message_at=datetime(2026, 1, 8),
+        )
+        db.session.add(conv)
+        db.session.flush()
+        db.session.add(TwilioMessage(
+            conversation_id=conv.id,
+            company_id=company_id,
+            direction="inbound",
+            from_number="+15551110000",
+            to_number="+15550007777",
+            body="assigned hello",
+            status="received",
+            created_at=datetime(2026, 1, 8),
+        ))
+        db.session.commit()
+        return user.id, conv.id
+
+
+def test_staff_mobile_inbox_user_can_log_in_and_open_inbox(client, app, world):
+    user_id, _ = _create_staff_mobile_inbox_user(app, world["co_a"])
+
+    resp = client.post("/auth/login", data={"email": "staff_mobile_true@test.com", "password": "secret"}, follow_redirects=False)
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/app/inbox")
+    inbox = client.get("/app/inbox", headers={"User-Agent": "Mozilla/5.0 (Linux; Android 14) Chrome/126 Mobile"})
+    assert inbox.status_code == 200
+
+
+def test_staff_mobile_inbox_user_can_subscribe_to_push(client, app, world):
+    user_id, _ = _create_staff_mobile_inbox_user(app, world["co_a"])
+    login(client, user_id)
+
+    resp = client.post("/api/push/subscribe", json={"endpoint": "https://push.test/1", "keys": {"p256dh": "p", "auth": "a"}})
+
+    assert resp.status_code == 200
+    assert resp.get_json()["success"] is True
+
+
+def test_staff_mobile_inbox_user_can_read_assigned_number_conversations(client, app, world):
+    user_id, conv_id = _create_staff_mobile_inbox_user(app, world["co_a"])
+    login(client, user_id)
+
+    listed = client.get("/api/inbox/conversations").get_json()
+    opened = client.get(f"/api/inbox/conversations/{conv_id}")
+    messages = client.get("/api/inbox/messages").get_json()
+
+    assert listed["success"] is True
+    assert [c["contact_name"] for c in listed["conversations"]] == ["Assigned Customer"]
+    assert opened.status_code == 200
+    assert opened.get_json()["messages"][0]["body"] == "assigned hello"
+    assert messages["messages"][0]["body"] == "assigned hello"
+
+
+def test_staff_mobile_inbox_user_cannot_access_campaigns_or_manage(client, app, world):
+    user_id, _ = _create_staff_mobile_inbox_user(app, world["co_a"])
+    login(client, user_id)
+
+    assert client.get("/campaigns").status_code == 403
+    manage_resp = client.get("/user/manage-users")
+    assert manage_resp.status_code in (302, 403)
+    assert manage_resp.status_code != 200
+
+
+def test_staff_mobile_inbox_no_number_returns_clear_empty_state(client, app, world):
+    user_id, _ = _create_staff_mobile_inbox_user(app, world["co_a"], with_number=False)
+    login(client, user_id)
+
+    resp = client.get("/api/inbox/conversations")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["code"] == "NO_ASSIGNED_NUMBER"
+    assert body["empty_title"] == "No phone number assigned"
+    assert body["conversations"] == []
+
+
+def test_staff_mobile_inbox_direct_link_does_not_loop_on_desktop_safari(client, app, world):
+    user_id, _ = _create_staff_mobile_inbox_user(app, world["co_a"])
+    login(client, user_id)
+
+    resp = client.get("/app/inbox", headers={"User-Agent": "Mozilla/5.0 Safari/605.1.15"}, follow_redirects=False)
+
+    assert resp.status_code == 200
+    assert b"LUXit" in resp.data or b"Inbox" in resp.data
+
+
+def test_staff_mobile_inbox_google_contacts_callback_returns_to_pwa(client, app, world, monkeypatch):
+    user_id, _ = _create_staff_mobile_inbox_user(app, world["co_a"])
+    login(client, user_id)
+    calls = []
+    monkeypatch.setattr("services.google_contacts.exchange_code", lambda user_id_arg, code: calls.append((user_id_arg, code)) or {"access_token": "tok"})
+    monkeypatch.setattr("services.google_contacts.sync_contacts", lambda user_id_arg, company_id: {"synced": 0, "matched": 0, "error": None})
+
+    resp = client.get("/twilio/google-contacts/callback?code=ok", follow_redirects=False)
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/app/inbox")
+    assert calls == [(user_id, "ok")]
+
+
+def test_staff_mobile_inbox_google_contacts_callback_handles_sync_exception(client, app, world, monkeypatch):
+    user_id, _ = _create_staff_mobile_inbox_user(app, world["co_a"])
+    login(client, user_id)
+    monkeypatch.setattr("services.google_contacts.exchange_code", lambda user_id_arg, code: {"access_token": "tok"})
+    def boom(user_id_arg, company_id):
+        raise RuntimeError("people api unavailable")
+    monkeypatch.setattr("services.google_contacts.sync_contacts", boom)
+
+    resp = client.get("/twilio/google-contacts/callback?code=ok", follow_redirects=False)
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/app/inbox")

--- a/twilio_sms.py
+++ b/twilio_sms.py
@@ -62,7 +62,7 @@ def _guard_sms_feature():
         "/twilio/voice/recording",
         "/twilio/voice/status",
     }
-    if request.path in _WEBHOOK_PATHS:
+    if request.path in _WEBHOOK_PATHS or request.path.startswith("/twilio/google-contacts/"):
         return None
 
     if not current_user.is_authenticated:
@@ -2626,6 +2626,22 @@ def save_note(conv_id):
 
 # ── Google Contacts sync ──────────────────────────────────────────────────
 
+def _mobile_inbox_return_url():
+    """Return the safe post-OAuth destination for mobile-inbox-only users."""
+    try:
+        from models import UserCompanyAccess
+        acc = UserCompanyAccess.query.filter_by(user_id=current_user.id).first()
+        if acc and not acc.has_full_app_access() and acc.has_mobile_inbox_access():
+            return "/app/inbox"
+    except Exception as exc:
+        logger.warning("Google Contacts return URL access check failed: %s", exc)
+    return url_for("twilio.inbox")
+
+
+def _google_contacts_redirect():
+    return redirect(_mobile_inbox_return_url())
+
+
 @twilio_bp.route("/google-contacts/connect")
 @login_required
 def google_contacts_connect():
@@ -2635,7 +2651,7 @@ def google_contacts_connect():
     import os
     if not os.environ.get("GOOGLE_CLIENT_ID"):
         flash("GOOGLE_CLIENT_ID is not configured. Add it in Settings → Secrets.", "danger")
-        return redirect(url_for("twilio.inbox"))
+        return _google_contacts_redirect()
     return redirect(get_auth_url(state=str(current_user.id)))
 
 
@@ -2649,15 +2665,23 @@ def google_contacts_callback():
     error = request.args.get("error")
     if error or not code:
         flash(f"Google sign-in was cancelled or failed: {error or 'no code'}", "warning")
-        return redirect(url_for("twilio.inbox"))
+        return _google_contacts_redirect()
     try:
         exchange_code(current_user.id, code)
     except Exception as exc:
         flash(f"Google Contacts connection failed: {exc}", "danger")
-        return redirect(url_for("twilio.inbox"))
+        return _google_contacts_redirect()
     # Run first sync immediately
     company = _get_company()
-    result  = sync_contacts(current_user.id, company.id)
+    if not company:
+        flash("Google Contacts connected, but no company is assigned to this account.", "warning")
+        return _google_contacts_redirect()
+    try:
+        result  = sync_contacts(current_user.id, company.id)
+    except Exception as exc:
+        logger.exception("Google Contacts initial sync failed for user %s", current_user.id)
+        flash(f"Google Contacts connected, but sync failed: {exc}", "warning")
+        return _google_contacts_redirect()
     if result.get("error"):
         flash(f"Connected but sync failed: {result['error']}", "warning")
     else:
@@ -2666,7 +2690,7 @@ def google_contacts_callback():
             f"{result['matched']} inbox names updated.",
             "success",
         )
-    return redirect(url_for("twilio.inbox"))
+    return _google_contacts_redirect()
 
 
 @twilio_bp.route("/google-contacts/sync", methods=["POST"])
@@ -2712,7 +2736,7 @@ def google_contacts_disconnect():
     from services.google_contacts import disconnect
     disconnect(current_user.id)
     flash("Google Contacts disconnected.", "info")
-    return redirect(url_for("twilio.inbox"))
+    return _google_contacts_redirect()
 
 
 # ===========================================================================

--- a/user_management.py
+++ b/user_management.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, request, flash, redirect, url_for, jsonify
+from flask import Blueprint, render_template, request, flash, redirect, url_for, jsonify, make_response
 from flask_login import login_required, current_user
 from werkzeug.security import generate_password_hash, check_password_hash
 from extensions import db
@@ -53,6 +53,10 @@ def change_password():
 @login_required
 def manage_users():
     """Manage all users (admin function)"""
+    company = current_user.get_default_company() if hasattr(current_user, "get_default_company") else None
+    from services.comms_permissions import can_manage_users
+    if not company or not can_manage_users(current_user, company.id):
+        return make_response("Forbidden", 403)
     users = User.query.order_by(User.created_at.desc()).all()
     return render_template('manage_users.html', users=users)
 


### PR DESCRIPTION
### Motivation
- Ensure the PWA JSON APIs are only usable by accounts with mobile inbox access and avoid leaking tenant data to desktop-only users.
- Provide a clear empty-state when a mobile-inbox-only user has no assigned phone number instead of returning confusing/empty results.
- Add a messages listing endpoint for the PWA and improve the Google Contacts OAuth return flow for mobile-inbox-only users.

### Description
- Added `_require_mobile_inbox_api_access` and applied it to PWA JSON endpoints including preferences, devices (register/heartbeat/settings), conversations, messages, notifications, and push subscribe/test endpoints to gate API access. 
- Implemented `GET /api/inbox/messages` to list recent TwilioMessage rows scoped to conversation numbers the user may access.
- Tightened `accessible_phone_numbers` logic so mobile-inbox-only staff must be explicitly assigned a number while Communications Hub users retain the legacy company-wide fallback.
- Updated the PWA frontend template `renderConvList` to accept API-provided metadata and surface `empty_title` / `empty_message` on no-number states.
- Adjusted Twilio Google Contacts flows to let mobile-inbox-only users return to `/app/inbox` after OAuth and to handle missing company or sync exceptions more robustly, and allowed google-contacts paths to bypass webhook guards where appropriate.
- Added guard on the `/manage-users` route to enforce `can_manage_users` at runtime and imported `make_response` for the 403 return.
- Added comprehensive tests and helpers in `tests/test_pwa_phone_system.py` covering mobile-inbox user creation, login, push subscription, conversation/message access, UI behavior when no number is assigned, Google Contacts callbacks, and access restrictions.

### Testing
- Ran the updated PWA-related test suite (`pytest tests/test_pwa_phone_system.py`) which includes new mobile-inbox user tests; all tests completed successfully.
- Exercised API endpoints for preferences, devices, conversations, messages, notifications, and push subscription in automated tests and verified expected success/error cases passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3492f600688322b70660220943600c)