### PR TITLE
Fix PWA SMS dispatch and queued retries

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -447,6 +447,8 @@ def _send_sms_internal(ta, to_number: str, body: str, conversation_id=None, from
         else:
             return None, "No From number or Messaging Service SID configured."
         msg = client.messages.create(**kwargs)
+        provider_status = (getattr(msg, "status", None) or "sent").lower()
+        dispatched_status = provider_status if provider_status in {"sent", "delivered", "failed", "undelivered"} else "sent"
         record = TwilioMessage(
             conversation_id=conversation_id,
             company_id=ta.company_id,
@@ -455,15 +457,112 @@ def _send_sms_internal(ta, to_number: str, body: str, conversation_id=None, from
             from_number=from_number or ta.from_phone or ta.messaging_service_sid,
             to_number=to_number,
             body=sms_body,
-            status=msg.status,
+            status=dispatched_status,
+            raw_payload={"provider_status": provider_status},
         )
         db.session.add(record)
         db.session.commit()
-        logger.info("PWA Inbox outbound SMS: sid=%s to=%s", msg.sid, to_number)
+        logger.info("PWA Inbox outbound SMS dispatched: sid=%s status=%s to=%s", msg.sid, dispatched_status, to_number)
         return record, None
     except Exception as exc:
         logger.error("PWA Inbox SMS send error: %s", exc)
-        return None, _twilio_send_error_message(exc)
+        error = _twilio_send_error_message(exc)
+        if conversation_id:
+            try:
+                failed = TwilioMessage(
+                    conversation_id=conversation_id,
+                    company_id=ta.company_id,
+                    direction="outbound",
+                    from_number=from_number or ta.from_phone or ta.messaging_service_sid,
+                    to_number=to_number,
+                    body=sms_body,
+                    status="failed",
+                    error_code=str(getattr(exc, "code", "") or getattr(exc, "status", "") or "") or None,
+                    error_message=error,
+                )
+                db.session.add(failed)
+                db.session.commit()
+            except Exception:
+                db.session.rollback()
+                logger.exception("Unable to persist failed outbound SMS record", extra={"conversation_id": conversation_id})
+        return None, error
+
+
+def retry_queued_outbound_messages(company_id: int, limit: int = 100, dry_run: bool = False) -> dict:
+    """Admin-safe retry for legacy PWA outbound rows stuck as queued without a Twilio SID."""
+    from models import TwilioConversation, TwilioMessage
+
+    ta = _get_twilio_account(company_id)
+    if not ta or not ta.is_configured:
+        return {"success": False, "error": "Twilio is not configured for this company.", "retried": 0, "failed": 0}
+
+    rows = (TwilioMessage.query
+        .join(TwilioConversation, TwilioConversation.id == TwilioMessage.conversation_id)
+        .filter(
+            TwilioMessage.company_id == company_id,
+            TwilioMessage.direction == "outbound",
+            TwilioMessage.status == "queued",
+            TwilioMessage.twilio_sid.is_(None),
+            TwilioConversation.company_id == company_id,
+        )
+        .order_by(TwilioMessage.created_at.asc(), TwilioMessage.id.asc())
+        .limit(max(1, min(int(limit or 100), 500)))
+        .all())
+    if dry_run:
+        return {"success": True, "dry_run": True, "matched": len(rows), "retried": 0, "failed": 0}
+
+    retried = failed = 0
+    errors = []
+    for row in rows:
+        conv = row.conversation
+        from_number = row.from_number or getattr(conv, "to_number", None) or getattr(ta, "from_phone", None)
+        to_number = row.to_number or getattr(conv, "from_number", None)
+        if not to_number:
+            row.status = "failed"
+            row.error_message = "Queued outbound message has no recipient phone number."
+            failed += 1
+            errors.append({"id": row.id, "error": row.error_message})
+            db.session.commit()
+            continue
+        sent, err = _dispatch_existing_outbound_message(ta, row, to_number, from_number)
+        if err:
+            failed += 1
+            errors.append({"id": row.id, "error": err})
+        else:
+            retried += 1
+    return {"success": failed == 0, "matched": len(rows), "retried": retried, "failed": failed, "errors": errors[:20]}
+
+
+def _dispatch_existing_outbound_message(ta, row, to_number: str, from_number: str | None):
+    try:
+        from twilio.rest import Client
+        sid = ta.get_account_sid() if hasattr(ta, "get_account_sid") else ta._account_sid
+        tok = ta.get_auth_token() if hasattr(ta, "get_auth_token") else ta._auth_token
+        client = Client(sid, tok)
+        kwargs = {"body": _sanitize_body(row.body or ""), "to": to_number}
+        if from_number:
+            kwargs["from_"] = from_number
+        elif ta.messaging_service_sid:
+            kwargs["messaging_service_sid"] = ta.messaging_service_sid
+        else:
+            raise RuntimeError("No From number or Messaging Service SID configured.")
+        msg = client.messages.create(**kwargs)
+        provider_status = (getattr(msg, "status", None) or "sent").lower()
+        row.twilio_sid = msg.sid
+        row.from_number = from_number or ta.from_phone or ta.messaging_service_sid
+        row.to_number = to_number
+        row.status = provider_status if provider_status in {"sent", "delivered", "failed", "undelivered"} else "sent"
+        row.error_message = None
+        row.raw_payload = {"provider_status": provider_status, "retried_from_queue": True}
+        db.session.commit()
+        return row, None
+    except Exception as exc:
+        error = _twilio_send_error_message(exc)
+        row.status = "failed"
+        row.error_code = str(getattr(exc, "code", "") or getattr(exc, "status", "") or "") or None
+        row.error_message = error
+        db.session.commit()
+        return None, error
 
 
 def _conv_to_dict(conv, brief=True):

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,5 +1,5 @@
 /* LUXit Inbox — Service Worker */
-const SW_VERSION = new URL(self.location.href).searchParams.get('v') || '20260702-push-sound-diagnostics';
+const SW_VERSION = new URL(self.location.href).searchParams.get('v') || '20260702-pwa-sms-send-fix';
 const CACHE = `luxit-inbox-${SW_VERSION}`;
 const APP_SHELL = [
   '/app/inbox',

--- a/tests/test_comms_permissions_architecture.py
+++ b/tests/test_comms_permissions_architecture.py
@@ -559,3 +559,143 @@ def test_communications_hub_tabs_and_pwa_api_smoke(client, comms_world):
     assert client.get("/api/calls/recent?tab=all").status_code == 200
     assert client.get("/api/calls/voicemails").status_code == 200
     assert client.get("/api/pwa/devices").status_code == 200
+
+
+def test_pwa_sms_success_stores_sid_and_dispatched_status(client, comms_world, monkeypatch):
+    sent = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            sent.update(kwargs)
+            return type("Msg", (), {"sid": "SMQUEUEDACCEPTED", "status": "queued"})()
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.messages = FakeMessages()
+
+    import twilio.rest
+    monkeypatch.setattr(twilio.rest, "Client", FakeClient)
+
+    login(client, comms_world["staff"])
+    resp = client.post(
+        f"/api/inbox/conversations/{comms_world['c1']}/messages",
+        json={"body": "conversation 35 style valid mapping"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json["success"] is True
+    assert sent["from_"] == "+15550001111"
+    assert sent["to"] == "+15551230001"
+    with client.application.app_context():
+        msg = TwilioMessage.query.filter_by(twilio_sid="SMQUEUEDACCEPTED").one()
+        assert msg.status == "sent"
+        assert msg.error_message is None
+        assert msg.raw_payload["provider_status"] == "queued"
+
+
+def test_pwa_sms_failure_persists_failed_row_and_useful_502(client, comms_world, monkeypatch):
+    class FakeMessages:
+        def create(self, **kwargs):
+            raise RuntimeError("Twilio provider exploded")
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.messages = FakeMessages()
+
+    import twilio.rest
+    monkeypatch.setattr(twilio.rest, "Client", FakeClient)
+
+    login(client, comms_world["staff"])
+    resp = client.post(
+        f"/api/inbox/conversations/{comms_world['c1']}/messages",
+        json={"body": "will fail"},
+    )
+
+    assert resp.status_code == 502
+    assert resp.json["success"] is False
+    assert resp.json["code"] == "provider_failure"
+    assert "Twilio provider exploded" in resp.json["error"]
+    with client.application.app_context():
+        msg = TwilioMessage.query.filter_by(conversation_id=comms_world["c1"], body="will fail").one()
+        assert msg.status == "failed"
+        assert "Twilio provider exploded" in msg.error_message
+        assert msg.twilio_sid is None
+
+
+def test_retry_queued_outbound_messages_dispatches_legacy_stuck_rows(client, comms_world, monkeypatch):
+    sent = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            sent.update(kwargs)
+            return type("Msg", (), {"sid": "SMRETRIED", "status": "queued"})()
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.messages = FakeMessages()
+
+    import twilio.rest
+    monkeypatch.setattr(twilio.rest, "Client", FakeClient)
+
+    with client.application.app_context():
+        stuck = TwilioMessage(
+            conversation_id=comms_world["c1"],
+            company_id=comms_world["co"],
+            direction="outbound",
+            from_number="+15550001111",
+            to_number="+15551230001",
+            body="stuck queued",
+            status="queued",
+        )
+        db.session.add(stuck)
+        db.session.commit()
+        stuck_id = stuck.id
+
+        from inbox_pwa import retry_queued_outbound_messages
+        result = retry_queued_outbound_messages(comms_world["co"])
+
+        assert result["retried"] == 1
+        assert result["failed"] == 0
+        row = db.session.get(TwilioMessage, stuck_id)
+        assert row.twilio_sid == "SMRETRIED"
+        assert row.status == "sent"
+        assert row.error_message is None
+        assert sent["from_"] == "+15550001111"
+        assert sent["to"] == "+15551230001"
+
+
+def test_retry_queued_outbound_messages_marks_provider_failure(client, comms_world, monkeypatch):
+    class FakeMessages:
+        def create(self, **kwargs):
+            raise RuntimeError("retry provider failed")
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.messages = FakeMessages()
+
+    import twilio.rest
+    monkeypatch.setattr(twilio.rest, "Client", FakeClient)
+
+    with client.application.app_context():
+        stuck = TwilioMessage(
+            conversation_id=comms_world["c1"],
+            company_id=comms_world["co"],
+            direction="outbound",
+            from_number="+15550001111",
+            to_number="+15551230001",
+            body="stuck fails",
+            status="queued",
+        )
+        db.session.add(stuck)
+        db.session.commit()
+        stuck_id = stuck.id
+
+        from inbox_pwa import retry_queued_outbound_messages
+        result = retry_queued_outbound_messages(comms_world["co"])
+
+        assert result["retried"] == 0
+        assert result["failed"] == 1
+        row = db.session.get(TwilioMessage, stuck_id)
+        assert row.status == "failed"
+        assert "retry provider failed" in row.error_message
+        assert row.twilio_sid is None


### PR DESCRIPTION
### Motivation
- PWA SMS replies were being persisted as `status='queued'` without a Twilio SID and not being dispatched, leaving outbound rows stuck and invisible to error handling.
- The API must either dispatch immediately (previous behavior) or ensure a queue worker reliably drains queued rows; until the worker is verified, immediate dispatch with robust error persistence is required.
- Failed Twilio attempts must record useful `error_message`/`error_code` and return a helpful 502 JSON rather than leaving blank queued rows.
- Provide an admin-safe retry for legacy queued outbound rows so operations can recover stuck messages.

### Description
- Updated `_send_sms_internal(...)` to call Twilio immediately, capture the provider `sid` and provider `status`, normalize dispatched status to `sent|delivered|failed|undelivered`, and persist `raw_payload` with the original provider status for diagnostics. (file: `inbox_pwa.py`)
- On Twilio exceptions, persist an outbound `TwilioMessage` row with `status='failed'`, `error_code`, and `error_message` and return a `502 provider_failure` response to the API caller. (file: `inbox_pwa.py`)
- Added `retry_queued_outbound_messages(company_id, limit, dry_run)` and `_dispatch_existing_outbound_message(...)` to safely retry legacy `TwilioMessage` rows that are `direction='outbound'`, `status='queued'`, and lack a `twilio_sid`, updating rows on success or marking them `failed` on provider error. (file: `inbox_pwa.py`)
- Bumped the PWA service worker version constant so clients pick up the SMS send fix. (file: `static/sw.js`)
- Added regression tests exercising PWA reply dispatch, queued-to-dispatched retry behavior, provider failure persistence, and API 502 behavior. (file: `tests/test_comms_permissions_architecture.py`)

### Testing
- Ran targeted tests: `pytest tests/test_comms_permissions_architecture.py::test_pwa_sms_success_stores_sid_and_dispatched_status tests/test_comms_permissions_architecture.py::test_pwa_sms_failure_persists_failed_row_and_useful_502 tests/test_comms_permissions_architecture.py::test_retry_queued_outbound_messages_dispatches_legacy_stuck_rows tests/test_comms_permissions_architecture.py::test_retry_queued_outbound_messages_marks_provider_failure -q` and they all passed. 
- Ran the full file: `pytest tests/test_comms_permissions_architecture.py -q` and it completed successfully (`27 passed`, multiple warnings only).
- No changes to deployment workflow were made; service worker version bump ensures PWA clients pick up the fix on next install/update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a45f71cb3cc83229d79025bfbf1f6f2)