### PR TITLE
Fix PWA SMS send 404s, permission checks, and service-worker cache bump

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -275,6 +275,41 @@ def _accessible_numbers_for(user, company_id: int) -> list[str]:
     return accessible_phone_numbers(user, company_id)
 
 
+def _can_send_sms_from_number(user, company_id: int, from_number: str) -> bool:
+    """Return whether the user may send SMS from a tenant-owned line."""
+    if not user or not company_id or not from_number:
+        return False
+    from services.comms_permissions import normalize_role, user_access_for_company
+    acc = user_access_for_company(user, company_id)
+    role = normalize_role(getattr(acc, "role", None)) if acc else "viewer"
+    if getattr(user, "is_admin", False) or role in {"owner", "admin"}:
+        return True
+
+    from models import PhoneNumberUserPermission, TwilioPhoneNumber
+    explicit_count = PhoneNumberUserPermission.query.filter_by(company_id=company_id, user_id=user.id).count()
+    pn = TwilioPhoneNumber.query.filter_by(company_id=company_id, phone_number=from_number, is_active=True).first()
+    if pn:
+        perm = PhoneNumberUserPermission.query.filter_by(
+            company_id=company_id, user_id=user.id, phone_number_id=pn.id
+        ).first()
+        if perm:
+            return bool(perm.can_access_pwa and perm.can_view_sms and perm.can_send_sms)
+        if explicit_count:
+            return False
+
+    assigned = getattr(acc, "assigned_number", None) if acc else None
+    if assigned:
+        return assigned == from_number
+    return bool(acc and acc.has_comms_hub_access())
+
+
+def _json_error(message: str, status: int, code: str | None = None):
+    payload = {"success": False, "error": message}
+    if code:
+        payload["code"] = code
+    return jsonify(payload), status
+
+
 _UNICODE_REPLACEMENTS = str.maketrans({
     "\u2026": "...",   # …  ellipsis
     "\u2019": "'",     # '  right single quotation mark
@@ -386,7 +421,7 @@ def _twilio_send_error_message_LEGACY(exc) -> str:
     return raw
 
 
-def _send_sms_internal(ta, to_number: str, body: str, conversation_id=None):
+def _send_sms_internal(ta, to_number: str, body: str, conversation_id=None, from_number: str | None = None):
     """Send SMS via Twilio — mirrors twilio_sms._send_sms.
 
     Keep customer SMS content isolated from notification/log text. Only
@@ -403,7 +438,9 @@ def _send_sms_internal(ta, to_number: str, body: str, conversation_id=None):
         tok = ta.get_auth_token()  if hasattr(ta, 'get_auth_token')  else ta._auth_token
         client = Client(sid, tok)
         kwargs = {"body": sms_body, "to": to_number}
-        if ta.messaging_service_sid:
+        if from_number:
+            kwargs["from_"] = from_number
+        elif ta.messaging_service_sid:
             kwargs["messaging_service_sid"] = ta.messaging_service_sid
         elif ta.from_phone:
             kwargs["from_"] = ta.from_phone
@@ -415,7 +452,7 @@ def _send_sms_internal(ta, to_number: str, body: str, conversation_id=None):
             company_id=ta.company_id,
             twilio_sid=msg.sid,
             direction="outbound",
-            from_number=ta.from_phone or ta.messaging_service_sid,
+            from_number=from_number or ta.from_phone or ta.messaging_service_sid,
             to_number=to_number,
             body=sms_body,
             status=msg.status,
@@ -520,7 +557,7 @@ def pwa_index():
         os.environ.get("LUXIT_ASSET_VERSION")
         or os.environ.get("GIT_SHA")
         or os.environ.get("RENDER_GIT_COMMIT")
-        or "20260621-pwa-communications"
+        or "20260702-pwa-sms-send-fix"
     )
     return render_template(
         "inbox_pwa/index.html",
@@ -550,7 +587,7 @@ def pwa_calls():
         os.environ.get("LUXIT_ASSET_VERSION")
         or os.environ.get("GIT_SHA")
         or os.environ.get("RENDER_GIT_COMMIT")
-        or "20260621-pwa-communications"
+        or "20260702-pwa-sms-send-fix"
     )
     return render_template("inbox_pwa/calls.html", user=user, company=company, pwa_version=pwa_version)
 
@@ -1587,37 +1624,44 @@ def send_message(conv_id):
     from services.comms_permissions import filter_conversations_for_user
     conv = filter_conversations_for_user(
         TwilioConversation.query.filter_by(id=conv_id, company_id=company.id), user, company.id
-    ).first_or_404()
+    ).first()
+    if not conv:
+        return _json_error("Conversation not found or is not assigned to one of your phone lines.", 404, "conversation_not_found")
 
-    payload = request.get_json() or {}
+    payload = request.get_json(silent=True) or {}
     body    = (payload.get("body") or "").strip()
     if not body:
-        return jsonify({"success": False, "error": "Message body is required."}), 400
+        return _json_error("Message body is required.", 422, "invalid_message")
+    if not conv.from_number:
+        return _json_error("Conversation has no recipient phone number.", 422, "invalid_recipient")
+    if not conv.to_number:
+        return _json_error("Conversation has no sending phone line.", 404, "phone_line_not_found")
+    if not _can_send_sms_from_number(user, company.id, conv.to_number):
+        return _json_error("You do not have permission to send SMS from this phone line.", 403, "phone_line_forbidden")
 
     ta = _get_twilio_account(company.id)
     if not ta:
         logger.warning("send_message: no Twilio account for company=%d user=%d conv=%d",
                        company.id, user.id, conv_id)
-        return jsonify({
-            "success": False,
-            "error": "Twilio is not configured for this account. Add your Twilio credentials in SMS Settings."
-        }), 400
+        return _json_error(
+            "Twilio is not configured for this account. Add your Twilio credentials in SMS Settings.",
+            404,
+            "phone_line_not_found",
+        )
     if not ta.is_configured:
         logger.warning("send_message: Twilio account incomplete for company=%d user=%d conv=%d",
                        company.id, user.id, conv_id)
-        return jsonify({
-            "success": False,
-            "error": "Twilio credentials are incomplete. Check your Account SID, Auth Token, and phone number in SMS Settings."
-        }), 400
+        return _json_error(
+            "Twilio credentials are incomplete. Check your Account SID, Auth Token, and phone number in SMS Settings.",
+            422,
+            "twilio_not_configured",
+        )
 
-    if not conv.from_number:
-        return jsonify({"success": False, "error": "Conversation has no destination phone number."}), 400
-
-    record, err = _send_sms_internal(ta, conv.from_number, body, conversation_id=conv.id)
+    record, err = _send_sms_internal(ta, conv.from_number, body, conversation_id=conv.id, from_number=conv.to_number)
     if err:
         logger.error("send_message failed: user=%d company=%d conv=%d to=%s error=%s",
                      user.id, company.id, conv_id, conv.from_number, err)
-        return jsonify({"success": False, "error": err}), 500
+        return _json_error(err, 502, "provider_failure")
 
     # Update conversation preview
     conv.last_message_at      = datetime.utcnow()
@@ -1650,25 +1694,39 @@ def _normalize_phone(raw: str) -> str:
 def new_conversation():
     user    = _require_auth()
     company = _require_company(user)
-    payload = request.get_json() or {}
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
+    payload = request.get_json(silent=True) or {}
     to_raw  = (payload.get("to") or "").strip()
     body    = (payload.get("body") or "").strip()
 
     if not to_raw:
-        return jsonify({"success": False, "error": "Recipient phone number is required."}), 400
+        return _json_error("Recipient phone number is required.", 422, "invalid_recipient")
     if not body:
-        return jsonify({"success": False, "error": "Message body is required."}), 400
+        return _json_error("Message body is required.", 422, "invalid_message")
 
     to_num = _normalize_phone(to_raw)
     if len(to_num) < 7:
-        return jsonify({"success": False, "error": f"Invalid phone number: {to_raw}"}), 400
+        return _json_error(f"Invalid phone number: {to_raw}", 422, "invalid_recipient")
 
     ta = _get_twilio_account(company.id)
-    if not ta or not ta.is_configured:
-        return jsonify({
-            "success": False,
-            "error": "Twilio is not configured for this account. Add your Twilio credentials in SMS Settings."
-        }), 400
+    if not ta:
+        return _json_error(
+            "No active sending phone line was found for this company.",
+            404,
+            "phone_line_not_found",
+        )
+    if not ta.is_configured:
+        return _json_error(
+            "Twilio is not configured for this account. Add your Twilio credentials in SMS Settings.",
+            422,
+            "twilio_not_configured",
+        )
+    if not ta.from_phone:
+        return _json_error("No sending phone line is configured for this company.", 404, "phone_line_not_found")
+    if not _can_send_sms_from_number(user, company.id, ta.from_phone):
+        return _json_error("You do not have permission to send SMS from this phone line.", 403, "phone_line_forbidden")
 
     from models import TwilioConversation
     # Look up by both the normalised form and the raw form so existing convs are found
@@ -1686,11 +1744,11 @@ def new_conversation():
         db.session.add(conv)
         db.session.flush()
 
-    record, err = _send_sms_internal(ta, to_num, body, conversation_id=conv.id)
+    record, err = _send_sms_internal(ta, to_num, body, conversation_id=conv.id, from_number=ta.from_phone)
     if err:
         logger.error("new_conversation send failed user=%d company=%d to=%s: %s",
                      user.id, company.id, to_num, err)
-        return jsonify({"success": False, "error": err}), 500
+        return _json_error(err, 502, "provider_failure")
 
     conv.last_message_at      = datetime.utcnow()
     conv.last_message_preview = f"You: {body[:150]}"

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,5 +1,5 @@
 /* LUXit Inbox — Service Worker */
-const SW_VERSION = new URL(self.location.href).searchParams.get('v') || '20260621-pwa-communications';
+const SW_VERSION = new URL(self.location.href).searchParams.get('v') || '20260702-pwa-sms-send-fix';
 const CACHE = `luxit-inbox-${SW_VERSION}`;
 const APP_SHELL = [
   '/app/inbox',

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -250,7 +250,7 @@
       display: inline-block;
       max-width: min(72vw, 420px); padding: 9px 14px; border-radius: 16px;
       font-size: .88rem; line-height: 1.45; word-break: normal;
-      overflow-wrap: normal; white-space: pre-wrap; min-width: 2.5rem;
+      overflow-wrap: break-word; white-space: pre-wrap; min-width: 2.5rem;
     }
     .bubble.out { background: var(--brand); color: var(--color-button-text); border-bottom-right-radius: 4px; }
     .bubble.in  { background: var(--color-surface); color: var(--text); border-bottom-left-radius: 4px; }
@@ -1431,17 +1431,24 @@ async function apiFetch(url, method = 'GET', body = null) {
     return { success: false, error: 'Network error — check your connection and try again.' };
   }
   if (res.status === 401) { location.href = '/auth/login?next=/app/inbox'; return null; }
-  if (res.status === 403) return { success: false, error: 'Permission denied.' };
   // Parse JSON safely — server may return HTML on uncaught exceptions
   let data;
   try {
     data = await res.json();
   } catch {
-    return { success: false, error: `Server error (${res.status}). Please try again.` };
+    const label = res.status === 403 ? 'Permission denied for this phone line.'
+      : res.status === 404 ? 'Conversation or phone line was not found.'
+      : `Request failed (${res.status}).`;
+    return { success: false, error: label, status: res.status };
   }
-  // Promote non-OK HTTP responses that have JSON bodies
-  if (!res.ok && data.error === undefined) {
-    return { success: false, error: `Request failed (${res.status}).` };
+  // Promote non-OK HTTP responses while preserving useful API messages.
+  if (!res.ok) {
+    return {
+      success: false,
+      error: data.error || data.message || `Request failed (${res.status}).`,
+      status: res.status,
+      code: data.code,
+    };
   }
   return data;
 }
@@ -1867,7 +1874,7 @@ async function loadFavorites() {
         <div style="flex:1;min-width:0;"><strong>${esc(f.display_name)}</strong><div class="small">${esc(f.phone_number)}</div></div>
       </div>
       <div class="actions" style="margin-top:10px;">
-        <a class="btn-small" href="tel:${esc(f.phone_number)}">Call</a>
+        <button class="btn-small" onclick="callFavorite('${esc(f.phone_number)}')">Call</button>
         <a class="btn-small" href="sms:${esc(f.phone_number)}">Text</a>
         <button class="btn-small" onclick="editFavorite(${f.id}, '${esc(f.display_name)}', '${esc(f.phone_number)}')">Edit</button>
         <button class="btn-small" onclick="removeFavorite(${f.id})">Remove</button>
@@ -1877,6 +1884,13 @@ async function loadFavorites() {
     </div>`).join('') : '<div class="pwa-card empty">No favorites yet. Add one below.</div>';
   window.__pwaFavorites = favorites;
 }
+async function callFavorite(phone) {
+  dialState.number = phone || '';
+  openDialPad();
+  _dialRefresh();
+  await dialPlaceCall();
+}
+
 async function saveFavorite() {
   const name = document.getElementById('favoriteName').value.trim();
   const phone = document.getElementById('favoritePhone').value.trim();

--- a/tests/test_comms_permissions_architecture.py
+++ b/tests/test_comms_permissions_architecture.py
@@ -178,6 +178,79 @@ def test_outbound_sms_body_excludes_notification_debug_text(client, comms_world,
     assert notification_debug_text not in sent["body"]
 
 
+def test_pwa_sms_send_uses_canonical_endpoint_and_appends_message(client, comms_world, monkeypatch):
+    sent = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            sent.update(kwargs)
+            return type("Msg", (), {"sid": "SMCANONICAL", "status": "sent"})()
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.messages = FakeMessages()
+
+    import twilio.rest
+    monkeypatch.setattr(twilio.rest, "Client", FakeClient)
+
+    login(client, comms_world["staff"])
+    resp = client.post(
+        f"/api/inbox/conversations/{comms_world['c1']}/messages",
+        json={"body": "Canonical PWA send"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json["success"] is True
+    assert sent["from_"] == "+15550001111"
+    assert sent["to"] == "+15551230001"
+    assert sent["body"] == "Canonical PWA send"
+
+    detail = client.get(f"/api/inbox/conversations/{comms_world['c1']}")
+    assert any(m["body"] == "Canonical PWA send" for m in detail.json["messages"])
+
+
+def test_pwa_sms_invalid_conversation_returns_useful_404(client, comms_world):
+    login(client, comms_world["staff"])
+    resp = client.post("/api/inbox/conversations/999999/messages", json={"body": "hello"})
+
+    assert resp.status_code == 404
+    assert resp.json["success"] is False
+    assert resp.json["code"] == "conversation_not_found"
+    assert "Conversation not found" in resp.json["error"]
+
+
+def test_pwa_sms_unassigned_phone_line_returns_403_not_generic_404(client, comms_world):
+    with client.application.app_context():
+        perm = PhoneNumberUserPermission.query.filter_by(
+            user_id=comms_world["staff"], phone_number_id=comms_world["pn1"]
+        ).first()
+        perm.can_send_sms = False
+        db.session.commit()
+
+    login(client, comms_world["staff"])
+    resp = client.post(
+        f"/api/inbox/conversations/{comms_world['c1']}/messages",
+        json={"body": "blocked"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json["code"] == "phone_line_forbidden"
+    assert "permission" in resp.json["error"].lower()
+
+
+def test_pwa_shell_and_service_worker_bump_sms_send_version():
+    html = (os.path.join(os.getcwd(), "templates/inbox_pwa/index.html"))
+    sw = (os.path.join(os.getcwd(), "static/sw.js"))
+    with open(html) as f:
+        page = f.read()
+    with open(sw) as f:
+        worker = f.read()
+
+    assert "/api/inbox/conversations/${state.activeConvId}/messages" in page
+    assert "/twilio/send" not in page
+    assert "Server error (${res.status}). Please try again." not in page
+    assert "20260702-pwa-sms-send-fix" in worker
+
 def test_pwa_notifications_and_push_subscription_are_scoped_by_number(client, comms_world):
     login(client, comms_world["staff"])
     sub = client.post("/api/pwa/push/subscribe", json={


### PR DESCRIPTION
### Motivation
- Installed PWA SMS sends returned a generic `Server error 404` because the PWA was hitting stale/unclear code paths and not surfacing actionable errors. 
- The send flow lacked explicit tenant/phone-line permission checks causing ambiguous 404s instead of 403 where appropriate. 
- Stale service-worker versioning allowed old JS to persist in installed PWAs, preventing fixes from reaching users. 
- The UI returned unhelpful generic messages on JSON API failures and did not reliably append sent messages to the thread.

### Description
- Added server helpers: `_can_send_sms_from_number(user, company_id, from_number)` and `_json_error(...)` to centralise permission checks and consistent JSON error responses. 
- Hardened `POST /api/inbox/conversations/<id>/messages` to validate conversation existence, required fields, conversation recipient/sender lines, and per-line `can_send_sms` permissions, and to return clear `401/403/404/422/502` style semantics via JSON. 
- Updated `_send_sms_internal` to accept an explicit `from_number` and ensured outbound Twilio calls use the backend-selected sending line and persist the correct `from_number` on the `TwilioMessage` record. 
- Hardened `POST /api/inbox/conversations` (new conversation) with PWA access gating, improved validation and permission checks, and consistent error codes. 
- Improved frontend `apiFetch` in `templates/inbox_pwa/index.html` to surface backend JSON errors (preserve `data.error`/`data.code`) and avoid showing the old generic `Server error (${res.status})` message. 
- Replaced native `tel:` call links in favorites with an app-driven call flow that uses the Twilio dial API (`dialPlaceCall`) so calls go through the Twilio path rather than native phone in PWA context. 
- Bumped service-worker/app asset version (`SW_VERSION` / `pwa_version`) to force installed PWAs to update cached JS (`20260702-pwa-sms-send-fix`). 
- Added/updated regression tests to cover canonical PWA sends, useful 404s, 403 phone-line permission behavior, service-worker bump, and that sent messages appear in the conversation after send.

### Testing
- Compiled Python module with `python -m py_compile inbox_pwa.py` which succeeded. 
- Ran targeted pytest suites: `pytest -q tests/test_comms_permissions_architecture.py` and `pytest -q tests/test_pwa_template_regressions.py`, and the added/updated tests passed. 
- Executed the combined verification `pytest -q tests/test_comms_permissions_architecture.py tests/test_pwa_template_regressions.py` and observed all tests in those suites passing locally under the test fixture environment. 
- Note: attempting to instantiate the full app via `create_app()` in this shell failed because no DATABASE_URL was available here, but the test fixtures configure the app and exercised the affected routes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a45bd6c620c8322b998f5fe07f70b22)