### PR TITLE
Documenso production safety, API JSON guard, migrations, and deployment checks

### DIFF
--- a/app.py
+++ b/app.py
@@ -331,6 +331,16 @@ def create_app() -> Flask:
             response.headers["Pragma"] = "no-cache"
             response.headers["Expires"] = "0"
 
+        try:
+            from services.api_json_guard import should_warn_api_non_json
+            if should_warn_api_non_json(request.path, response.status_code, response.mimetype):
+                logging.warning(
+                    "[API JSON guard] Non-JSON response sent path=%s status=%s mimetype=%s",
+                    request.path, response.status_code, response.mimetype
+                )
+        except Exception:
+            pass
+
         return response
 
     # --------------------------------------------------------
@@ -436,6 +446,23 @@ def create_app() -> Flask:
         import models  # noqa
 
         db.create_all()
+
+        # Documenso startup validation: never prints key/secret values.
+        try:
+            from services.documenso_service import validate_documenso_startup
+            _documenso_cfg = validate_documenso_startup()
+            if _documenso_cfg.api_key_present:
+                logging.info("[Documenso] API key present; send-for-signature enabled.")
+            else:
+                logging.warning("[Documenso] DOCUMENSO_API_KEY missing; send-for-signature disabled.")
+            if _documenso_cfg.webhook_secret_present:
+                logging.info("[Documenso] Webhook secret present; incoming events will be verified.")
+            else:
+                logging.warning("[Documenso] DOCUMENSO_WEBHOOK_SECRET missing; incoming events are unverified until configured.")
+        except Exception as _documenso_exc:
+            logging.error("[Documenso] Startup validation failed: %s", _documenso_exc)
+            if os.environ.get("DOCUMENSO_REQUIRED", "").lower() in {"1", "true", "yes"}:
+                raise
 
         # Self-heal guard: ensure at least one company exists and users are linked.
         # This prevents post-sync "no company" outages when ops scripts were skipped.

--- a/docs/documenso_vps_audit_status_20260624.md
+++ b/docs/documenso_vps_audit_status_20260624.md
@@ -1,0 +1,36 @@
+# Documenso VPS audit status — 2026-06-24
+
+This note answers the Documenso VPS audit questions for the current working
+copy. It does not mark the LUXit Documenso incident fixed.
+
+## Confirmations
+
+1. **Repository:** this working copy is `/workspace/LUXit.app`. The local Git
+   config in this environment does not define a remote URL.
+2. **Application modified:** the prior PR modified files in this `LUXit.app`
+   working copy. It did not prove changes in a separate `MyPayLink.app`
+   repository.
+3. **Dedicated live audit workflow run:** no workflow run was executed from this
+   container. The repository contains a `Documenso VPS Audit` workflow with
+   `workflow_dispatch`, but there is no local evidence that it was triggered for
+   this review.
+4. **Audit artifact:** no downloaded or generated `documenso-live-audit-*`
+   artifact is present in this working copy.
+5. **Live VPS inspection:** the live Documenso Docker containers, runtime env,
+   templates, compose/env files, and database were not inspected from this
+   container. The audit script is designed to perform those checks only when run
+   on the Documenso VPS or through the GitHub Actions SSH workflow.
+6. **Broken `/app/contractor-hub/contracts/` path on VPS:** not determined. The
+   audit script would search container files, compose files, env files, logs, and
+   database text/json columns for this path, but the live audit has not been run.
+7. **Contract `735551c2-ec6c-41e6-976d-1eef4e13bfa5` in Documenso metadata:**
+   not determined. The audit script defaults to that contract id and searches
+   Documenso logs and Postgres metadata when run live, but no live audit output
+   is available here.
+
+## Required next step
+
+Run the dedicated `.github/workflows/documenso-vps-audit.yml` workflow or run
+`scripts/documenso/live_documenso_vps_audit.sh` directly on the Documenso VPS,
+then review and attach the redacted `documenso-live-audit-*` artifact. Do not
+close the LUXit Documenso incident based on PayLink-side application files alone.

--- a/docs/paylink_documenso_production_signing_scope.md
+++ b/docs/paylink_documenso_production_signing_scope.md
@@ -1,0 +1,65 @@
+# PayLink/Documenso production signing fix scope
+
+This change set is intentionally scoped to the PayLink/Documenso production
+contract-signing incident. It should be reviewed and approved only for the
+signing flow and deployment guardrails needed to support that flow.
+
+**Review status:** approved for LUXit infrastructure hardening and
+Documenso/deployment safety improvements only. Communications production
+readiness remains incomplete and open.
+
+## In scope
+
+- Documenso API-key and webhook-secret startup validation without printing
+  secret values.
+- Disabling or failing send-for-signature when `DOCUMENSO_API_KEY` is missing.
+- Verifying Documenso webhook signatures when `DOCUMENSO_WEBHOOK_SECRET` is
+  configured.
+- Idempotently persisting Documenso document/envelope IDs, signing URLs,
+  recipient IDs, and signature request rows for contract signing.
+- Avoiding production SQL failures seen while notifying contract activation
+  recipients.
+- Adding narrow schema-drift compatibility only where production signing or its
+  notification path trips over missing preference columns.
+- Preventing deploy/startup regressions that block the PayLink app from serving
+  the signing flow, including missing frontend index paths and duplicate port
+  listeners.
+
+## Explicit non-goals
+
+This PR must **not** be approved as solving broader LUXit communications issues,
+including but not limited to:
+
+- PWA feature completeness.
+- SMS sending or campaign reliability.
+- After-hours routing behavior.
+- Push notification delivery quality.
+- Sound, vibration, unread reminder, or alert UX behavior.
+
+The migration includes compatibility columns for production schema drift only;
+that is not a product-level fix or acceptance claim for PWA, SMS, after-hours,
+push, sound, or alert systems.
+
+## Communications workstream status
+
+This infrastructure-hardening PR does **not** complete the LUXit communications
+workstream. Communications production readiness requires a separate PR with live
+VPS/Twilio/database/browser evidence for at least the following unresolved areas:
+
+1. After-hours SMS behavior, including an 11:00 AM inbound SMS producing the
+   configured after-hours reply, Twilio accepting the outbound message, same
+   conversation-thread persistence, and `auto_responded=true` on inbound rows.
+2. A canonical after-hours settings audit proving there is exactly one editable
+   source, no duplicate/stale editors or APIs, and clear UI load/save paths.
+3. Push notification implementation and validation for SMS, missed calls,
+   voicemail, and unread conversations across iPhone Safari/PWA, Android Chrome,
+   installed PWA, backgrounded app, and locked-screen states.
+4. Business-hours sound/vibration reminders every 60 seconds for unread
+   conversations until read, replied to, or auto-responded, with suppression
+   outside business hours while preserving after-hours SMS auto replies.
+5. Missed-call ringing, alerts, voicemail alerts, badge counts, and PWA wake
+   behavior.
+6. Production evidence from `journalctl -u luxit -f`, Twilio logs, database
+   rows, and screenshots/video demonstrating the expected behavior.
+
+Do not mark communications complete from this PR.

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+  apps: [{
+    name: 'paylink',
+    script: 'gunicorn',
+    args: '--config gunicorn.conf.py wsgi:app',
+    exec_mode: 'fork',
+    instances: 1,
+    autorestart: true,
+    max_restarts: 10,
+    env: { PORT: '8000' }
+  }]
+};

--- a/migrations/20260623_paylink_documenso_production_fix.sql
+++ b/migrations/20260623_paylink_documenso_production_fix.sql
@@ -1,0 +1,37 @@
+BEGIN;
+-- Scope note: these preference columns are compatibility fixes for production
+-- schema drift encountered by the PayLink/Documenso signing notification path.
+-- They are not a product-level PWA/push/after-hours feature completion claim.
+ALTER TABLE IF EXISTS pwa_device ADD COLUMN IF NOT EXISTS push_enabled BOOLEAN DEFAULT FALSE;
+ALTER TABLE IF EXISTS "user" ADD COLUMN IF NOT EXISTS pwa_after_hours_push_enabled BOOLEAN DEFAULT FALSE;
+ALTER TABLE IF EXISTS contractor_contracts ADD COLUMN IF NOT EXISTS documenso_document_id TEXT;
+ALTER TABLE IF EXISTS contractor_contracts ADD COLUMN IF NOT EXISTS documenso_signing_url TEXT;
+ALTER TABLE IF EXISTS contractor_contracts ADD COLUMN IF NOT EXISTS signature_status TEXT;
+ALTER TABLE IF EXISTS contract_signers ADD COLUMN IF NOT EXISTS documenso_recipient_id TEXT;
+ALTER TABLE IF EXISTS contract_signers ADD COLUMN IF NOT EXISTS signing_url TEXT;
+ALTER TABLE IF EXISTS contract_signers ADD COLUMN IF NOT EXISTS status TEXT;
+CREATE TABLE IF NOT EXISTS documenso_signature_requests (
+  id BIGSERIAL PRIMARY KEY,
+  contract_id UUID NOT NULL,
+  documenso_document_id TEXT NOT NULL,
+  signing_url TEXT,
+  recipient_id TEXT,
+  status TEXT NOT NULL DEFAULT 'sent',
+  response_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_documenso_signature_requests_contract_doc_recipient
+  ON documenso_signature_requests (contract_id, documenso_document_id, COALESCE(recipient_id, ''));
+CREATE TABLE IF NOT EXISTS documenso_webhook_events (
+  id BIGSERIAL PRIMARY KEY,
+  event_id TEXT UNIQUE,
+  documenso_document_id TEXT,
+  event_type TEXT,
+  verified BOOLEAN NOT NULL DEFAULT FALSE,
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  processed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+COMMIT;
+-- Rollback notes: drop only columns/index/tables created above after confirming no production Documenso data is needed.

--- a/scripts/verify_paylink_deploy.sh
+++ b/scripts/verify_paylink_deploy.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+APP_ROOT="${APP_ROOT:-$(pwd)}"
+PORT="${PORT:-8000}"
+HOST="${HOST:-127.0.0.1}"
+INDEX_CANDIDATES=(
+  "$APP_ROOT/dist/public/index.html"
+  "$APP_ROOT/dist/index.html"
+  "$APP_ROOT/build/index.html"
+  "$APP_ROOT/index.html"
+)
+found=""
+for f in "${INDEX_CANDIDATES[@]}"; do
+  if [[ -f "$f" ]]; then found="$f"; break; fi
+done
+if [[ -z "$found" ]]; then
+  echo "ERROR: frontend index.html missing; checked: ${INDEX_CANDIDATES[*]}" >&2
+  exit 20
+fi
+echo "frontend_index=$found"
+listeners=$(ss -lntp 2>/dev/null | awk -v p=":$PORT" '$4 ~ p {print}' || true)
+count=$(printf '%s\n' "$listeners" | sed '/^$/d' | wc -l | tr -d ' ')
+echo "$listeners"
+if [[ "$count" -gt 1 ]]; then
+  echo "ERROR: multiple listeners on $HOST:$PORT" >&2
+  exit 21
+fi
+if command -v pm2 >/dev/null 2>&1; then pm2 list; else echo "pm2_unavailable=1"; fi
+if curl -fsSI "http://$HOST:$PORT" >/tmp/paylink_headers.$$ 2>/dev/null; then cat /tmp/paylink_headers.$$; rm -f /tmp/paylink_headers.$$; fi

--- a/services/api_json_guard.py
+++ b/services/api_json_guard.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+_ALLOWED_BINARY = {"application/pdf", "application/octet-stream", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"}
+
+
+def should_warn_api_non_json(path: str, status_code: int, mimetype: str | None) -> bool:
+    if not path.startswith("/api/"):
+        return False
+    if status_code in (204, 304):
+        return False
+    mt = (mimetype or "").split(";")[0].lower()
+    if mt in _ALLOWED_BINARY or mt.startswith("image/") or mt.startswith("audio/"):
+        return False
+    return mt not in {"application/json", "text/json"}

--- a/services/appdoctor_sql.py
+++ b/services/appdoctor_sql.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from sqlalchemy import text
+
+
+def insert_appdoctor_run_sql():
+    return text("""
+        INSERT INTO appdoctor_runs
+          (company_id, user_id, model, prompt, response, status, error_message, metadata, started_at, completed_at)
+        VALUES
+          (CAST(:company_id AS integer), CAST(:user_id AS integer), CAST(:model AS text), CAST(:prompt AS text),
+           CAST(:response AS text), CAST(:status AS text), CAST(:error_message AS text), CAST(:metadata AS jsonb),
+           CAST(:started_at AS timestamptz), CAST(:completed_at AS timestamptz))
+        RETURNING id
+    """)

--- a/services/contract_notifications.py
+++ b/services/contract_notifications.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from sqlalchemy import text
+
+
+def activation_recipients_sql() -> str:
+    return """
+        SELECT u.id AS user_id,
+               u.email,
+               COALESCE(NULLIF(c.phone, ''), NULLIF(cs.phone, '')) AS phone
+          FROM contract_signers cs
+          LEFT JOIN "user" u ON u.id = cs.user_id
+          LEFT JOIN contact c ON c.id = cs.contact_id
+         WHERE cs.contract_id = CAST(:contract_id AS uuid)
+    """
+
+
+def fetch_activation_recipients(db_session, contract_id: str):
+    return [dict(r._mapping) for r in db_session.execute(text(activation_recipients_sql()), {"contract_id": contract_id})]

--- a/services/documenso_service.py
+++ b/services/documenso_service.py
@@ -1,0 +1,86 @@
+"""Documenso production safety helpers.
+
+Centralizes config validation, webhook signature checking, and persistence SQL for
+contract signing requests without logging secrets.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import text
+
+
+@dataclass(frozen=True)
+class DocumensoConfig:
+    api_key_present: bool
+    webhook_secret_present: bool
+    base_url: str
+    enabled: bool
+
+
+def load_documenso_config(env: dict[str, str] | None = None) -> DocumensoConfig:
+    env = env or os.environ
+    api_key = (env.get("DOCUMENSO_API_KEY") or "").strip()
+    webhook_secret = (env.get("DOCUMENSO_WEBHOOK_SECRET") or "").strip()
+    base_url = (env.get("DOCUMENSO_BASE_URL") or env.get("DOCUMENSO_PUBLIC_URL") or "https://document.luxit.app").strip().rstrip("/")
+    return DocumensoConfig(bool(api_key), bool(webhook_secret), base_url, bool(api_key))
+
+
+def validate_documenso_startup(require_api_key: bool | None = None, env: dict[str, str] | None = None) -> DocumensoConfig:
+    cfg = load_documenso_config(env)
+    if require_api_key is None:
+        require_api_key = (env or os.environ).get("DOCUMENSO_REQUIRED", "").lower() in {"1", "true", "yes"}
+    if require_api_key and not cfg.api_key_present:
+        raise RuntimeError("DOCUMENSO_API_KEY is required; send-for-signature is disabled until configured")
+    return cfg
+
+
+def send_for_signature_available(env: dict[str, str] | None = None) -> bool:
+    return load_documenso_config(env).enabled
+
+
+def verify_webhook_signature(raw_body: bytes, signature_header: str | None, secret: str | None = None) -> bool:
+    secret = secret if secret is not None else os.environ.get("DOCUMENSO_WEBHOOK_SECRET")
+    if not secret:
+        return True
+    if not signature_header:
+        return False
+    provided = signature_header.split(",")[-1].split("=")[-1].strip()
+    expected = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(provided, expected)
+
+
+def persist_signature_request(db_session: Any, *, contract_id: str, document_id: str, signing_url: str | None, recipient_id: str | None, status: str = "sent", response_payload: dict[str, Any] | None = None) -> None:
+    """Persist Documenso IDs idempotently across all contract signing tables."""
+    payload = response_payload or {}
+    db_session.execute(text("""
+        UPDATE contractor_contracts
+           SET documenso_document_id = :document_id,
+               documenso_signing_url = COALESCE(:signing_url, documenso_signing_url),
+               signature_status = :status,
+               updated_at = NOW()
+         WHERE id = CAST(:contract_id AS uuid)
+    """), {"contract_id": contract_id, "document_id": document_id, "signing_url": signing_url, "status": status})
+    db_session.execute(text("""
+        UPDATE contract_signers
+           SET documenso_recipient_id = COALESCE(:recipient_id, documenso_recipient_id),
+               signing_url = COALESCE(:signing_url, signing_url),
+               status = :status,
+               updated_at = NOW()
+         WHERE contract_id = CAST(:contract_id AS uuid)
+    """), {"contract_id": contract_id, "recipient_id": recipient_id, "signing_url": signing_url, "status": status})
+    db_session.execute(text("""
+        INSERT INTO documenso_signature_requests
+            (contract_id, documenso_document_id, signing_url, recipient_id, status, response_payload, created_at, updated_at)
+        VALUES
+            (CAST(:contract_id AS uuid), :document_id, :signing_url, :recipient_id, :status, CAST(:payload AS jsonb), NOW(), NOW())
+        ON CONFLICT (contract_id, documenso_document_id, COALESCE(recipient_id, ''))
+        DO UPDATE SET signing_url = COALESCE(EXCLUDED.signing_url, documenso_signature_requests.signing_url),
+                      status = EXCLUDED.status,
+                      response_payload = EXCLUDED.response_payload,
+                      updated_at = NOW()
+    """), {"contract_id": contract_id, "document_id": document_id, "signing_url": signing_url, "recipient_id": recipient_id, "status": status, "payload": __import__('json').dumps(payload)})

--- a/tests/test_paylink_production_fixes.py
+++ b/tests/test_paylink_production_fixes.py
@@ -1,0 +1,65 @@
+import json
+
+from services.api_json_guard import should_warn_api_non_json
+from services.appdoctor_sql import insert_appdoctor_run_sql
+from services.contract_notifications import activation_recipients_sql
+from services.documenso_service import load_documenso_config, send_for_signature_available, verify_webhook_signature
+
+
+def test_documenso_config_validation_disables_send_when_api_key_missing():
+    env = {"DOCUMENSO_WEBHOOK_SECRET": "whsec"}
+    cfg = load_documenso_config(env)
+    assert not cfg.api_key_present
+    assert not send_for_signature_available(env)
+
+
+def test_documenso_webhook_signature_verification():
+    import hmac, hashlib
+    body = b'{"event":"document.completed"}'
+    sig = hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+    assert verify_webhook_signature(body, f"sha256={sig}", "secret") is True
+    assert verify_webhook_signature(body, "sha256=bad", "secret") is False
+    assert verify_webhook_signature(body, None, "secret") is False
+
+
+def test_contract_notification_query_does_not_reference_missing_users_phone_as_only_source():
+    sql = activation_recipients_sql()
+    assert "u.phone" not in sql
+    assert "COALESCE(NULLIF(c.phone" in sql
+    assert "cs.phone" in sql
+
+
+def test_appdoctor_insert_casts_nullable_parameters():
+    sql = str(insert_appdoctor_run_sql())
+    for cast in ["CAST(:metadata AS jsonb)", "CAST(:error_message AS text)", "CAST(:completed_at AS timestamptz)"]:
+        assert cast in sql
+
+
+def test_api_json_guard_ignores_304_and_pdf_but_warns_html_fallthrough():
+    assert should_warn_api_non_json("/api/contracts", 304, "text/html") is False
+    assert should_warn_api_non_json("/api/content/export/pdf", 200, "application/pdf") is False
+    assert should_warn_api_non_json("/api/missing", 200, "text/html") is True
+    assert should_warn_api_non_json("/dashboard", 200, "text/html") is False
+
+
+def test_documenso_persist_sql_contains_idempotent_conflict_clause():
+    import inspect
+    from services import documenso_service
+    src = inspect.getsource(documenso_service.persist_signature_request)
+    assert "ON CONFLICT" in src
+    assert "contractor_contracts" in src
+    assert "contract_signers" in src
+    assert "documenso_signature_requests" in src
+
+
+def test_schema_drift_preference_columns_are_narrow_compatibility_only():
+    sql = open("migrations/20260623_paylink_documenso_production_fix.sql").read()
+    assert "ADD COLUMN IF NOT EXISTS push_enabled" in sql
+    assert "ADD COLUMN IF NOT EXISTS pwa_after_hours_push_enabled" in sql
+
+
+def test_paylink_signing_deploy_smoke_checks_index_and_port_guard():
+    script = open("scripts/verify_paylink_deploy.sh").read()
+    assert "dist/public/index.html" in script
+    assert "multiple listeners" in script
+    assert "pm2 list" in script


### PR DESCRIPTION
### Motivation

- Harden PayLink/Documenso signing flow by validating runtime config, preventing accidental secret logging, and ensuring idempotent persistence of signing identifiers.
- Detect unexpected non-JSON responses from API endpoints to aid debugging and reduce silent API client breakage.
- Add narrow schema-drift compatibility columns and tables required by the Documenso signing/notification path and add simple deploy/startup smoke checks.

### Description

- Add `services/documenso_service.py` to centralize Documenso config loading, startup validation (`validate_documenso_startup`), webhook signature verification (`verify_webhook_signature`), and idempotent persistence (`persist_signature_request`).
- Integrate Documenso startup validation into `create_app()` in `app.py` with safe logging (no secret values) and optional hard-fail when `DOCUMENSO_REQUIRED` is set.
- Add `services/api_json_guard.py` and wire it into `app.after_request` to log warnings when `/api/` endpoints return non-JSON (excluding allowed binary/image/audio types) for non-no-content statuses.
- Add SQL migration `migrations/20260623_paylink_documenso_production_fix.sql` to create compatibility columns and Documenso-related tables and indexes.
- Add helper services `services/appdoctor_sql.py` and `services/contract_notifications.py` for SQL used by signing and notifications, and add `tests/test_paylink_production_fixes.py` unit tests covering the new behaviors.
- Add `scripts/verify_paylink_deploy.sh` and `ecosystem.config.cjs` plus documentation files `docs/*` describing audit and scope decisions.

### Testing

- Ran the new unit tests with `pytest tests/test_paylink_production_fixes.py` and all assertions passed.
- The tests exercise `load_documenso_config`, `send_for_signature_available`, `verify_webhook_signature`, `should_warn_api_non_json`, SQL generation helpers, and the migration contents, and they succeeded.
- No automated integration or live VPS audit was performed as part of these tests; the `docs/documenso_vps_audit_status_20260624.md` notes the required next manual audit step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3aafdbfb748322bda90a0626fd745f)