### PR TITLE
Use Tailscale for production deploy SSH

### DIFF
--- a/.github/workflows/push-to-production.yml
+++ b/.github/workflows/push-to-production.yml
@@ -17,21 +17,32 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - name: Confirm SSH connection
+      - name: Connect Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_CLIENT_SECRET }}
+          tags: tag:github-actions
+
+      - name: Confirm Tailscale SSH connection
         shell: bash
+        env:
+          HOST: 100.85.15.43
+          PORT: 22
+          USERNAME: serveradmin
         run: |
           set -euo pipefail
-          HOST_VALUE="${{ secrets.HOST }}"
-          echo "HOST starts with: ${HOST_VALUE:0:7}"
-          echo "Testing SSH port on HOST..."
-          timeout 15 bash -c "</dev/tcp/${HOST_VALUE}/22"
-          echo "SSH port reachable"
+          echo "Testing SSH port on ${HOST}:${PORT} over Tailscale as ${USERNAME}..."
+          tailscale status
+          tailscale ping "${HOST}"
+          timeout 15 bash -c "</dev/tcp/${HOST}/${PORT}"
+          echo "Tailscale SSH port reachable"
 
       - name: Deploy to Production VPS
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.HOST }}
-          username: root
+          host: 100.85.15.43
+          username: serveradmin
           key: ${{ secrets.VPS_PRIVATE_KEY }}
           port: 22
           timeout: 60s


### PR DESCRIPTION
### Motivation
- The production deploy was failing at the TCP probe to the public VPS IP, so the workflow should connect over the Tailnet to avoid upstream/provider firewall or runner network reachability issues. 
- Use the VPS Tailscale address and keep the established `USERNAME=serveradmin` and `PORT=22` for SSH connectivity. 
- Avoid changing SSH keys, sudoers, or other server-side configuration since the runner cannot reach TCP/22 over the public interface.

### Description
- Add a `Connect Tailscale` step using `tailscale/github-action@v3` and pass `TS_CLIENT_ID` and `TS_CLIENT_SECRET` from secrets. 
- Add a `Confirm Tailscale SSH connection` script that runs `tailscale status`, `tailscale ping`, and a `timeout` `/dev/tcp/${HOST}/${PORT}` probe with `HOST=100.85.15.43`, `PORT=22`, and `USERNAME=serveradmin`. 
- Update the `Deploy to Production VPS` `appleboy/ssh-action` invocation to use `host: 100.85.15.43` and `username: serveradmin` while keeping the existing `key` and `port` settings. 
- Commit changes to `.github/workflows/push-to-production.yml` to switch SSH reachability checks and deployment to the VPS Tailscale address.

### Testing
- Validated that the edited workflow YAML parses by running `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/push-to-production.yml')"`, which succeeded. 
- Ran `git diff --check` and committed the updated workflow file, and both checks completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a45c742d4d88322970dd3518cc49252)