### PR TITLE
Add Documenso VPS live-audit workflow, verifier script, runbook, and tests

### DIFF
--- a/.github/workflows/documenso-vps-audit.yml
+++ b/.github/workflows/documenso-vps-audit.yml
@@ -1,0 +1,96 @@
+name: Documenso VPS Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      contract_id:
+        description: Contract id to investigate in Documenso logs/metadata
+        required: true
+        default: 735551c2-ec6c-41e6-976d-1eef4e13bfa5
+      documenso_public_url:
+        description: Public Documenso base URL to probe
+        required: true
+        default: https://document.luxit.app
+
+concurrency:
+  group: documenso-vps-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Audit Documenso VPS
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout audit scripts
+        uses: actions/checkout@v4
+
+      - name: Configure SSH key
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' '${{ secrets.VPS_PRIVATE_KEY }}' > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          HOST_VALUE='${{ secrets.HOST }}'
+          ssh-keyscan -p 22 -H "$HOST_VALUE" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Upload audit scripts to VPS
+        shell: bash
+        run: |
+          set -euo pipefail
+          HOST_VALUE='${{ secrets.HOST }}'
+          REMOTE_DIR="/tmp/luxit-documenso-audit-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "REMOTE_DIR=$REMOTE_DIR" >> "$GITHUB_ENV"
+          ssh -i ~/.ssh/id_ed25519 root@"$HOST_VALUE" "rm -rf '$REMOTE_DIR' && mkdir -p '$REMOTE_DIR/repo/scripts'"
+          scp -i ~/.ssh/id_ed25519 -r scripts/documenso root@"$HOST_VALUE":"$REMOTE_DIR/repo/scripts/"
+
+      - name: Run Documenso VPS audit over SSH
+        id: remote_audit
+        shell: bash
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          HOST_VALUE='${{ secrets.HOST }}'
+          ssh -i ~/.ssh/id_ed25519 root@"$HOST_VALUE" \
+            "cd '$REMOTE_DIR/repo' && DOCUMENSO_PUBLIC_URL='${{ inputs.documenso_public_url }}' CONTRACT_ID='${{ inputs.contract_id }}' OUT_DIR='$REMOTE_DIR/bundle' scripts/documenso/live_documenso_vps_audit.sh" \
+            2>&1 | tee remote-audit-stdout.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Package remote audit bundle
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          HOST_VALUE='${{ secrets.HOST }}'
+          ssh -i ~/.ssh/id_ed25519 root@"$HOST_VALUE" \
+            "cd '$REMOTE_DIR' && tar -czf documenso-live-audit.tgz bundle repo 2>/dev/null || tar -czf documenso-live-audit.tgz ."
+          mkdir -p documenso-live-audit-artifact
+          scp -i ~/.ssh/id_ed25519 root@"$HOST_VALUE":"$REMOTE_DIR/documenso-live-audit.tgz" documenso-live-audit-artifact/
+          cp remote-audit-stdout.log documenso-live-audit-artifact/
+
+      - name: Redact downloaded artifact logs
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          find documenso-live-audit-artifact -type f -name '*.log' -o -name '*.out' -o -name '*.err' | while read -r file; do
+            perl -0pi -e 's/((?:SECRET|TOKEN|KEY|PASSWORD|PASS|PRIVATE|AUTH|CREDENTIAL|SALT)[A-Z0-9_]*=)[^\s]+/$1<redacted>/gi' "$file"
+          done
+
+      - name: Upload audit artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: documenso-live-audit-${{ github.run_id }}-${{ github.run_attempt }}
+          path: documenso-live-audit-artifact
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Fail if remote audit failed
+        if: steps.remote_audit.outputs.exit_code != '0'
+        shell: bash
+        run: |
+          echo "Documenso VPS audit failed with exit code ${{ steps.remote_audit.outputs.exit_code }}. Download the artifact for logs."
+          exit 1

--- a/docs/documenso_vps_signing_runbook.md
+++ b/docs/documenso_vps_signing_runbook.md
@@ -1,0 +1,140 @@
+# LUXit Documenso VPS signing-link runbook
+
+This repository does **not** contain the MyPayLink frontend/backend route that failed:
+`https://app.mypaylink.app/app/contractor-hub/contracts/735551c2-ec6c-41e6-976d-1eef4e13bfa5/sign`.
+Treat MyPayLink application fixes as out of scope unless a future branch adds the
+Documenso integration code that generates MyPayLink signing links.
+
+## Required signing URL policy
+
+Documenso signing-required emails must use one of these explicitly configured URL
+sources:
+
+1. **Documenso-hosted signing URL**: preferred default. Public URL variables such
+   as `APP_URL`, `NEXT_PUBLIC_WEBAPP_URL`, `NEXTAUTH_URL`, `WEBAPP_URL`, or the
+   deployment-specific `DOCUMENSO_PUBLIC_URL` must point to the reachable
+   Documenso public host, not MyPayLink.
+2. **MyPayLink-owned public token URL**: allowed only when MyPayLink confirms and
+   owns the route. Store the URL as metadata/return URL only when needed.
+3. **MyPayLink authenticated deep link**: blocked unless explicitly confirmed.
+   Do not send `/app/contractor-hub/contracts/:id/sign` from Documenso by
+   default; that path is a known-broken signing email target from the incident.
+
+## VPS investigation checklist
+
+Run these on the LUXit/Documenso VPS (Debian 13 Docker Manager host):
+
+```bash
+# Identify Documenso containers and compose project.
+docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Ports}}'
+
+# Inspect runtime URL/mail/webhook environment without dumping unrelated secrets.
+docker inspect <documenso-container> \
+  --format '{{range .Config.Env}}{{println .}}{{end}}' \
+  | sort \
+  | grep -E '^(APP_URL|NEXT_PUBLIC_WEBAPP_URL|NEXTAUTH_URL|WEBAPP_URL|DOCUMENSO_|MAIL_|SMTP_|WEBHOOK_|API_)='
+
+# Inspect compose-time configuration.
+find / -name 'docker-compose*.yml' -o -name 'compose*.yaml' 2>/dev/null \
+  | xargs -r grep -nE 'APP_URL|NEXT_PUBLIC_WEBAPP_URL|NEXTAUTH_URL|WEBAPP_URL|DOCUMENSO_|WEBHOOK_|MAIL_|SMTP_|contractor-hub'
+
+# Search mounted templates/config for the broken path.
+docker exec <documenso-container> sh -lc \
+  "grep -R --line-number '/app/contractor-hub/contracts/' /app /data 2>/dev/null || true"
+```
+
+## Affected contract/document investigation
+
+Use the incident contract id:
+`735551c2-ec6c-41e6-976d-1eef4e13bfa5`.
+
+```bash
+# Application logs around document creation/signing email/webhook delivery.
+docker logs --since 168h <documenso-container> 2>&1 \
+  | grep -E '735551c2-ec6c-41e6-976d-1eef4e13bfa5|signing|email|webhook|redirect|return|metadata|document'
+
+# Database inspection. Adjust container/db/user names to the VPS compose file.
+docker exec -it <postgres-container> psql -U <user> -d <database>
+```
+
+Inside `psql`, first list Documenso table names because upstream schemas vary by
+version:
+
+```sql
+\dt
+SELECT table_name, column_name
+FROM information_schema.columns
+WHERE column_name ILIKE '%metadata%'
+   OR column_name ILIKE '%redirect%'
+   OR column_name ILIKE '%return%'
+   OR column_name ILIKE '%sign%'
+   OR column_name ILIKE '%webhook%'
+ORDER BY table_name, ordinal_position;
+```
+
+Then query the document, recipients/signers, webhook/event records, and metadata
+for the affected contract id. The exact table names may differ by Documenso
+version, but the query target is:
+
+- Documenso document id
+- document status and completion timestamp
+- signer names/emails/status
+- generated signing token/link fields
+- redirect/return URL fields
+- metadata payload containing the LUXit/MyPayLink contract id
+- webhook event delivery status/history
+- completed PDF/download reference
+
+## Completion email behavior
+
+Documenso completion email support is deployment/version dependent. Confirm in
+Documenso admin settings and email/template settings whether completion emails
+are enabled for all required parties. If Documenso cannot deliver completed
+agreements in this setup, MyPayLink must handle completed-document emails after a
+Documenso completion webhook; do not implement MyPayLink email delivery in this
+repository unless this repository owns that integration.
+
+The completion webhook payload must include, or allow MyPayLink to retrieve:
+
+- document id and event id
+- document status
+- signer names, emails, and status
+- completion timestamp
+- signed PDF download/reference
+- metadata for contract/company/contractor/proposal/invoice ids
+
+## Guard validation
+
+Before sending signing email links, validate that generated links are absolute
+HTTPS URLs and are not the known-broken MyPayLink deep link. Emit audit events:
+
+- `signing_link_generated`
+- `signing_link_generation_failed`
+- `signing_email_sent`
+- `signing_email_blocked_invalid_url`
+
+Use `scripts/documenso/verify_documenso_signing_config.py` in CI/deployment to
+block checked-in compose/template/config files that contain the broken path or
+invalid Documenso public URL settings.
+
+## One-command live audit helper
+
+After copying this repository to the Documenso VPS, run:
+
+```bash
+DOCUMENSO_PUBLIC_URL=https://document.luxit.app \
+CONTRACT_ID=735551c2-ec6c-41e6-976d-1eef4e13bfa5 \
+scripts/documenso/live_documenso_vps_audit.sh
+```
+
+The helper writes a timestamped `documenso-live-audit-*` directory containing
+redacted Docker container lists, runtime URL/mail/webhook env values, compose/env
+file search results, recent logs filtered around the affected contract and
+signing/webhook terms, mounted config/template searches for the broken path, and
+a Documenso public URL reachability check. It exits with code `2` when it is run
+outside the VPS or any host without Docker.
+
+## GitHub Actions remote audit workflow
+
+Use the **Documenso VPS Audit** workflow (`.github/workflows/documenso-vps-audit.yml`) when direct shell access is unavailable. Trigger it with `workflow_dispatch`, keep the default contract id unless investigating a different contract, and download the `documenso-live-audit-*` artifact when it completes. The workflow copies only the Documenso audit scripts to the VPS, runs the live audit over SSH, captures stdout/stderr, redacts common secret assignments, and uploads the audit bundle for review.
+

--- a/scripts/documenso/live_documenso_vps_audit.sh
+++ b/scripts/documenso/live_documenso_vps_audit.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTRACT_ID="${CONTRACT_ID:-735551c2-ec6c-41e6-976d-1eef4e13bfa5}"
+BROKEN_PATH="/app/contractor-hub/contracts/"
+DOCUMENSO_PUBLIC_URL="${DOCUMENSO_PUBLIC_URL:-${DOCUMENSO_BASE_URL:-https://document.luxit.app}}"
+OUT_DIR="${OUT_DIR:-./documenso-live-audit-$(date -u +%Y%m%dT%H%M%SZ)}"
+mkdir -p "$OUT_DIR"
+
+log() { printf '\n== %s ==\n' "$*" | tee -a "$OUT_DIR/summary.txt"; }
+run() {
+  local name="$1"; shift
+  log "$name"
+  set +e
+  "$@" >"$OUT_DIR/$name.out" 2>"$OUT_DIR/$name.err"
+  local code=$?
+  set -e
+  printf 'exit_code=%s\n' "$code" | tee -a "$OUT_DIR/summary.txt"
+  sed -n '1,120p' "$OUT_DIR/$name.out" | tee -a "$OUT_DIR/summary.txt"
+  if [ "$code" -ne 0 ]; then sed -n '1,80p' "$OUT_DIR/$name.err" | tee -a "$OUT_DIR/summary.txt"; fi
+  return 0
+}
+
+redact_env() {
+  sed -E 's/(SECRET|TOKEN|KEY|PASSWORD|PASS|PRIVATE|AUTH|CREDENTIAL|SALT)=.*/\1=<redacted>/I'
+}
+
+log "audit_context"
+{
+  echo "contract_id=$CONTRACT_ID"
+  echo "documenso_public_url=$DOCUMENSO_PUBLIC_URL"
+  date -u '+utc=%Y-%m-%dT%H:%M:%SZ'
+  uname -a || true
+} | tee -a "$OUT_DIR/summary.txt"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker command not found. Run this script on the Documenso VPS." | tee -a "$OUT_DIR/summary.txt"
+  exit 2
+fi
+
+run docker_ps docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}'
+
+docker ps --format '{{.Names}} {{.Image}}' \
+  | awk 'tolower($0) ~ /documenso|document/ {print $1}' > "$OUT_DIR/documenso_containers.txt"
+
+if [ ! -s "$OUT_DIR/documenso_containers.txt" ]; then
+  echo "ERROR: no container with image/name matching documenso|document found." | tee -a "$OUT_DIR/summary.txt"
+  exit 3
+fi
+
+while IFS= read -r container; do
+  [ -n "$container" ] || continue
+  safe_name="${container//[^A-Za-z0-9_.-]/_}"
+
+  log "container_$safe_name"
+  echo "$container" | tee -a "$OUT_DIR/summary.txt"
+
+  docker inspect "$container" --format '{{range .Config.Env}}{{println .}}{{end}}' \
+    | sort \
+    | grep -E '^(APP_URL|NEXT_PUBLIC_WEBAPP_URL|NEXTAUTH_URL|WEBAPP_URL|DOCUMENSO_|MAIL_|SMTP_|WEBHOOK_|API_|NEXT_PUBLIC_|PUBLIC_)=' \
+    | redact_env > "$OUT_DIR/${safe_name}_runtime_env.redacted.txt" || true
+  sed -n '1,200p' "$OUT_DIR/${safe_name}_runtime_env.redacted.txt" | tee -a "$OUT_DIR/summary.txt"
+
+  run "${safe_name}_logs_contract" sh -c "docker logs --since 168h '$container' 2>&1 | grep -Ei '$CONTRACT_ID|signing|email|webhook|redirect|return|metadata|document' | tail -n 300"
+  run "${safe_name}_search_broken_path" docker exec "$container" sh -lc "grep -R --line-number '$BROKEN_PATH' /app /data /config 2>/dev/null || true"
+done < "$OUT_DIR/documenso_containers.txt"
+
+# Best-effort Documenso Postgres inspection. This is read-only and uses the
+# Postgres container's own POSTGRES_USER/POSTGRES_DB environment when present.
+docker ps --format '{{.Names}} {{.Image}}' \
+  | awk 'tolower($0) ~ /postgres|postgis|pgvector/ {print $1}' > "$OUT_DIR/postgres_containers.txt" || true
+
+while IFS= read -r pg_container; do
+  [ -n "$pg_container" ] || continue
+  pg_safe="${pg_container//[^A-Za-z0-9_.-]/_}"
+  log "postgres_$pg_safe"
+
+  pg_env="$OUT_DIR/${pg_safe}_postgres_env.redacted.txt"
+  docker inspect "$pg_container" --format '{{range .Config.Env}}{{println .}}{{end}}' \
+    | sort \
+    | grep -E '^(POSTGRES_DB|POSTGRES_USER|DATABASE_URL|PGDATABASE|PGUSER)=' \
+    | redact_env > "$pg_env" || true
+  sed -n '1,80p' "$pg_env" | tee -a "$OUT_DIR/summary.txt"
+
+  pg_user="$(docker inspect "$pg_container" --format '{{range .Config.Env}}{{println .}}{{end}}' | awk -F= '$1=="POSTGRES_USER" {print $2; exit}')"
+  pg_db="$(docker inspect "$pg_container" --format '{{range .Config.Env}}{{println .}}{{end}}' | awk -F= '$1=="POSTGRES_DB" {print $2; exit}')"
+  pg_user="${pg_user:-postgres}"
+  pg_db="${pg_db:-$pg_user}"
+
+  run "${pg_safe}_tables" docker exec "$pg_container" psql -U "$pg_user" -d "$pg_db" -v ON_ERROR_STOP=1 -Atc "select schemaname||'.'||tablename from pg_tables where schemaname not in ('pg_catalog','information_schema') order by 1;"
+  run "${pg_safe}_relevant_columns" docker exec "$pg_container" psql -U "$pg_user" -d "$pg_db" -v ON_ERROR_STOP=1 -Atc "select table_schema||'.'||table_name||'.'||column_name from information_schema.columns where table_schema not in ('pg_catalog','information_schema') and (column_name ilike '%metadata%' or column_name ilike '%redirect%' or column_name ilike '%return%' or column_name ilike '%sign%' or column_name ilike '%webhook%' or column_name ilike '%status%' or column_name ilike '%email%' or column_name ilike '%document%') order by 1;"
+
+  cat > "$OUT_DIR/${pg_safe}_search.sql" <<SQL
+\\pset tuples_only on
+\\pset pager off
+DO \$do\$
+DECLARE
+  r record;
+  sql text;
+  contract_id text := '$CONTRACT_ID';
+  broken_path text := '$BROKEN_PATH';
+BEGIN
+  FOR r IN
+    SELECT table_schema, table_name, column_name
+    FROM information_schema.columns
+    WHERE table_schema NOT IN ('pg_catalog','information_schema')
+      AND data_type IN ('text','character varying','character','json','jsonb','uuid')
+  LOOP
+    sql := format('SELECT %L AS source, count(*)::text AS matches FROM %I.%I WHERE %I::text ILIKE %L OR %I::text ILIKE %L',
+      r.table_schema||'.'||r.table_name||'.'||r.column_name,
+      r.table_schema, r.table_name, r.column_name, '%'||contract_id||'%', r.column_name, '%'||broken_path||'%');
+    EXECUTE 'INSERT INTO pg_temp.luxit_documenso_matches ' || sql;
+  END LOOP;
+END
+\$do\$;
+SELECT source||' matches='||matches FROM pg_temp.luxit_documenso_matches WHERE matches::int > 0 ORDER BY source;
+SQL
+  sed -i '1i CREATE TEMP TABLE luxit_documenso_matches(source text, matches text);' "$OUT_DIR/${pg_safe}_search.sql"
+  docker cp "$OUT_DIR/${pg_safe}_search.sql" "$pg_container:/tmp/luxit_documenso_search.sql" >/dev/null 2>&1 || true
+  run "${pg_safe}_contract_metadata_search" docker exec "$pg_container" psql -U "$pg_user" -d "$pg_db" -v ON_ERROR_STOP=1 -f /tmp/luxit_documenso_search.sql
+  run "${pg_safe}_candidate_document_rows" docker exec "$pg_container" psql -U "$pg_user" -d "$pg_db" -v ON_ERROR_STOP=1 -Atc "select 'documents table exists: '||to_regclass('public.Document')::text union all select 'documents lowercase exists: '||to_regclass('public.document')::text union all select 'recipients exists: '||to_regclass('public.Recipient')::text union all select 'webhooks exists: '||to_regclass('public.Webhook')::text;"
+done < "$OUT_DIR/postgres_containers.txt"
+
+run compose_file_search sh -c "find / -name 'docker-compose*.yml' -o -name 'docker-compose*.yaml' -o -name 'compose*.yml' -o -name 'compose*.yaml' 2>/dev/null | xargs -r grep -nE 'APP_URL|NEXT_PUBLIC_WEBAPP_URL|NEXTAUTH_URL|WEBAPP_URL|DOCUMENSO_|WEBHOOK_|MAIL_|SMTP_|contractor-hub' | sed -E 's/(SECRET|TOKEN|KEY|PASSWORD|PASS|PRIVATE|AUTH|CREDENTIAL|SALT)=([^[:space:]]+)/\\1=<redacted>/Ig'"
+run env_file_search sh -c "find / -name '.env' -o -name '*.env' 2>/dev/null | xargs -r grep -nE 'APP_URL|NEXT_PUBLIC_WEBAPP_URL|NEXTAUTH_URL|WEBAPP_URL|DOCUMENSO_|WEBHOOK_|MAIL_|SMTP_|contractor-hub' | sed -E 's/(SECRET|TOKEN|KEY|PASSWORD|PASS|PRIVATE|AUTH|CREDENTIAL|SALT)=([^[:space:]]+)/\\1=<redacted>/Ig'"
+python3 - <<PY > "$OUT_DIR/public_url_check.out" 2> "$OUT_DIR/public_url_check.err" || true
+import os, urllib.request
+url = os.environ.get('DOCUMENSO_PUBLIC_URL') or os.environ.get('DOCUMENSO_BASE_URL') or '$DOCUMENSO_PUBLIC_URL'
+url = url.rstrip('/') + '/'
+req = urllib.request.Request(url, headers={'User-Agent':'luxit-documenso-live-audit/1.0'})
+with urllib.request.urlopen(req, timeout=15) as resp:
+    print('status=' + str(resp.status))
+    print('final_url=' + resp.geturl())
+    print('content_type=' + str(resp.headers.get('content-type', '')))
+PY
+log public_url_check
+cat "$OUT_DIR/public_url_check.out" "$OUT_DIR/public_url_check.err" | tee -a "$OUT_DIR/summary.txt"
+
+if [ -x ./scripts/documenso/verify_documenso_signing_config.py ]; then
+  run validator_real_config python3 ./scripts/documenso/verify_documenso_signing_config.py --root / --documenso-public-url "$DOCUMENSO_PUBLIC_URL"
+fi
+
+log "operator_next_steps"
+cat <<'EOF' | tee -a "$OUT_DIR/summary.txt"
+Use the redacted runtime env and search outputs above to record before/after URL values.
+For database metadata, connect to the Documenso Postgres container and query tables/columns containing metadata, redirect, return, sign, webhook, and the affected contract id.
+Do not paste secrets into tickets or PRs; include only redacted host/path/status values.
+EOF
+
+printf '\nAudit bundle written to %s\n' "$OUT_DIR" | tee -a "$OUT_DIR/summary.txt"

--- a/scripts/documenso/verify_documenso_signing_config.py
+++ b/scripts/documenso/verify_documenso_signing_config.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Validate LUXit/Documenso signing URL configuration before emails are sent.
+
+This intentionally does not call MyPayLink or mutate Documenso. It validates local
+compose/env/template files and, when DOCUMENSO_PUBLIC_URL is set, verifies that the
+public Documenso URL resolves.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+BROKEN_PATH = "/app/contractor-hub/contracts/"
+DOCUMENSO_URL_KEYS = {
+    "APP_URL",
+    "NEXT_PUBLIC_WEBAPP_URL",
+    "NEXTAUTH_URL",
+    "WEBAPP_URL",
+    "DOCUMENSO_PUBLIC_URL",
+    "DOCUMENSO_WEBAPP_URL",
+    "DOCUMENSO_APP_URL",
+    "DOCUMENSO_BASE_URL",
+    "DOCUMENSO_WEBHOOK_URL",
+    "WEBHOOK_URL",
+}
+MY_PAY_LINK_HOSTS = {"app.mypaylink.app", "mypaylink.app", "www.mypaylink.app"}
+URL_RE = re.compile(r"https?://[^\s\"'<>)}]+")
+
+
+def iter_files(root: Path):
+    skip_dirs = {".git", "node_modules", ".venv", "venv", "__pycache__"}
+    for path in root.rglob("*"):
+        if any(part in skip_dirs for part in path.parts):
+            continue
+        if "tests" in path.parts:
+            continue
+        if path.is_file() and path.suffix.lower() in {".py", ".js", ".ts", ".tsx", ".jsx", ".html", ".txt", ".env", ".yml", ".yaml", ".json"}:
+            yield path
+
+
+def parse_env_like(path: Path):
+    values = {}
+    try:
+        for raw in path.read_text(errors="ignore").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            if line.startswith("-"):
+                line = line[1:].strip()
+            key, value = line.split("=", 1)
+            key = key.strip().lstrip("export ").strip()
+            value = value.strip().strip('"').strip("'")
+            if key in DOCUMENSO_URL_KEYS or key.startswith("DOCUMENSO_"):
+                values.setdefault(key, set()).add(value)
+    except OSError:
+        pass
+    return values
+
+
+def validate_url(name: str, value: str, errors: list[str], warnings: list[str]):
+    if not value or value.startswith("${"):
+        warnings.append(f"{name} is templated or empty: {value!r}")
+        return
+    parsed = urllib.parse.urlparse(value)
+    if parsed.scheme != "https":
+        errors.append(f"{name} must use https in production: {value}")
+    if not parsed.netloc:
+        errors.append(f"{name} is not an absolute URL: {value}")
+    if parsed.netloc.lower() in MY_PAY_LINK_HOSTS and parsed.path.startswith("/app/contractor-hub/contracts"):
+        errors.append(f"{name} points at known-broken MyPayLink deep link: {value}")
+
+
+def check_public_url(url: str, errors: list[str], warnings: list[str]):
+    if not url:
+        warnings.append("DOCUMENSO_PUBLIC_URL not set; skipping live reachability check")
+        return
+    req = urllib.request.Request(url.rstrip("/") + "/", method="GET", headers={"User-Agent": "luxit-documenso-config-check/1.0"})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            if resp.status >= 400:
+                errors.append(f"Documenso public URL returned HTTP {resp.status}: {url}")
+    except urllib.error.HTTPError as exc:
+        if exc.code >= 500:
+            errors.append(f"Documenso public URL returned HTTP {exc.code}: {url}")
+        else:
+            warnings.append(f"Documenso public URL returned HTTP {exc.code}; verify manually: {url}")
+    except Exception as exc:  # noqa: BLE001 - CLI reports operator-facing validation failure
+        errors.append(f"Documenso public URL is not reachable: {url} ({exc})")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="Repository/deployment root to scan")
+    parser.add_argument("--documenso-public-url", default=os.getenv("DOCUMENSO_PUBLIC_URL", ""))
+    parser.add_argument("--skip-network", action="store_true")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    errors: list[str] = []
+    warnings: list[str] = []
+    found_values: dict[str, set[str]] = {}
+
+    for path in iter_files(root):
+        rel = path.relative_to(root)
+        text = path.read_text(errors="ignore")
+        if BROKEN_PATH in text and "verify_documenso_signing_config.py" not in str(rel):
+            errors.append(f"known-broken path found in {rel}: {BROKEN_PATH}")
+        for url in URL_RE.findall(text):
+            parsed = urllib.parse.urlparse(url)
+            if parsed.netloc.lower() in MY_PAY_LINK_HOSTS and parsed.path.startswith(BROKEN_PATH):
+                errors.append(f"known-broken MyPayLink signing URL found in {rel}: {url}")
+        if "verify_documenso_signing_config.py" not in str(rel):
+            for key, vals in parse_env_like(path).items():
+                found_values.setdefault(key, set()).update(vals)
+
+    for key, vals in sorted(found_values.items()):
+        for value in sorted(vals):
+            validate_url(key, value, errors, warnings)
+
+    public_url = args.documenso_public_url or next(iter(found_values.get("DOCUMENSO_PUBLIC_URL", [])), "")
+    if not args.skip_network:
+        check_public_url(public_url, errors, warnings)
+
+    for warning in warnings:
+        print(f"WARNING: {warning}")
+    if found_values:
+        print("Documenso URL-related config keys found:")
+        for key, vals in sorted(found_values.items()):
+            print(f"  {key}=" + ", ".join(sorted(vals)))
+    else:
+        print("No Documenso URL-related config keys found in scanned files.")
+
+    if errors:
+        print("FAILED:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print("PASS: no known-broken signing links or invalid Documenso URL config found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_documenso_signing_config.py
+++ b/tests/test_documenso_signing_config.py
@@ -1,0 +1,44 @@
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path("scripts/documenso/verify_documenso_signing_config.py")
+
+
+def run_checker(root: Path):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root), "--skip-network"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_checker_passes_without_documenso_config(tmp_path):
+    (tmp_path / "template.html").write_text("<a href='https://documenso.example.com/sign/abc'>Sign</a>")
+
+    result = run_checker(tmp_path)
+
+    assert result.returncode == 0
+    assert "PASS" in result.stdout
+
+
+def test_checker_blocks_known_broken_mypaylink_deep_link(tmp_path):
+    (tmp_path / "template.html").write_text(
+        "https://app.mypaylink.app/app/contractor-hub/contracts/735551c2-ec6c-41e6-976d-1eef4e13bfa5/sign"
+    )
+
+    result = run_checker(tmp_path)
+
+    assert result.returncode == 1
+    assert "known-broken" in result.stderr
+
+
+def test_checker_requires_https_public_documenso_url(tmp_path):
+    (tmp_path / "compose.yml").write_text("APP_URL=http://documenso.example.com\n")
+
+    result = run_checker(tmp_path)
+
+    assert result.returncode == 1
+    assert "must use https" in result.stderr


### PR DESCRIPTION
### Motivation
- Provide an operator-friendly, auditable investigation path for Documenso VPS incidents when direct shell access is unavailable by running live audits over SSH and capturing redacted artifacts.
- Prevent sending known-broken MyPayLink deep-links from Documenso by adding a pre-deployment/CI validator for signing URL configuration.
- Collect and centralize runtime environment, Docker/container logs, and Postgres metadata search results to make debugging the affected contract easier.

### Description
- Add a GitHub Actions workflow ` .github/workflows/documenso-vps-audit.yml` that uploads audit scripts to a VPS over SSH, runs `scripts/documenso/live_documenso_vps_audit.sh`, redacts secrets, and uploads a compressed artifact for review.
- Add a runbook `docs/documenso_vps_signing_runbook.md` documenting investigation steps, required signing URL policy, and how to use the live audit helper and workflow.
- Add the live audit helper script `scripts/documenso/live_documenso_vps_audit.sh` that enumerates Documenso containers, captures redacted runtime env, filters recent logs for the affected contract id, inspects Postgres containers, searches compose/env files, and checks public URL reachability.
- Add a validator `scripts/documenso/verify_documenso_signing_config.py` that scans repository/deployment files for known-broken signing links and validates Documenso URL configuration and reachability.
- Add unit tests `tests/test_documenso_signing_config.py` covering basic validator behavior for passing configs, known-broken MyPayLink deep links, and non-HTTPS public URLs.

### Testing
- Ran the new unit tests in `tests/test_documenso_signing_config.py` with `pytest` (invoking the validator via `python`), and the tests passed.
- Exercised the verifier locally with `--skip-network` to validate file scanning and known-broken-path detection, which produced expected pass/fail results.
- The GitHub Actions audit workflow is implemented with `workflow_dispatch` and uploads artifacts when run, and its exit behavior returns non-zero when the remote audit script fails.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a35df7dc90883229ba8d73879b0e085)