### PR TITLE
PWA: per-user push decisioning, badge counts, and service-worker improvements

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -1819,6 +1819,65 @@ def unread_count():
 
 
 
+
+def _pwa_badge_counts_for(user, company):
+    """Tenant- and user-scoped communication badge counts for installed PWAs."""
+    from models import Notification, TwilioCallLog, TwilioConversation, VoiceVoicemailMessage
+    from services.comms_permissions import filter_calls_for_user, filter_conversations_for_user
+
+    sms_unread = filter_conversations_for_user(
+        TwilioConversation.query.filter_by(company_id=company.id, is_read=False),
+        user, company.id,
+    ).all()
+    sms_unread = [c for c in sms_unread if not _is_archived_conversation(c)]
+
+    missed_calls = filter_calls_for_user(
+        TwilioCallLog.query.filter_by(company_id=company.id, direction="inbound", is_read=False, is_archived=False),
+        user, company.id,
+    ).filter(TwilioCallLog.status.in_(["missed", "no-answer", "busy", "failed"])).count()
+
+    voicemails = VoiceVoicemailMessage.query.filter_by(
+        company_id=company.id,
+        is_read=False,
+        is_deleted=False,
+    )
+    try:
+        from models import TwilioPhoneNumber
+        accessible_numbers = _accessible_numbers_for(user, company.id)
+        accessible_ids = [pn.id for pn in TwilioPhoneNumber.query.filter(TwilioPhoneNumber.company_id == company.id, TwilioPhoneNumber.phone_number.in_(accessible_numbers or ["__none__"])).all()]
+        if accessible_ids:
+            voicemails = voicemails.filter(db.or_(VoiceVoicemailMessage.phone_number_id.is_(None), VoiceVoicemailMessage.phone_number_id.in_(accessible_ids)))
+    except Exception:
+        pass
+    voicemails = voicemails.count()
+
+    notifications = Notification.query.filter_by(
+        user_id=user.id,
+        company_id=company.id,
+        is_read=False,
+    ).count()
+
+    total = len(sms_unread) + missed_calls + voicemails + notifications
+    return {
+        "count": total,
+        "smsUnread": len(sms_unread),
+        "missedCalls": missed_calls,
+        "voicemails": voicemails,
+        "notifications": notifications,
+    }
+
+
+@inbox_pwa_bp.route("/api/pwa/badge-count")
+def pwa_badge_count():
+    user = _require_auth()
+    company = _get_company(user)
+    if not company:
+        return jsonify({"count": 0, "smsUnread": 0, "missedCalls": 0, "voicemails": 0, "notifications": 0})
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
+    return jsonify(_pwa_badge_counts_for(user, company))
+
 # ── API: PWA notification center ─────────────────────────────────────────────
 
 def _notification_to_dict(row):
@@ -1862,8 +1921,8 @@ def _authorized_notification_users(company_id: int, phone_number_id=None):
 
 def _event_allowed_for_user(user, event_type: str) -> bool:
     event_type = (event_type or "").lower()
-    if event_type in {"inbound_sms", "new_message", "unread_message_reminder"}:
-        attr = "pwa_unread_reminder_alerts_enabled" if event_type == "unread_message_reminder" else "pwa_text_alerts_enabled"
+    if event_type in {"inbound_sms", "incoming_sms", "new_message", "unread_message_reminder", "unread_reminder"}:
+        attr = "pwa_unread_reminder_alerts_enabled" if event_type in {"unread_message_reminder", "unread_reminder"} else "pwa_text_alerts_enabled"
     elif event_type in {"incoming_call", "missed_call", "call"}:
         attr = "pwa_call_alerts_enabled"
     elif event_type in {"voicemail", "new_voicemail"}:
@@ -1872,6 +1931,58 @@ def _event_allowed_for_user(user, event_type: str) -> bool:
         attr = None
     return True if not attr else getattr(user, attr, True) is not False
 
+
+
+def _canonical_push_event_type(event_type: str) -> str:
+    aliases = {
+        "inbound_sms": "incoming_sms",
+        "new_message": "incoming_sms",
+        "unread_message_reminder": "unread_reminder",
+        "new_voicemail": "voicemail",
+        "call": "missed_call",
+    }
+    return aliases.get((event_type or "notification").lower(), (event_type or "notification").lower())
+
+
+def _hm_to_minutes(value):
+    try:
+        hour, minute = [int(part) for part in (value or "").split(":", 1)]
+        if 0 <= hour <= 23 and 0 <= minute <= 59:
+            return hour * 60 + minute
+    except Exception:
+        return None
+    return None
+
+
+def _now_in_user_quiet_hours(user, now=None) -> bool:
+    start = _hm_to_minutes(getattr(user, "pwa_quiet_hours_start", None))
+    end = _hm_to_minutes(getattr(user, "pwa_quiet_hours_end", None))
+    if start is None or end is None or start == end:
+        return False
+    now = now or datetime.now()
+    current = now.hour * 60 + now.minute
+    return start <= current < end if start < end else (current >= start or current < end)
+
+
+def _push_debug_decision(user, event_type: str, *, requested_silent: bool, in_business_hours=True):
+    canonical = _canonical_push_event_type(event_type)
+    if not _event_allowed_for_user(user, event_type) and not _event_allowed_for_user(user, canonical):
+        return {"send": False, "reason": "user_alert_preference_disabled", "event_type": canonical}
+    if getattr(user, "pwa_alerts_business_hours_only", True) is not False and in_business_hours is False and getattr(user, "pwa_after_hours_push_enabled", False) is not True:
+        return {"send": False, "reason": "outside_business_hours_and_after_hours_push_disabled", "event_type": canonical}
+    quiet = _now_in_user_quiet_hours(user)
+    sound_enabled = getattr(user, "notification_sounds_enabled", True) is not False
+    silent = bool(requested_silent or quiet or not sound_enabled)
+    vibration_enabled = getattr(user, "pwa_vibration_enabled", True) is not False
+    return {
+        "send": True,
+        "reason": "quiet_hours" if quiet else ("sound_preference_disabled" if not sound_enabled else "alert_enabled"),
+        "event_type": canonical,
+        "silent": silent,
+        "vibrate": [200, 100, 200] if (vibration_enabled and not silent) else [],
+        "sound": None if silent else "default",
+        "renotify": True,
+    }
 
 def _notification_payload_preferences(user, *, silent: bool = False):
     return {
@@ -1998,27 +2109,79 @@ def _send_web_push_to_subscriptions(subscriptions, payload: dict):
     db.session.commit()
     return {"sent": sent, "errors": errors}
 
-def send_pwa_push_notification(company_id: int, *, user_ids, title: str, body: str, link: str = "/app/inbox", tag: str = "luxit-inbox", event_type: str = "notification", phone_number_id=None, silent: bool = False):
+def send_pwa_push_notification(company_id: int, *, user_ids, title: str, body: str, link: str = "/app/inbox", tag: str = "luxit-inbox", event_type: str = "notification", phone_number_id=None, silent: bool = False, in_business_hours=True):
     """Internal tenant-scoped push helper for notifications already permission-filtered by caller."""
-    from models import PushSubscription
-    from models import User
+    from models import PushSubscription, User
     ids = [int(uid) for uid in (user_ids or [])]
-    if ids:
-        users = User.query.filter(User.id.in_(ids)).all()
-        ids = [u.id for u in users if _event_allowed_for_user(u, event_type)]
     if not ids:
-        return {"sent": 0, "errors": []}
-    subs = PushSubscription.query.filter(
-        PushSubscription.company_id == company_id,
-        PushSubscription.user_id.in_(ids),
-        PushSubscription.is_active.is_(True),
-    ).all()
-    return _send_web_push_to_subscriptions(subs, {
-        "title": title, "body": body, "url": link, "tag": tag, "eventType": event_type,
-        "icon": "/static/favicon.png", "badge": "/static/favicon.png", "sound": None if silent else "default",
-        "silent": bool(silent), "vibrate": [] if silent else [80, 40, 80],
-        "data": {"company_id": company_id, "phone_number_id": phone_number_id, "event_type": event_type, "silent": bool(silent)},
-    })
+        return {"sent": 0, "errors": [], "debug": []}
+
+    users = User.query.filter(User.id.in_(ids)).all()
+    total = 0
+    errors = []
+    debug = []
+    for user in users:
+        decision = _push_debug_decision(user, event_type, requested_silent=silent, in_business_hours=in_business_hours)
+        decision.update({"user_id": user.id})
+        debug.append(decision)
+        if not decision.get("send"):
+            continue
+        subs = PushSubscription.query.filter_by(
+            company_id=company_id,
+            user_id=user.id,
+            is_active=True,
+        ).all()
+        decision["active_subscriptions"] = len(subs)
+        try:
+            from models import Company
+            company = db.session.get(Company, company_id)
+            badge_count = _pwa_badge_counts_for(user, company)["count"] if company else None
+        except Exception:
+            badge_count = None
+        payload = {
+            "title": title,
+            "body": body,
+            "url": link,
+            "tag": tag,
+            "renotify": True,
+            "requireInteraction": False,
+            "eventType": decision["event_type"],
+            "icon": "/static/icons/icon-192.png",
+            "badge": "/static/icons/badge-72.png",
+            "sound": decision["sound"],
+            "silent": bool(decision["silent"]),
+            "vibrate": decision["vibrate"],
+            "data": {
+                "company_id": company_id,
+                "phone_number_id": phone_number_id,
+                "event_type": decision["event_type"],
+                "silent": bool(decision["silent"]),
+                "debug_reason": decision["reason"],
+                "badgeCount": badge_count,
+            },
+            "badgeCount": badge_count,
+        }
+        result = _send_web_push_to_subscriptions(subs, payload)
+        total += result.get("sent", 0)
+        errors.extend(result.get("errors", []))
+    return {"sent": total, "errors": errors, "debug": debug}
+
+
+@inbox_pwa_bp.route("/api/pwa/push/debug")
+def pwa_push_debug():
+    """Explain whether the current user's next PWA push would alert, vibrate, or be skipped."""
+    user = _require_auth()
+    company = _require_company(user)
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
+    event_type = request.args.get("event_type") or "incoming_sms"
+    in_business = str(request.args.get("in_business_hours", "1")).lower() not in {"0", "false", "no"}
+    decision = _push_debug_decision(user, event_type, requested_silent=False, in_business_hours=in_business)
+    from models import PushSubscription
+    active_subscriptions = PushSubscription.query.filter_by(company_id=company.id, user_id=user.id, is_active=True).count()
+    return jsonify({"success": True, "active_subscription": active_subscriptions > 0, "active_subscriptions": active_subscriptions, "decision": decision})
+
 
 # ── API: Push notification subscribe ─────────────────────────────────────────
 
@@ -2127,6 +2290,11 @@ def push_test():
         "icon": "/static/favicon.png",
         "badge": "/static/favicon.png",
         "sound": "default",
+        "silent": False,
+        "vibrate": [200, 100, 200],
+        "renotify": True,
+        "requireInteraction": False,
+        "data": {"event_type": "push_test", "silent": False},
     })
     sent = result["sent"]
     errors = result["errors"]
@@ -2517,7 +2685,7 @@ def _fire_push_notification(company_id: int, conv, message_body: str, *, silent:
     link = f"/app/inbox?conv={conv.id}"
     _create_notification_records(
         company_id,
-        event_type="inbound_sms",
+        event_type="incoming_sms",
         title=title,
         notification_body=notification_body,
         link=link,
@@ -2527,9 +2695,7 @@ def _fire_push_notification(company_id: int, conv, message_body: str, *, silent:
 
     allowed_user_ids = [u.id for u in _authorized_notification_users(company_id, phone_number_id)]
     in_business = _conversation_in_business_hours(conv)
-    silent = (not in_business) if silent is None else bool(silent)
-    if silent:
-        allowed_user_ids = [u.id for u in _authorized_notification_users(company_id, phone_number_id) if getattr(u, "pwa_after_hours_push_enabled", False) is True]
+    silent = False if silent is None else bool(silent)
     send_pwa_push_notification(
         company_id,
         user_ids=allowed_user_ids,
@@ -2537,9 +2703,10 @@ def _fire_push_notification(company_id: int, conv, message_body: str, *, silent:
         body=notification_body,
         link=link,
         tag=f"sms-{conv.id}",
-        event_type="inbound_sms",
+        event_type="incoming_sms",
         phone_number_id=phone_number_id,
         silent=silent,
+        in_business_hours=in_business,
     )
 
 

--- a/static/sw.js
+++ b/static/sw.js
@@ -44,19 +44,32 @@ self.addEventListener('fetch', e => {
 self.addEventListener('push', e => {
   let data = { title: 'LUXit Inbox', body: 'New message', url: '/app/inbox' };
   try { data = e.data ? e.data.json() : data; } catch {}
+  const badgeCount = data.badgeCount ?? (data.data && data.data.badgeCount);
+  const updateBadge = () => {
+    if (!self.registration.setAppBadge && !self.registration.clearAppBadge) return Promise.resolve();
+    if (!Number.isFinite(Number(badgeCount)) || Number(badgeCount) <= 0) {
+      return self.registration.clearAppBadge ? self.registration.clearAppBadge() : Promise.resolve();
+    }
+    return self.registration.setAppBadge ? self.registration.setAppBadge(Number(badgeCount)) : Promise.resolve();
+  };
   e.waitUntil(
-    self.registration.showNotification(data.title, {
+    Promise.all([
+      updateBadge(),
+      self.registration.showNotification(data.title, {
       body:    data.body,
       icon:    data.icon || '/static/favicon.png',
       badge:   data.badge || '/static/favicon.png',
       tag:     data.tag || 'luxit-inbox',
       data:    Object.assign({ url: data.url || '/app/inbox' }, data.data || {}),
-      vibrate: data.vibrate || [80, 40, 80],
+      renotify: data.renotify !== false,
+      requireInteraction: data.requireInteraction === true,
+      vibrate: data.silent === true ? [] : (data.vibrate || [200, 100, 200]),
       silent:  data.silent === true,
-      // Browsers/OSes may ignore custom push sounds; foreground sounds are handled in-app.
-      sound:   data.sound,
-      actions: [{ action: 'open', title: 'Open Inbox' }],
-    })
+      // Android Chrome/PWA uses the app/channel default sound when silent is false.
+      sound:   data.sound || 'default',
+        actions: [{ action: 'open', title: 'Open Inbox' }],
+      })
+    ])
   );
 });
 

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -847,7 +847,7 @@
         <div class="settings-account-sub">{{ user.email or '' }}</div>
       </div>
     </div>
-    <a href="/logout" class="settings-action-btn settings-signout">
+    <a href="/logout" class="settings-action-btn settings-signout" onclick="updateAppBadge(0)">
       <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
       Sign Out
     </a>
@@ -1382,8 +1382,9 @@ function handleSSEEvent(data) {
       ci.classList.add('new-flash');
     }
 
-    // Refresh conversations list
+    // Refresh conversations list and app badge
     loadConversations();
+    loadBadgeCounts();
 
     // If we're in this conversation, append the message immediately
     if (state.activeConvId === data.conversation_id) {
@@ -1484,6 +1485,7 @@ async function loadConversations() {
   renderConvList(state.conversations, data);
   cacheConversations(state.conversations);
   updateUnreadBadge(data.unread_count);
+  loadBadgeCounts();
 }
 
 function mergeConversations(current, incoming) {
@@ -2044,17 +2046,26 @@ async function refreshApp() {
   }
 }
 
-/* ── Badge counts (missed calls + voicemail) ───────────────────── */
+/* ── PWA app badge counts ─────────────────────────────────────── */
+async function updateAppBadge(count) {
+  try {
+    const n = Number(count || 0);
+    if (n > 0 && 'setAppBadge' in navigator) await navigator.setAppBadge(n);
+    else if (n <= 0 && 'clearAppBadge' in navigator) await navigator.clearAppBadge();
+  } catch (e) {}
+}
+
 async function loadBadgeCounts() {
   try {
-    const data = await apiFetch('/api/inbox/badge-counts');
+    const data = await apiFetch('/api/pwa/badge-count');
     if (!data) return;
-    const mc = data.missed_calls || 0;
-    const vm = data.voicemails   || 0;
+    const mc = data.missedCalls || 0;
+    const vm = data.voicemails  || 0;
     const mcBadge = document.getElementById('missedCallsBadge');
     const vmBadge = document.getElementById('vmBadge');
     if (mcBadge) { mcBadge.textContent = mc; mcBadge.style.display = mc > 0 ? 'flex' : 'none'; }
     if (vmBadge) { vmBadge.textContent = vm; vmBadge.style.display = vm > 0 ? 'flex' : 'none'; }
+    await updateAppBadge(data.count || 0);
   } catch (e) {}
 }
 
@@ -2161,6 +2172,7 @@ async function markCurrentRead(isRead = true) {
     renderConvList(state.conversations);
     toast(isRead ? 'Marked as read.' : 'Marked as unread.');
     loadConversations();
+    loadBadgeCounts();
   }
 }
 

--- a/tests/test_pwa_communications_completion.py
+++ b/tests/test_pwa_communications_completion.py
@@ -112,8 +112,8 @@ def test_push_subscription_and_notifications_are_permission_scoped(pwa_app, monk
         conv = TwilioConversation(company_id=ids["company"], phone_number_id=ids["line"], from_number="+14155551212", to_number="+15550001000", contact_name="John Smith")
         db.session.add(conv); db.session.commit()
         inbox_pwa._fire_push_notification(ids["company"], conv, "Hello")
-        assert Notification.query.filter_by(user_id=ids["staff"], event_type="inbound_sms").count() == 1
-        assert Notification.query.filter_by(user_id=ids["denied"], event_type="inbound_sms").count() == 0
+        assert Notification.query.filter_by(user_id=ids["staff"], event_type="incoming_sms").count() == 1
+        assert Notification.query.filter_by(user_id=ids["denied"], event_type="incoming_sms").count() == 0
         assert ids["staff"] in sent["payload"]["user_ids"]
         assert ids["denied"] not in sent["payload"]["user_ids"]
         inbox_pwa.create_pwa_notification(ids["company"], event_type="voicemail", title="New voicemail", body="Voicemail", phone_number_id=ids["line"], link="/app/calls")
@@ -128,6 +128,7 @@ def test_pwa_static_assets_support_unified_theme_voicemail_and_push_behaviors():
     assert "--pwa-primary" in calls and "pwa-card" in calls and "voicemail/audio" in calls
     assert "Play Voicemail" in calls and "Call Recording" in calls
     assert "self.addEventListener('push'" in sw
+    assert "self.registration.setAppBadge" in sw and "self.registration.clearAppBadge" in sw
     assert "notificationclick" in sw and "clients.openWindow" in sw
     assert "function playSound" in index and "notificationSoundsEnabled" in index
     assert "vibrate" in index and "EventSource('/api/inbox/stream')" in index
@@ -315,7 +316,7 @@ def test_unread_reminders_obey_business_hours_and_stop_conditions(pwa_app, monke
         assert sent and sent[0]["event_type"] == "unread_message_reminder"
 
 
-def test_after_hours_sms_push_is_silent_and_requires_after_hours_opt_in(pwa_app, monkeypatch):
+def test_after_hours_sms_push_is_not_silent_and_defers_skip_decision_to_user_preferences(pwa_app, monkeypatch):
     app, _client, ids = pwa_app
     import inbox_pwa
     with app.app_context():
@@ -328,12 +329,9 @@ def test_after_hours_sms_push_is_silent_and_requires_after_hours_opt_in(pwa_app,
         sent = []
         monkeypatch.setattr(inbox_pwa, "send_pwa_push_notification", lambda company_id, **kw: sent.append(kw) or {"sent": len(kw.get("user_ids", [])), "errors": []})
         inbox_pwa._fire_push_notification(ids["company"], conv, "after hours", silent=None)
-        assert sent[-1]["silent"] is True
-        assert ids["staff"] not in sent[-1]["user_ids"]
-        user.pwa_after_hours_push_enabled = True
-        db.session.commit()
-        inbox_pwa._fire_push_notification(ids["company"], conv, "after hours", silent=None)
-        assert sent[-1]["silent"] is True
+        assert sent[-1]["silent"] is False
+        assert sent[-1]["event_type"] == "incoming_sms"
+        assert sent[-1]["in_business_hours"] is False
         assert ids["staff"] in sent[-1]["user_ids"]
 
 
@@ -343,8 +341,10 @@ def test_service_worker_and_in_app_alerts_honor_silent_sound_vibration_flags():
     assert "if (!data.silent)" in index
     assert "vibrateIfEnabled([80, 40, 80])" in index
     assert "playSound('sms-'" in index
+    assert "navigator.setAppBadge" in index and "navigator.clearAppBadge" in index
     assert "silent:  data.silent === true" in sw
-    assert "vibrate: data.vibrate || [80, 40, 80]" in sw
+    assert "renotify: data.renotify !== false" in sw
+    assert "vibrate: data.silent === true ? [] : (data.vibrate || [200, 100, 200])" in sw
 
 
 def test_call_missed_voicemail_and_reminder_notifications_emit_push_and_sse(pwa_app, monkeypatch):
@@ -382,3 +382,53 @@ def test_unread_reminder_stops_for_resolved_or_closed_tags(pwa_app, monkeypatch)
         result = inbox_pwa.create_unread_message_reminders()
         assert result["created"] == 0
         assert Notification.query.filter_by(event_type="unread_message_reminder").count() == 0
+
+def test_pwa_badge_count_endpoint_is_user_and_company_scoped(pwa_app):
+    app, client, ids = pwa_app
+    with app.app_context():
+        conv = TwilioConversation(company_id=ids["company"], phone_number_id=ids["line"], from_number="+14155550001", to_number="+15550001000", is_read=False, last_message_preview="Unread")
+        hidden_conv = TwilioConversation(company_id=ids["company"], phone_number_id=ids["other_line"], from_number="+14155550002", to_number="+15550002000", is_read=False, last_message_preview="Hidden")
+        call = TwilioCallLog(company_id=ids["company"], phone_number_id=ids["line"], twilio_sid="CAmissed", direction="inbound", from_number="+14155550003", to_number="+15550001000", status="missed", is_read=False)
+        vm_call = TwilioCallLog(company_id=ids["company"], phone_number_id=ids["line"], twilio_sid="CAvoice", direction="inbound", from_number="+14155550004", to_number="+15550001000", status="voicemail", is_read=False)
+        db.session.add_all([conv, hidden_conv, call, vm_call]); db.session.flush()
+        vm = VoiceVoicemailMessage(company_id=ids["company"], call_log_id=vm_call.id, phone_number_id=ids["line"], recording_url="https://example.test/vm.mp3", is_read=False)
+        note = Notification(user_id=ids["staff"], company_id=ids["company"], event_type="missed_call", title="Pending", message="Pending", is_read=False)
+        db.session.add_all([vm, note]); db.session.commit()
+        call_id = call.id
+        conv_id = conv.id
+    login(client, ids["staff"])
+    data = client.get("/api/pwa/badge-count").get_json()
+    assert data == {"count": 4, "smsUnread": 1, "missedCalls": 1, "voicemails": 1, "notifications": 1}
+    client.patch(f"/api/inbox/conversations/{conv_id}/read", json={"is_read": True})
+    client.post(f"/api/calls/{call_id}/mark-read")
+    data = client.get("/api/pwa/badge-count").get_json()
+    assert data["smsUnread"] == 0
+    assert data["missedCalls"] == 0
+    assert data["count"] == 2
+
+
+def test_push_payload_non_silent_vibration_badge_and_quiet_hours(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import inbox_pwa
+    with app.app_context():
+        user = db.session.get(User, ids["staff"])
+        db.session.add(PushSubscription(user_id=ids["staff"], company_id=ids["company"], endpoint="https://push.example/sub/ios", p256dh="p", auth_key="a", is_active=True))
+        db.session.add(TwilioConversation(company_id=ids["company"], phone_number_id=ids["line"], from_number="+14155550005", to_number="+15550001000", is_read=False))
+        db.session.commit()
+        payloads = []
+        monkeypatch.setattr(inbox_pwa, "_send_web_push_to_subscriptions", lambda subs, payload: payloads.append(payload) or {"sent": len(subs), "errors": []})
+        inbox_pwa.send_pwa_push_notification(ids["company"], user_ids=[ids["staff"]], title="SMS", body="Body", event_type="incoming_sms", phone_number_id=ids["line"])
+        assert payloads[-1]["silent"] is False
+        assert payloads[-1]["vibrate"] == [200, 100, 200]
+        assert payloads[-1]["renotify"] is True
+        assert payloads[-1]["data"]["badgeCount"] >= 1
+        user.pwa_vibration_enabled = False
+        db.session.commit()
+        inbox_pwa.send_pwa_push_notification(ids["company"], user_ids=[ids["staff"]], title="iOS", body="Body", event_type="missed_call", phone_number_id=ids["line"])
+        assert payloads[-1]["silent"] is False
+        assert payloads[-1]["vibrate"] == []
+        user.pwa_quiet_hours_start = "00:00"
+        user.pwa_quiet_hours_end = "23:59"
+        db.session.commit()
+        inbox_pwa.send_pwa_push_notification(ids["company"], user_ids=[ids["staff"]], title="Quiet", body="Body", event_type="voicemail", phone_number_id=ids["line"])
+        assert payloads[-1]["silent"] is True

--- a/twilio_sms.py
+++ b/twilio_sms.py
@@ -1364,7 +1364,7 @@ def inbound_sms():
                 in_business_for_alert = _is_business_hours(ta.company_id, phone_config=ta)
             except Exception:
                 in_business_for_alert = True
-            alert_silent = (not in_business_for_alert) or bool(auto_reply_sent)
+            alert_silent = False
             _push_sse_event(ta.company_id, "new_message", {
                 "conversation_id":      conv.id,
                 "from_number":          from_number,


### PR DESCRIPTION
### Motivation
- Consolidate and normalize push event types and per-user delivery decisions so PWA notifications respect user prefs, quiet hours, and vibration/sound settings. 
- Expose a user- and tenant-scoped badge count API for PWAs so the app and OS badge reflect missed communications and notifications. 
- Improve service worker and client-side handling of vibration, sound, renotify, requireInteraction, and the App Badge API for a consistent cross-platform experience.

### Description
- Added `_pwa_badge_counts_for` and `/api/pwa/badge-count` to compute tenant- and user-scoped badge totals including unread SMS, missed calls, voicemails, and notifications via `Notification`, `TwilioCallLog`, `TwilioConversation`, and `VoiceVoicemailMessage` filtering. 
- Normalized event types and aliases via `_canonical_push_event_type` and extended `_event_allowed_for_user`, implemented `_push_debug_decision` to evaluate per-user send/silent/vibrate/sound decisions (quiet hours, business-hours, user prefs), and exposed a debug endpoint `/api/pwa/push/debug`. 
- Reworked `send_pwa_push_notification` to make per-user decisions, include debug info and `badgeCount` in payloads, and honor `in_business_hours` from callers. 
- Updated `_fire_push_notification` and notification creation to use the canonical `incoming_sms` event name and to pass `in_business_hours` and explicit `silent` behavior to the push sender. 
- Enhanced service worker (`static/sw.js`) to update the App Badge via `setAppBadge`/`clearAppBadge`, and to use `renotify`, `requireInteraction`, `sound`, and conditional `vibrate`/`silent` behavior from the push payload. 
- Updated client UI (`templates/inbox_pwa/index.html`) to load badge counts from the new endpoint, set/clear app badge using `navigator.setAppBadge`/`navigator.clearAppBadge`, clear badge on sign-out, and refresh badge counts after SSE events and actions. 
- Adjusted inbound SMS handling in `twilio_sms.py` to defer per-user silence logic to the new push decisioning (removed automatic `alert_silent` business-hours gating). 
- Updated tests in `tests/test_pwa_communications_completion.py` to reflect event renames, new badge endpoint, and push payload behaviors.

### Testing
- Ran the PWA communications test suite including `tests/test_pwa_communications_completion.py` which covers push subscriptions, permission scoping, service-worker asset checks, after-hours behavior, unread reminders, badge counts, and push payload flags, and all assertions passed. 
- Exercised the new `/api/pwa/badge-count` and `/api/pwa/push/debug` endpoints via unit tests to validate correct scoping and decision outputs. 
- Verified service worker and client-side static assertions in tests to ensure App Badge API usage and updated notification payload fields are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3e29902ec08322a354b3d7746862c7)