### PR TITLE
Fix PWA push debug authentication

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -2170,8 +2170,20 @@ def send_pwa_push_notification(company_id: int, *, user_ids, title: str, body: s
 @inbox_pwa_bp.route("/api/pwa/push/debug")
 def pwa_push_debug():
     """Explain whether the current user's next PWA push would alert, vibrate, or be skipped."""
-    user = _require_auth()
-    company = _require_company(user)
+    user = _current_user()
+    if not user:
+        return jsonify({
+            "success": False,
+            "code": "AUTHENTICATION_REQUIRED",
+            "error": "Authentication required. Open the PWA and sign in again.",
+        }), 401
+    company = _get_company(user)
+    if not company:
+        return jsonify({
+            "success": False,
+            "code": "NO_COMPANY",
+            "error": "No company is configured for this user.",
+        }), 409
     denied = _require_mobile_inbox_api_access(user, company)
     if denied:
         return denied
@@ -2180,7 +2192,15 @@ def pwa_push_debug():
     decision = _push_debug_decision(user, event_type, requested_silent=False, in_business_hours=in_business)
     from models import PushSubscription
     active_subscriptions = PushSubscription.query.filter_by(company_id=company.id, user_id=user.id, is_active=True).count()
-    return jsonify({"success": True, "active_subscription": active_subscriptions > 0, "active_subscriptions": active_subscriptions, "decision": decision})
+    return jsonify({
+        "success": True,
+        "user": {"id": user.id, "email": user.email, "username": user.username},
+        "company": {"id": company.id, "name": company.name},
+        "mobile_inbox_access": True,
+        "active_subscription": active_subscriptions > 0,
+        "active_subscriptions": active_subscriptions,
+        "decision": decision,
+    })
 
 
 # ── API: Push notification subscribe ─────────────────────────────────────────

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -967,6 +967,11 @@
       <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
       Check for Updates &amp; Refresh
     </button>
+    <button class="settings-action-btn" onclick="runPushDebug()" style="margin-top:6px;">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 17H2a3 3 0 0 0 3-3V9a7 7 0 0 1 14 0v5a3 3 0 0 0 3 3z"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+      Run Push Diagnostics
+    </button>
+    <div id="pushDebugResult" style="display:none;margin-top:8px;padding:8px;border-radius:8px;background:rgba(15,23,42,.72);border:1px solid rgba(148,163,184,.22);color:var(--pwa-muted);font-size:.78rem;white-space:pre-wrap;"></div>
     <a href="/dashboard" class="settings-action-btn" style="margin-top:6px;text-decoration:none;">
       <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
       Back to Dashboard
@@ -1430,15 +1435,17 @@ async function apiFetch(url, method = 'GET', body = null) {
   } catch (networkErr) {
     return { success: false, error: 'Network error — check your connection and try again.' };
   }
-  if (res.status === 401) { location.href = '/auth/login?next=/app/inbox'; return null; }
-  if (res.status === 403) return { success: false, error: 'Permission denied.' };
   // Parse JSON safely — server may return HTML on uncaught exceptions
   let data;
   try {
     data = await res.json();
   } catch {
+    if (res.status === 401) { location.href = '/auth/login?next=/app/inbox'; return null; }
+    if (res.status === 403) return { success: false, error: 'Permission denied.' };
     return { success: false, error: `Server error (${res.status}). Please try again.` };
   }
+  if (res.status === 401) { location.href = '/auth/login?next=/app/inbox'; return null; }
+  if (res.status === 403) return { success: false, error: data.error || 'Permission denied.' };
   // Promote non-OK HTTP responses that have JSON bodies
   if (!res.ok && data.error === undefined) {
     return { success: false, error: `Request failed (${res.status}).` };
@@ -2016,6 +2023,31 @@ async function togglePushFromSettings() {
   }
   await requestPush();
   openSettingsSheet(); // refresh labels
+}
+
+async function runPushDebug() {
+  const box = document.getElementById('pushDebugResult');
+  if (box) {
+    box.style.display = 'block';
+    box.textContent = 'Checking push diagnostics…';
+  }
+  const data = await apiFetch('/api/pwa/push/debug');
+  if (!data) return;
+  if (!data.success) {
+    if (box) box.textContent = data.error || 'Push diagnostics failed.';
+    toast(data.error || 'Push diagnostics failed');
+    return;
+  }
+  const decision = data.decision || {};
+  const lines = [
+    `Signed in as: ${(data.user && (data.user.email || data.user.username)) || 'current user'}`,
+    `Company: ${(data.company && data.company.name) || 'current company'}`,
+    `Active push subscriptions: ${data.active_subscriptions || 0}`,
+    `Decision: ${decision.send ? 'will send' : 'will not send'} (${decision.reason || 'unknown'})`,
+    `Sound: ${decision.sound || 'none'} · Vibration: ${(decision.vibrate || []).length ? 'on' : 'off'}`,
+  ];
+  if (box) box.textContent = lines.join('\n');
+  toast('Push diagnostics complete');
 }
 
 /* ── Refresh / check for updates ───────────────────────────────── */

--- a/tests/test_pwa_communications_completion.py
+++ b/tests/test_pwa_communications_completion.py
@@ -432,3 +432,45 @@ def test_push_payload_non_silent_vibration_badge_and_quiet_hours(pwa_app, monkey
         db.session.commit()
         inbox_pwa.send_pwa_push_notification(ids["company"], user_ids=[ids["staff"]], title="Quiet", body="Body", event_type="voicemail", phone_number_id=ids["line"])
         assert payloads[-1]["silent"] is True
+
+
+def test_push_debug_uses_logged_in_pwa_user_session(pwa_app):
+    app, client, ids = pwa_app
+    login(client, ids["staff"])
+    with app.app_context():
+        db.session.add(PushSubscription(
+            user_id=ids["staff"],
+            company_id=ids["company"],
+            endpoint="https://push.example/sub/debug",
+            p256dh="p",
+            auth_key="a",
+            is_active=True,
+        ))
+        db.session.commit()
+    resp = client.get("/api/pwa/push/debug")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert data["user"]["id"] == ids["staff"]
+    assert data["company"]["id"] == ids["company"]
+    assert data["mobile_inbox_access"] is True
+    assert data["active_subscriptions"] == 1
+    assert data["decision"]["event_type"] == "incoming_sms"
+
+
+def test_push_debug_returns_clear_auth_and_permission_responses(pwa_app):
+    app, client, ids = pwa_app
+    unauth = client.get("/api/pwa/push/debug")
+    assert unauth.status_code == 401
+    assert unauth.get_json()["code"] == "AUTHENTICATION_REQUIRED"
+    with app.app_context():
+        blocked = User(username="pwa_blocked", email="pwa_blocked@example.com", password_hash=generate_password_hash("pw"), default_company_id=ids["company"])
+        db.session.add(blocked)
+        db.session.flush()
+        db.session.add(UserCompanyAccess(user_id=blocked.id, company_id=ids["company"], role="staff", is_default=True, can_access_mobile_inbox=False, pwa_access_enabled=False))
+        db.session.commit()
+        blocked_id = blocked.id
+    login(client, blocked_id)
+    forbidden = client.get("/api/pwa/push/debug")
+    assert forbidden.status_code == 403
+    assert forbidden.get_json()["error"] == "Mobile inbox access is not enabled for this account."


### PR DESCRIPTION
### Motivation
- The `/api/pwa/push/debug` endpoint was returning generic unauthorized responses for PWA-installed users instead of authenticating against the PWA session and giving actionable diagnostics. 
- PWA users needed an in-app way to run push diagnostics without manually opening the API URL so they can confirm subscription and permission state. 

### Description
- Update `pwa_push_debug` to resolve the session with `_current_user()`, return JSON `401`/`409` errors when unauthenticated or no company is configured, and preserve the mobile-inbox permission gate via `_require_mobile_inbox_api_access`. 
- Include the current `user` and `company` info, `active_subscriptions`, and `_push_debug_decision` in successful debug responses from `/api/pwa/push/debug`. 
- Add a Settings button and UI panel in the PWA (`templates/inbox_pwa/index.html`) called `Run Push Diagnostics` that calls `/api/pwa/push/debug` and displays signed-in user, company, subscription count, and push decision. 
- Improve the client `apiFetch` JSON handling so server-provided `403` messages are surfaced instead of a generic "Permission denied." text. 
- Add regression tests in `tests/test_pwa_communications_completion.py` covering a logged-in PWA user, unauthenticated access, and a logged-in user without mobile inbox access. 

### Testing
- Ran `pytest tests/test_pwa_communications_completion.py::test_pwa_static_assets_support_unified_theme_voicemail_and_push_behaviors tests/test_pwa_communications_completion.py::test_push_debug_uses_logged_in_pwa_user_session tests/test_pwa_communications_completion.py::test_push_debug_returns_clear_auth_and_permission_responses -q` and all tests passed (`3 passed`). 
- Verified `python -m py_compile inbox_pwa.py` succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a447b4805dc8322b79e086b6cb98b01)