### PR TITLE
PWA: silent after-hours push, unread reminders, business-hours defaults, DB migrations, and systemd timer

### DIFF
--- a/deploy/systemd/luxit-pwa-unread-reminders.service
+++ b/deploy/systemd/luxit-pwa-unread-reminders.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=LUXit PWA unread SMS reminder runner
+After=network.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/var/www/LUXit.app
+EnvironmentFile=-/etc/luxit/lux-email-bot.env
+ExecStart=/usr/bin/env python scripts/run_pwa_unread_reminders.py

--- a/deploy/systemd/luxit-pwa-unread-reminders.timer
+++ b/deploy/systemd/luxit-pwa-unread-reminders.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run LUXit PWA unread SMS reminders every minute
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+AccuracySec=1s
+Unit=luxit-pwa-unread-reminders.service
+
+[Install]
+WantedBy=timers.target

--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -474,7 +474,8 @@ def _safe_conversation_tags(raw_tags):
 
 
 def _is_archived_conversation(conv):
-    return "archived" in _safe_conversation_tags(getattr(conv, "tags", None))
+    tags = set(_safe_conversation_tags(getattr(conv, "tags", None)))
+    return bool(tags.intersection({"archived", "resolved", "closed"}))
 
 
 def _msg_to_dict(m):
@@ -775,6 +776,7 @@ def api_pwa_preferences():
             "unreadReminderAlertsEnabled": "pwa_unread_reminder_alerts_enabled",
             "vibrationEnabled": "pwa_vibration_enabled",
             "businessHoursOnly": "pwa_alerts_business_hours_only",
+            "afterHoursPushEnabled": "pwa_after_hours_push_enabled",
         }
         for json_key, attr in pref_map.items():
             snake_key = re.sub(r"(?<!^)(?=[A-Z])", "_", json_key).lower()
@@ -800,6 +802,7 @@ def api_pwa_preferences():
             "unreadReminderAlertsEnabled": getattr(user, "pwa_unread_reminder_alerts_enabled", True) is not False,
             "vibrationEnabled": getattr(user, "pwa_vibration_enabled", True) is not False,
             "businessHoursOnly": getattr(user, "pwa_alerts_business_hours_only", True) is not False,
+            "afterHoursPushEnabled": getattr(user, "pwa_after_hours_push_enabled", False) is True,
             "quietHoursStart": getattr(user, "pwa_quiet_hours_start", None),
             "quietHoursEnd": getattr(user, "pwa_quiet_hours_end", None),
             "unreadRepeatMinutes": getattr(user, "pwa_unread_repeat_minutes", None) or 1,
@@ -1036,7 +1039,7 @@ def api_voicemails():
 
 
 def _default_business_hours():
-    return {str(i): {"is_open": i < 5, "open": "09:00", "close": "17:00"} for i in range(7)}
+    return {str(i): {"is_open": True, "open": "14:00", "close": "02:00"} for i in range(7)}
 
 
 def _settings_to_dict(settings):
@@ -1083,13 +1086,16 @@ def api_phone_number_settings(number_id):
             "sms_forward_to", "sms_forwarding_enabled", "auto_reply_enabled", "number_auto_reply_text",
             "call_forward_to", "voice_forwarding_enabled", "ring_timeout",
             "voicemail_greeting_text", "voicemail_greeting_audio_url", "missed_call_text",
-            "after_hours_text", "after_hours_sms_enabled", "after_hours_voicemail_enabled",
+            "after_hours_text", "after_hours_sms_body", "after_hours_cooldown_minutes", "after_hours_sms_enabled", "after_hours_voicemail_enabled",
             "browser_calling_enabled", "cell_callback_enabled", "wifi_only",
             "mobile_data_allowed", "fallback_behavior", "caller_id_display_name",
         }
         for key in allowed:
             if key in data:
-                setattr(pn, key, data[key])
+                if key == "after_hours_sms_body":
+                    pn.after_hours_text = data[key]
+                else:
+                    setattr(pn, key, data[key])
         db.session.commit()
     return jsonify({
         "success": True,
@@ -1113,6 +1119,8 @@ def api_phone_number_settings(number_id):
             "voicemail_greeting_audio_url": pn.voicemail_greeting_audio_url,
             "missed_call_text": pn.missed_call_text,
             "after_hours_text": pn.after_hours_text,
+            "after_hours_sms_body": pn.after_hours_text,
+            "after_hours_cooldown_minutes": pn.after_hours_cooldown_minutes,
             "after_hours_sms_enabled": pn.after_hours_sms_enabled,
             "after_hours_voicemail_enabled": pn.after_hours_voicemail_enabled,
             "browser_calling_enabled": pn.browser_calling_enabled,
@@ -1865,10 +1873,11 @@ def _event_allowed_for_user(user, event_type: str) -> bool:
     return True if not attr else getattr(user, attr, True) is not False
 
 
-def _notification_payload_preferences(user):
+def _notification_payload_preferences(user, *, silent: bool = False):
     return {
-        "soundEnabled": getattr(user, "notification_sounds_enabled", True) is not False,
-        "vibrationEnabled": getattr(user, "pwa_vibration_enabled", True) is not False,
+        "soundEnabled": (getattr(user, "notification_sounds_enabled", True) is not False) and not silent,
+        "vibrationEnabled": (getattr(user, "pwa_vibration_enabled", True) is not False) and not silent,
+        "silent": bool(silent),
         "quietHoursStart": getattr(user, "pwa_quiet_hours_start", None),
         "quietHoursEnd": getattr(user, "pwa_quiet_hours_end", None),
     }
@@ -1989,7 +1998,7 @@ def _send_web_push_to_subscriptions(subscriptions, payload: dict):
     db.session.commit()
     return {"sent": sent, "errors": errors}
 
-def send_pwa_push_notification(company_id: int, *, user_ids, title: str, body: str, link: str = "/app/inbox", tag: str = "luxit-inbox", event_type: str = "notification", phone_number_id=None):
+def send_pwa_push_notification(company_id: int, *, user_ids, title: str, body: str, link: str = "/app/inbox", tag: str = "luxit-inbox", event_type: str = "notification", phone_number_id=None, silent: bool = False):
     """Internal tenant-scoped push helper for notifications already permission-filtered by caller."""
     from models import PushSubscription
     from models import User
@@ -2006,8 +2015,9 @@ def send_pwa_push_notification(company_id: int, *, user_ids, title: str, body: s
     ).all()
     return _send_web_push_to_subscriptions(subs, {
         "title": title, "body": body, "url": link, "tag": tag, "eventType": event_type,
-        "icon": "/static/favicon.png", "badge": "/static/favicon.png", "sound": "default",
-        "data": {"company_id": company_id, "phone_number_id": phone_number_id, "event_type": event_type},
+        "icon": "/static/favicon.png", "badge": "/static/favicon.png", "sound": None if silent else "default",
+        "silent": bool(silent), "vibrate": [] if silent else [80, 40, 80],
+        "data": {"company_id": company_id, "phone_number_id": phone_number_id, "event_type": event_type, "silent": bool(silent)},
     })
 
 # ── API: Push notification subscribe ─────────────────────────────────────────
@@ -2471,7 +2481,34 @@ def dial_number():
         return jsonify({"success": False, "error": _twilio_send_error_message(exc)}), 400
 
 
-def _fire_push_notification(company_id: int, conv, message_body: str):
+def _conversation_in_business_hours(conv) -> bool:
+    phone_config = getattr(conv, "phone_number", None)
+    # Legacy rows without explicit per-number hours should not suddenly silence
+    # alerts/reminders because no schedule was configured.
+    if not (getattr(phone_config, "business_hours", None) if phone_config else None):
+        return True
+    try:
+        import twilio_sms
+        return twilio_sms._is_business_hours(conv.company_id, phone_config=phone_config)
+    except Exception:
+        return True
+
+
+def _conversation_has_stop_condition(conv, now=None) -> bool:
+    if getattr(conv, "is_read", False):
+        return True
+    if _is_archived_conversation(conv):
+        return True
+    from models import TwilioMessage
+    latest = conv.messages.order_by(TwilioMessage.created_at.desc()).first()
+    if latest and latest.direction == "outbound":
+        return True
+    if latest and getattr(latest, "is_auto_reply", False):
+        return True
+    return False
+
+
+def _fire_push_notification(company_id: int, conv, message_body: str, *, silent: bool | None = None):
     """Called from inbound SMS webhook; records notification history and sends Web Push."""
     sender = conv.contact_name or conv.from_number
     phone_number_id = getattr(conv, "phone_number_id", None)
@@ -2489,6 +2526,10 @@ def _fire_push_notification(company_id: int, conv, message_body: str):
     )
 
     allowed_user_ids = [u.id for u in _authorized_notification_users(company_id, phone_number_id)]
+    in_business = _conversation_in_business_hours(conv)
+    silent = (not in_business) if silent is None else bool(silent)
+    if silent:
+        allowed_user_ids = [u.id for u in _authorized_notification_users(company_id, phone_number_id) if getattr(u, "pwa_after_hours_push_enabled", False) is True]
     send_pwa_push_notification(
         company_id,
         user_ids=allowed_user_ids,
@@ -2498,11 +2539,12 @@ def _fire_push_notification(company_id: int, conv, message_body: str):
         tag=f"sms-{conv.id}",
         event_type="inbound_sms",
         phone_number_id=phone_number_id,
+        silent=silent,
     )
 
 
 def create_pwa_notification(company_id: int, *, event_type: str, title: str, body: str,
-                            link: str = "/app/inbox", phone_number_id=None, icon: str = "bell"):
+                            link: str = "/app/inbox", phone_number_id=None, icon: str = "bell", silent: bool = False, emit_sse: bool = True):
     """Public helper for call/voicemail webhooks to persist notification history and push to permitted users."""
     records = _create_notification_records(
         company_id,
@@ -2523,7 +2565,17 @@ def create_pwa_notification(company_id: int, *, event_type: str, title: str, bod
         tag=f"{event_type}-{phone_number_id or 'company'}",
         event_type=event_type,
         phone_number_id=phone_number_id,
+        silent=silent,
     )
+    if emit_sse:
+        _push_sse_event(company_id, event_type, {
+            "title": title,
+            "body": body,
+            "link": link,
+            "url": link,
+            "phone_number_id": phone_number_id,
+            "silent": bool(silent),
+        })
     return records
 
 
@@ -2536,7 +2588,9 @@ def create_unread_message_reminders(now=None, dry_run: bool = False):
     would_create = 0
     unread = TwilioConversation.query.filter_by(is_read=False).all()
     for conv in unread:
-        if _is_archived_conversation(conv):
+        if _conversation_has_stop_condition(conv, now=now):
+            continue
+        if not _conversation_in_business_hours(conv):
             continue
         last = Notification.query.filter_by(
             company_id=conv.company_id,
@@ -2549,11 +2603,11 @@ def create_unread_message_reminders(now=None, dry_run: bool = False):
         if dry_run:
             would_create += 1
             continue
-        rows = _create_notification_records(
+        rows = create_pwa_notification(
             conv.company_id,
             event_type="unread_message_reminder",
             title=f"Unread message from {conv.contact_name or conv.from_number}",
-            notification_body=conv.last_message_preview or "Unread message needs attention",
+            body=conv.last_message_preview or "Unread message needs attention",
             link=f"/app/inbox?conv={conv.id}",
             phone_number_id=getattr(conv, "phone_number_id", None),
             icon="message-circle",

--- a/migrations/20260622_after_hours_sms_canonical.sql
+++ b/migrations/20260622_after_hours_sms_canonical.sql
@@ -1,0 +1,19 @@
+-- Canonicalize after-hours SMS settings on twilio_phone_number.
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS after_hours_cooldown_minutes INTEGER DEFAULT 720;
+ALTER TABLE twilio_message ADD COLUMN IF NOT EXISTS auto_responded BOOLEAN DEFAULT FALSE;
+
+UPDATE twilio_phone_number pn
+SET after_hours_text = COALESCE(NULLIF(pn.after_hours_text, ''), NULLIF(ps.after_hours_sms_body, ''), NULLIF(ta.after_hours_text, ''), 'Thanks for reaching out. Our business hours are daily from 2 PM to 2 AM. We’ll respond as soon as we’re back online.'),
+    after_hours_cooldown_minutes = COALESCE(pn.after_hours_cooldown_minutes, ta.after_hours_cooldown_minutes, 720),
+    business_hours = CASE
+        WHEN pn.business_hours IS NULL OR pn.business_hours = '{}'::jsonb THEN '{"0":{"is_open":true,"open":"14:00","close":"02:00"},"1":{"is_open":true,"open":"14:00","close":"02:00"},"2":{"is_open":true,"open":"14:00","close":"02:00"},"3":{"is_open":true,"open":"14:00","close":"02:00"},"4":{"is_open":true,"open":"14:00","close":"02:00"},"5":{"is_open":true,"open":"14:00","close":"02:00"},"6":{"is_open":true,"open":"14:00","close":"02:00"}}'::jsonb
+        ELSE pn.business_hours
+    END
+FROM twilio_account ta
+LEFT JOIN phone_settings ps ON ps.company_id = pn.company_id
+WHERE ta.id = pn.twilio_account_id OR ta.company_id = pn.company_id;
+
+UPDATE twilio_account
+SET after_hours_text = COALESCE(NULLIF(after_hours_text, ''), 'Thanks for reaching out. Our business hours are daily from 2 PM to 2 AM. We’ll respond as soon as we’re back online.'),
+    after_hours_cooldown_minutes = COALESCE(after_hours_cooldown_minutes, 720);
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS pwa_after_hours_push_enabled BOOLEAN DEFAULT FALSE;

--- a/models.py
+++ b/models.py
@@ -207,6 +207,7 @@ class User(UserMixin, db.Model):
     pwa_unread_reminder_alerts_enabled = db.Column(db.Boolean, default=True)
     pwa_vibration_enabled = db.Column(db.Boolean, default=True)
     pwa_alerts_business_hours_only = db.Column(db.Boolean, default=True)
+    pwa_after_hours_push_enabled = db.Column(db.Boolean, default=False)
     pwa_quiet_hours_start = db.Column(db.String(5), nullable=True)
     pwa_quiet_hours_end = db.Column(db.String(5), nullable=True)
     pwa_unread_repeat_minutes = db.Column(db.Integer, default=1)
@@ -2960,7 +2961,7 @@ class TwilioAccount(db.Model):
     ai_mode              = db.Column(db.String(20), default="off")   # off | assist | auto
     ai_system_prompt     = db.Column(db.Text)
     missed_call_text     = db.Column(db.Text, default="Sorry we missed your call! Reply to schedule a callback.")
-    after_hours_text     = db.Column(db.Text, default="Thanks for reaching out. We’re currently closed, but your message has been received. A team member will reply as soon as we’re back during business hours. Reply STOP to opt out.")
+    after_hours_text     = db.Column(db.Text, default="Thanks for reaching out. Our business hours are daily from 2 PM to 2 AM. We’ll respond as soon as we’re back online.")
     after_hours_cooldown_minutes = db.Column(db.Integer, default=720, server_default="720")
     sms_forward_to       = db.Column(db.String(20))   # Forward all inbound SMS to this number
     call_forward_to      = db.Column(db.String(20))   # Forward all inbound calls to this number
@@ -3080,6 +3081,7 @@ class TwilioMessage(db.Model):
     num_segments    = db.Column(db.Integer, default=1)
     media_urls      = db.Column(JSON)
     is_auto_reply   = db.Column(db.Boolean, default=False)
+    auto_responded  = db.Column(db.Boolean, default=False)
     rule_id         = db.Column(db.Integer, db.ForeignKey("auto_reply_rule.id"), nullable=True)
     error_code      = db.Column(db.String(20))
     error_message   = db.Column(db.Text)
@@ -3709,6 +3711,7 @@ class TwilioPhoneNumber(db.Model):
     voicemail_greeting_audio_url  = db.Column(db.String(500))
     missed_call_text              = db.Column(db.Text)
     after_hours_text              = db.Column(db.Text)
+    after_hours_cooldown_minutes  = db.Column(db.Integer, default=720, server_default="720")
     after_hours_sms_enabled       = db.Column(db.Boolean, default=True)
     after_hours_voicemail_enabled = db.Column(db.Boolean, default=True)
 

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -1369,8 +1369,10 @@ function connectSSE() {
 
 function handleSSEEvent(data) {
   if (data.type === 'new_message') {
-    vibrateIfEnabled([80, 40, 80]);
-    playSound('sms-' + data.conversation_id + '-' + (data.message_id || data.created_at || Date.now()));
+    if (!data.silent) {
+      vibrateIfEnabled([80, 40, 80]);
+      playSound('sms-' + data.conversation_id + '-' + (data.message_id || data.created_at || Date.now()));
+    }
 
     // Flash the conversation row if visible
     const ci = document.getElementById('ci-' + data.conversation_id);
@@ -1387,9 +1389,11 @@ function handleSSEEvent(data) {
     if (state.activeConvId === data.conversation_id) {
       refreshMessages(data.conversation_id);
     }
-  } else if (['incoming_call', 'missed_call', 'voicemail'].includes(data.type)) {
-    vibrateIfEnabled([120, 60, 120]);
-    playSound(data.type + '-' + (data.call_id || data.id || data.call_sid || Date.now()));
+  } else if (['incoming_call', 'missed_call', 'voicemail', 'unread_message_reminder'].includes(data.type)) {
+    if (!data.silent) {
+      vibrateIfEnabled([120, 60, 120]);
+      playSound(data.type + '-' + (data.call_id || data.id || data.call_sid || Date.now()));
+    }
     loadBadgeCounts();
   } else if (data.type === 'message_status') {
     if (state.activeConvId === data.conversation_id) {

--- a/tests/test_pwa_communications_completion.py
+++ b/tests/test_pwa_communications_completion.py
@@ -282,3 +282,103 @@ def test_pwa_calls_visual_nav_sdk_and_voicemail_static_requirements():
     assert "favoritesScreen" in index and "saveFavorite" in index and "removeFavorite" in index and "moveFavorite" in index
     assert "setPalette('slate')" in index and "setPalette('rose')" in index
     assert "mark-unread" in calls and "/api/calls/${id}/${read?'mark-read':'mark-unread'}" in calls
+
+
+def test_unread_reminders_obey_business_hours_and_stop_conditions(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import inbox_pwa
+    with app.app_context():
+        open_line = db.session.get(TwilioPhoneNumber, ids["line"])
+        open_line.business_hours = {str(i): {"is_open": True, "open": "00:00", "close": "23:59"} for i in range(7)}
+        closed_line = TwilioPhoneNumber(company_id=ids["company"], phone_number="+15550003000", sms_enabled=True, voice_enabled=True, is_active=True, business_hours={str(i): {"is_open": False} for i in range(7)})
+        db.session.add(closed_line); db.session.flush()
+        open_conv = TwilioConversation(company_id=ids["company"], phone_number_id=ids["line"], from_number="+14155550001", to_number="+15550001000", is_read=False, last_message_preview="Open unread")
+        closed_conv = TwilioConversation(company_id=ids["company"], phone_number_id=closed_line.id, from_number="+14155550002", to_number="+15550003000", is_read=False, last_message_preview="Closed unread")
+        replied_conv = TwilioConversation(company_id=ids["company"], phone_number_id=ids["line"], from_number="+14155550003", to_number="+15550001000", is_read=False, last_message_preview="Already replied")
+        auto_conv = TwilioConversation(company_id=ids["company"], phone_number_id=ids["line"], from_number="+14155550004", to_number="+15550001000", is_read=False, last_message_preview="Auto replied")
+        db.session.add_all([open_conv, closed_conv, replied_conv, auto_conv]); db.session.flush()
+        from models import TwilioMessage
+        db.session.add_all([
+            TwilioMessage(conversation_id=open_conv.id, company_id=ids["company"], direction="inbound", body="Open unread"),
+            TwilioMessage(conversation_id=closed_conv.id, company_id=ids["company"], direction="inbound", body="Closed unread"),
+            TwilioMessage(conversation_id=replied_conv.id, company_id=ids["company"], direction="outbound", body="Human reply"),
+            TwilioMessage(conversation_id=auto_conv.id, company_id=ids["company"], direction="outbound", body="Auto reply", is_auto_reply=True),
+        ])
+        db.session.commit()
+        sent = []
+        monkeypatch.setattr(inbox_pwa, "send_pwa_push_notification", lambda company_id, **kw: sent.append(kw) or {"sent": 1, "errors": []})
+        result = inbox_pwa.create_unread_message_reminders()
+        assert result["created"] >= 1
+        reminders = Notification.query.filter_by(event_type="unread_message_reminder").all()
+        assert reminders
+        assert {r.link for r in reminders} == {f"/app/inbox?conv={open_conv.id}"}
+        assert sent and sent[0]["event_type"] == "unread_message_reminder"
+
+
+def test_after_hours_sms_push_is_silent_and_requires_after_hours_opt_in(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import inbox_pwa
+    with app.app_context():
+        user = db.session.get(User, ids["staff"])
+        user.pwa_after_hours_push_enabled = False
+        line = db.session.get(TwilioPhoneNumber, ids["line"])
+        line.business_hours = {str(i): {"is_open": False} for i in range(7)}
+        conv = TwilioConversation(company_id=ids["company"], phone_number_id=ids["line"], from_number="+14155559999", to_number="+15550001000", is_read=False)
+        db.session.add(conv); db.session.commit()
+        sent = []
+        monkeypatch.setattr(inbox_pwa, "send_pwa_push_notification", lambda company_id, **kw: sent.append(kw) or {"sent": len(kw.get("user_ids", [])), "errors": []})
+        inbox_pwa._fire_push_notification(ids["company"], conv, "after hours", silent=None)
+        assert sent[-1]["silent"] is True
+        assert ids["staff"] not in sent[-1]["user_ids"]
+        user.pwa_after_hours_push_enabled = True
+        db.session.commit()
+        inbox_pwa._fire_push_notification(ids["company"], conv, "after hours", silent=None)
+        assert sent[-1]["silent"] is True
+        assert ids["staff"] in sent[-1]["user_ids"]
+
+
+def test_service_worker_and_in_app_alerts_honor_silent_sound_vibration_flags():
+    index = open("templates/inbox_pwa/index.html", encoding="utf-8").read()
+    sw = open("static/sw.js", encoding="utf-8").read()
+    assert "if (!data.silent)" in index
+    assert "vibrateIfEnabled([80, 40, 80])" in index
+    assert "playSound('sms-'" in index
+    assert "silent:  data.silent === true" in sw
+    assert "vibrate: data.vibrate || [80, 40, 80]" in sw
+
+
+def test_call_missed_voicemail_and_reminder_notifications_emit_push_and_sse(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import inbox_pwa
+    with app.app_context():
+        sent_push = []
+        sent_sse = []
+        monkeypatch.setattr(inbox_pwa, "send_pwa_push_notification", lambda company_id, **kw: sent_push.append(kw) or {"sent": 1, "errors": []})
+        monkeypatch.setattr(inbox_pwa, "_push_sse_event", lambda company_id, event_type, data: sent_sse.append((event_type, data)))
+        for event_type in ("missed_call", "voicemail", "unread_message_reminder"):
+            inbox_pwa.create_pwa_notification(
+                ids["company"],
+                event_type=event_type,
+                title=f"Test {event_type}",
+                body="Alert body",
+                link="/app/inbox?tab=calls" if event_type != "unread_message_reminder" else "/app/inbox?conv=1",
+                phone_number_id=ids["line"],
+            )
+        assert [p["event_type"] for p in sent_push] == ["missed_call", "voicemail", "unread_message_reminder"]
+        assert [e[0] for e in sent_sse] == ["missed_call", "voicemail", "unread_message_reminder"]
+        assert all(e[1]["silent"] is False for e in sent_sse)
+
+
+def test_unread_reminder_stops_for_resolved_or_closed_tags(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import inbox_pwa
+    with app.app_context():
+        line = db.session.get(TwilioPhoneNumber, ids["line"])
+        line.business_hours = {str(i): {"is_open": True, "open": "00:00", "close": "23:59"} for i in range(7)}
+        resolved_conv = TwilioConversation(company_id=ids["company"], phone_number_id=ids["line"], from_number="+14155550101", to_number="+15550001000", is_read=False, tags=["resolved"], last_message_preview="Resolved")
+        closed_conv = TwilioConversation(company_id=ids["company"], phone_number_id=ids["line"], from_number="+14155550102", to_number="+15550001000", is_read=False, tags=["closed"], last_message_preview="Closed")
+        db.session.add_all([resolved_conv, closed_conv]); db.session.commit()
+        monkeypatch.setattr(inbox_pwa, "send_pwa_push_notification", lambda company_id, **kw: {"sent": 1, "errors": []})
+        result = inbox_pwa.create_unread_message_reminders()
+        assert result["created"] == 0
+        assert Notification.query.filter_by(event_type="unread_message_reminder").count() == 0

--- a/tests/test_pwa_phone_system.py
+++ b/tests/test_pwa_phone_system.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -1067,3 +1067,76 @@ def test_per_number_business_and_after_hours_auto_replies_work_without_rules(app
     assert closed_resp.status_code == 200
     assert (world["co_a"], "+15550003001", "+15551113001", "Open hours line reply", True) in sent
     assert (world["co_a"], "+15550003002", "+15551113002", "Closed line reply", True) in sent
+
+
+def test_cross_midnight_business_hours_two_pm_to_two_am(app, world):
+    import twilio_sms
+    with app.app_context():
+        pn = TwilioPhoneNumber(
+            company_id=world["co_a"],
+            phone_number="+15550003333",
+            timezone="America/New_York",
+            business_hours={str(i): {"is_open": True, "open": "14:00", "close": "02:00"} for i in range(7)},
+        )
+        db.session.add(pn); db.session.commit()
+        cases = [
+            (datetime(2026, 6, 22, 15, 0), False),  # 11 AM ET
+            (datetime(2026, 6, 22, 17, 59), False), # 1:59 PM ET
+            (datetime(2026, 6, 22, 18, 0), True),   # 2 PM ET
+            (datetime(2026, 6, 23, 3, 0), True),    # 11 PM ET
+            (datetime(2026, 6, 23, 5, 59), True),   # 1:59 AM ET
+            (datetime(2026, 6, 23, 6, 0), False),   # 2 AM ET
+        ]
+        for at_utc, expected in cases:
+            assert twilio_sms._is_business_hours(world["co_a"], at_time=at_utc.replace(tzinfo=timezone.utc), phone_config=pn) is expected
+
+
+def test_number_after_hours_copy_alias_persists_and_reloads(client, app, world):
+    login(client, world["alice"])
+    required = "Thanks for reaching out. Our business hours are daily from 2 PM to 2 AM. We’ll respond as soon as we’re back online."
+    with app.app_context():
+        pn = TwilioPhoneNumber(company_id=world["co_a"], phone_number="+15550004444", sms_enabled=True, is_active=True)
+        db.session.add(pn); db.session.commit(); number_id = pn.id
+    resp = client.put(f"/api/phone/numbers/{number_id}/settings", json={"after_hours_sms_body": required, "after_hours_sms_enabled": True, "after_hours_cooldown_minutes": 30})
+    assert resp.status_code == 200
+    body = client.get(f"/api/phone/numbers/{number_id}/settings").get_json()["settings"]
+    assert body["after_hours_text"] == required
+    assert body["after_hours_sms_body"] == required
+    assert body["after_hours_cooldown_minutes"] == 30
+
+
+def test_after_hours_auto_reply_fallback_creates_outbound_and_marks_inbound(app, client, world, monkeypatch):
+    import twilio_sms
+    required = "Thanks for reaching out. Our business hours are daily from 2 PM to 2 AM. We’ll respond as soon as we’re back online."
+    with app.app_context():
+        ta = TwilioAccount.query.filter_by(company_id=world["co_a"]).one()
+        ta._account_sid = "ACtest"; ta._auth_token = "auth"; ta.automation_enabled = True; ta.after_hours_sms_enabled = True
+        pn = TwilioPhoneNumber(company_id=world["co_a"], twilio_account_id=ta.id, phone_number="+15550005555", sms_enabled=True, is_active=True, auto_reply_enabled=True, after_hours_sms_enabled=True, after_hours_text=required, business_hours={str(i): {"is_open": True, "open": "14:00", "close": "02:00"} for i in range(7)}, timezone="America/New_York")
+        db.session.add(pn); db.session.commit()
+    monkeypatch.setattr(twilio_sms, "_validate_twilio_signature", lambda *a, **k: True)
+    monkeypatch.setattr(twilio_sms, "_is_business_hours", lambda *a, **k: False)
+    monkeypatch.setattr(twilio_sms, "_build_client", lambda ta: object())
+    resp = client.post("/twilio/sms/inbound", data={"From": "+15551112222", "To": "+15550005555", "Body": "hello", "MessageSid": "SMINAH1"})
+    assert resp.status_code == 200
+    with app.app_context():
+        conv = TwilioConversation.query.filter_by(company_id=world["co_a"], from_number="+15551112222").one()
+        inbound = TwilioMessage.query.filter_by(conversation_id=conv.id, direction="inbound").one()
+        outbound = TwilioMessage.query.filter_by(conversation_id=conv.id, direction="outbound", is_auto_reply=True).one()
+        assert inbound.auto_responded is True
+        assert outbound.body == required
+        assert outbound.to_number == "+15551112222"
+
+
+def test_stop_opt_out_does_not_receive_after_hours_auto_reply(app, client, world, monkeypatch):
+    import twilio_sms
+    with app.app_context():
+        ta = TwilioAccount.query.filter_by(company_id=world["co_a"]).one()
+        ta._account_sid = "ACtest"; ta._auth_token = "auth"; ta.automation_enabled = True; ta.after_hours_sms_enabled = True
+        db.session.add(TwilioPhoneNumber(company_id=world["co_a"], twilio_account_id=ta.id, phone_number="+15550006666", sms_enabled=True, is_active=True, after_hours_sms_enabled=True, after_hours_text="closed")); db.session.commit()
+    monkeypatch.setattr(twilio_sms, "_validate_twilio_signature", lambda *a, **k: True)
+    resp = client.post("/twilio/sms/inbound", data={"From": "+15551113333", "To": "+15550006666", "Body": "STOP", "MessageSid": "SMSTOP1"})
+    assert resp.status_code == 200
+    with app.app_context():
+        conv = TwilioConversation.query.filter_by(company_id=world["co_a"], from_number="+15551113333").one()
+        assert conv.is_opted_out is True
+        assert TwilioMessage.query.filter_by(conversation_id=conv.id, direction="outbound", is_auto_reply=True).count() == 0

--- a/twilio_sms.py
+++ b/twilio_sms.py
@@ -32,6 +32,9 @@ import html
 from datetime import datetime, timezone, timedelta
 from zoneinfo import ZoneInfo
 
+REQUIRED_AFTER_HOURS_SMS_COPY = "Thanks for reaching out. Our business hours are daily from 2 PM to 2 AM. We’ll respond as soon as we’re back online."
+DEFAULT_PHONE_BUSINESS_HOURS = {str(i): {"is_open": True, "open": "14:00", "close": "02:00"} for i in range(7)}
+
 from flask import (
     Blueprint, abort, flash, jsonify, redirect,
     render_template, request, url_for, g, has_request_context
@@ -139,6 +142,7 @@ class _NumberScopedTwilioConfig:
         "voicemail_greeting_audio_url",
         "missed_call_text",
         "after_hours_text",
+        "after_hours_cooldown_minutes",
         "after_hours_sms_enabled",
         "after_hours_voicemail_enabled",
         "business_hours",
@@ -273,7 +277,7 @@ def _seed_phone_numbers_from_accounts():
                     call_forward_to         = ta.call_forward_to,
                     voice_forwarding_enabled = bool(ta.voice_forwarding_enabled),
                     ring_timeout            = 25,
-                    business_hours          = {},
+                    business_hours          = dict(DEFAULT_PHONE_BUSINESS_HOURS),
                     timezone                = "America/Los_Angeles",
                     during_hours_route      = "ring_pwa",
                     after_hours_route       = "voicemail",
@@ -337,8 +341,6 @@ def _twiml_message(text: str):
 
 _UNICODE_REPLACEMENTS = str.maketrans({
     "\u2026": "...",   # …  ellipsis
-    "\u2019": "'",     # '  right single quotation mark
-    "\u2018": "'",     # '  left single quotation mark
     "\u201c": '"',     # "  left double quotation mark
     "\u201d": '"',     # "  right double quotation mark
     "\u2013": "-",     # –  en dash
@@ -363,8 +365,6 @@ def _safe_sms_text(value):
              .replace("–", "-")
              .replace("“", '"')
              .replace("”", '"')
-             .replace("‘", "'")
-             .replace("’", "'")
              .replace("\u00a0", " ")
     )
 
@@ -773,8 +773,10 @@ def _send_number_configured_auto_reply(conv, ta, *, in_business=None) -> bool:
         response_body = getattr(ta, "number_auto_reply_text", None)
     if not response_body:
         return False
-    cooldown_minutes = getattr(ta, "after_hours_cooldown_minutes", None) or 720
-    cutoff = datetime.now(timezone.utc) - timedelta(minutes=cooldown_minutes)
+    cooldown_minutes = getattr(ta, "after_hours_cooldown_minutes", None)
+    if cooldown_minutes is None:
+        cooldown_minutes = 720
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=int(cooldown_minutes))
     from models import TwilioMessage
     recent = TwilioMessage.query.filter(
         TwilioMessage.conversation_id == conv.id,
@@ -874,8 +876,10 @@ def _apply_auto_reply_rules(conv, body: str, ta) -> bool:
                 matched = False
                 skip_reason = "currently in business hours"
             else:
-                cooldown_minutes = getattr(ta, "after_hours_cooldown_minutes", None) or 720
-                cutoff = datetime.now(timezone.utc) - timedelta(minutes=cooldown_minutes)
+                cooldown_minutes = getattr(ta, "after_hours_cooldown_minutes", None)
+                if cooldown_minutes is None:
+                    cooldown_minutes = 720
+                cutoff = datetime.now(timezone.utc) - timedelta(minutes=int(cooldown_minutes))
                 from models import TwilioMessage
                 recent = TwilioMessage.query.filter(
                     TwilioMessage.conversation_id == conv.id,
@@ -955,7 +959,7 @@ def _apply_auto_reply_rules(conv, body: str, ta) -> bool:
             response_body = rule.response
             if rule.trigger_type == "after_hours":
                 response_body = (getattr(ta, "after_hours_text", None) or rule.response or
-                                 "Thanks for reaching out. We’re currently closed, but your message has been received. A team member will reply as soon as we’re back during business hours. Reply STOP to opt out.")
+                                 REQUIRED_AFTER_HOURS_SMS_COPY)
             if reply_sent:
                 logger.debug("%s rule id=%s skipped — reply already sent", _tag, rule.id)
                 continue
@@ -975,7 +979,8 @@ def _apply_auto_reply_rules(conv, body: str, ta) -> bool:
             logger.warning("%s rule id=%s action=reply but response is empty — skipped", _tag, rule.id)
 
     if not reply_sent:
-        logger.info("%s no rule produced a reply for this message", _tag)
+        logger.info("%s no rule produced a reply for this message; checking canonical per-number/company fallback", _tag)
+        reply_sent = _send_number_configured_auto_reply(conv, ta, in_business=in_business)
     return reply_sent
 
 
@@ -1043,7 +1048,7 @@ def _seed_default_rules(company_id: int):
 
 def _seed_default_hours(company_id: int):
     """
-    Seed business hours for a new company: 11:00 AM – 1:00 AM (next day),
+    Seed business hours for a new company: 2:00 PM – 2:00 AM (next day),
     America/Los_Angeles, every day of the week.
     Times are stored in local LA time; _is_business_hours() handles the
     midnight-crossing comparison correctly.
@@ -1057,12 +1062,12 @@ def _seed_default_hours(company_id: int):
             company_id=company_id,
             day_of_week=day,
             is_open=True,
-            open_time="11:00",
-            close_time="01:00",   # 1 AM next day — midnight-crossing
+            open_time="14:00",
+            close_time="02:00",   # 2 AM next day — midnight-crossing
         )
         db.session.add(bh)
     db.session.commit()
-    logger.info("Seeded default business hours (11 AM–1 AM LA) for company %s", company_id)
+    logger.info("Seeded default business hours (2 PM–2 AM LA) for company %s", company_id)
 
 
 # ---------------------------------------------------------------------------
@@ -1314,6 +1319,7 @@ def inbound_sms():
         except Exception as campaign_rule_exc:
             logger.exception("Error in campaign SMS keyword engine: %s", campaign_rule_exc)
 
+        auto_reply_sent = False
         # ── 6. Auto-reply rule engine ──────────────────────────────────────
         try:
             # Auto-capture lead on first contact
@@ -1322,9 +1328,12 @@ def inbound_sms():
 
             # Run rules only if not opted out
             if not conv.is_opted_out and getattr(ta, "auto_reply_enabled", True):
-                _apply_auto_reply_rules(conv, body, ta)
+                auto_reply_sent = _apply_auto_reply_rules(conv, body, ta)
         except Exception as rule_exc:
             logger.exception("Error in auto-reply rule engine: %s", rule_exc)
+        if auto_reply_sent:
+            msg_record.auto_responded = True
+            db.session.commit()
 
         # Clear first-contact flag after first processed message
         if conv.is_first_contact:
@@ -1351,6 +1360,11 @@ def inbound_sms():
         try:
             from inbox_pwa import _fire_push_notification, _push_sse_event
             sender = conv.contact_name or from_number
+            try:
+                in_business_for_alert = _is_business_hours(ta.company_id, phone_config=ta)
+            except Exception:
+                in_business_for_alert = True
+            alert_silent = (not in_business_for_alert) or bool(auto_reply_sent)
             _push_sse_event(ta.company_id, "new_message", {
                 "conversation_id":      conv.id,
                 "from_number":          from_number,
@@ -1359,8 +1373,10 @@ def inbound_sms():
                 "has_media":            num_media > 0,
                 "last_message_at":      conv.last_message_at.isoformat() if conv.last_message_at else None,
                 "last_message_preview": conv.last_message_preview or "",
+                "silent":               alert_silent,
+                "auto_responded":       bool(auto_reply_sent),
             })
-            _fire_push_notification(ta.company_id, conv, body or "(media)")
+            _fire_push_notification(ta.company_id, conv, body or "(media)", silent=alert_silent)
         except Exception as push_exc:
             logger.debug("Push/SSE notification skipped: %s", push_exc)
 
@@ -1625,10 +1641,14 @@ def _inbound_call_impl():
             f"</Response>"
         )
 
-    route = (
-        (getattr(ta, "during_hours_route", None) if in_hours else getattr(ta, "after_hours_route", None))
-        or (settings.during_hours_route if settings and in_hours else settings.after_hours_route if settings else None)
-    )
+    number_route = getattr(ta, "during_hours_route", None) if in_hours else getattr(ta, "after_hours_route", None)
+    settings_route = (settings.during_hours_route if settings and in_hours else settings.after_hours_route if settings else None)
+    # Treat model defaults as unset so tenant PhoneSettings keep routing calls unless
+    # the selected phone number has a non-default explicit route.
+    if settings_route and number_route in (None, "", "ring_pwa") and settings_route != number_route:
+        route = settings_route
+    else:
+        route = number_route or settings_route
     forward_to = (
         (getattr(ta, "call_forward_to", None) if pn else None)
         or ((settings.forward_number if in_hours else settings.after_hours_forward_number) if settings else None)
@@ -1680,6 +1700,7 @@ def _inbound_call_impl():
                 link="/app/inbox?tab=calls",
                 phone_number_id=getattr(pn, "id", None),
                 icon="phone",
+                emit_sse=False,
             )
         except Exception as exc:
             logger.debug("PWA incoming call event failed: %s", exc)


### PR DESCRIPTION
### Motivation
- Make push notifications respectful of after-hours by sending silent pushes and allowing opt-in for after-hours push delivery. 
- Prevent unread-reminder storms and ensure reminders only run during configured business hours and stop for resolved/closed/replied conversations. 
- Canonicalize after-hours SMS copy, cooldowns and default business hours across phone number/account models and seed logic. 
- Add a systemd timer/service to run unread reminder tasks regularly.

### Description
- Added systemd unit and timer files `deploy/systemd/luxit-pwa-unread-reminders.service` and `deploy/systemd/luxit-pwa-unread-reminders.timer` to run the unread reminder runner every minute. 
- Extended notification and PWA preferences: added `pwa_after_hours_push_enabled` to `User`, exposed `afterHoursPushEnabled` in the preferences API, and mapped incoming/outgoing settings through `api_pwa_preferences`. 
- Implemented silent/after-hours push behavior by adding a `silent` flag to `send_pwa_push_notification`, embedding `silent`/`vibrate` in payloads, and honoring `silent` in the client `index.html` event handlers. 
- Added server-side logic to determine conversation stop conditions (`_conversation_has_stop_condition`) and to respect per-number business hours (`_conversation_in_business_hours`) when firing notifications and when creating unread reminders; updated `_fire_push_notification`, `create_pwa_notification`, and `create_unread_message_reminders` accordingly. 
- Updated default business hours to 14:00–02:00 in `twilio_sms` seeding and `_default_business_hours` in `inbox_pwa.py`, and adjusted routing fallback logic for phone/settings routing decisions. 
- Model and schema changes: added `pwa_after_hours_push_enabled` on `User`, `after_hours_cooldown_minutes` on `TwilioPhoneNumber`, `auto_responded` on `TwilioMessage`, changed some default `after_hours_text` values on `TwilioAccount`, and added a migration SQL `migrations/20260622_after_hours_sms_canonical.sql` to canonicalize values and add columns. 
- Minor API/serialization adjustments: map `after_hours_sms_body` to `after_hours_text` on phone number settings PUT, return `after_hours_sms_body` and `after_hours_cooldown_minutes` in settings GET, and emit SSE events from `create_pwa_notification` with `silent` metadata. 
- Tests: added and updated tests to cover unread reminders business-hours/stop conditions, after-hours silent push behavior and opt-in, cross-midnight business hours, auto-reply fallbacks, and related UI/service worker expectations.

### Testing
- Ran the project unit tests with `pytest` including the new/updated tests in `tests/test_pwa_communications_completion.py` and `tests/test_pwa_phone_system.py`. All tests completed successfully on the local test run. 
- Exercised the unread reminders flow via the `create_unread_message_reminders` unit tests which verify business hour gating, stop conditions, and push delivery filtering. 
- Exercised after-hours auto-reply and push behavior in unit tests that validate payload `silent` semantics and opt-in gating for after-hours push delivery.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a395b10f67083229a2ec0db63f8ff90)