### PR TITLE
Fix inbox PWA conversation indentation

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -1757,10 +1757,10 @@ def _normalize_phone(raw: str) -> str:
 def new_conversation():
     user    = _require_auth()
     company = _require_company(user)
-denied = _require_pwa_communications_access(user, company)
-if denied:
-    return denied
-payload = request.get_json(silent=True) or {}
+    denied = _require_pwa_communications_access(user, company)
+    if denied:
+        return denied
+    payload = request.get_json(silent=True) or {}
     to_raw  = (payload.get("to") or "").strip()
     body    = (payload.get("body") or "").strip()
 


### PR DESCRIPTION
### Motivation
- Fix an `IndentationError` in `inbox_pwa.py` caused by `_require_pwa_communications_access()` and payload parsing being dedented out of the `new_conversation()` route, which prevented production deployment.

### Description
- Re-indented the `_require_pwa_communications_access()` call, its denial `return`, and `payload = request.get_json(...)` so they execute inside the `new_conversation()` function in `inbox_pwa.py` and made no other changes.

### Testing
- Ran `python3 -m py_compile inbox_pwa.py` and `python3 -m py_compile app.py auth.py routes.py models.py inbox_pwa.py twilio_sms.py`, and both compilations succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a45f066625c8322ac9881b9dbc3b9e4)