### PR TITLE
Add TikTok integration: service, models, routes, UI, and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -386,6 +386,18 @@ def create_app() -> Flask:
     except Exception as exc:
         app.logger.warning("Failed to register integrations blueprint: %s", exc)
     try:
+        from services.tiktok_service import TikTokService
+        _tiktok_config_ok, _tiktok_config_error = TikTokService().validate_configuration()
+        if not _tiktok_config_ok:
+            raise RuntimeError(_tiktok_config_error)
+        from tiktok_auth import tiktok_bp
+        app.register_blueprint(tiktok_bp)
+        csrf.exempt(tiktok_bp)
+    except Exception as exc:
+        app.logger.warning("Failed to register TikTok blueprint: %s", exc)
+        if os.environ.get("TIKTOK_CLIENT_KEY") or os.environ.get("TIKTOK_CLIENT_SECRET"):
+            raise
+    try:
         from admin_communications import admin_communications_bp
         app.register_blueprint(admin_communications_bp)
     except Exception as exc:

--- a/models.py
+++ b/models.py
@@ -540,8 +540,8 @@ class TikTokOAuth(db.Model):
     company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=True)
 
     open_id = db.Column(db.String(255), nullable=False)
-    access_token = db.Column(db.Text, nullable=False)
-    refresh_token = db.Column(db.Text)
+    _access_token = db.Column("access_token", db.Text, nullable=False)
+    _refresh_token = db.Column("refresh_token", db.Text)
     expires_at = db.Column(db.DateTime)
     refresh_expires_at = db.Column(db.DateTime)
     scope = db.Column(db.String(500))
@@ -549,13 +549,92 @@ class TikTokOAuth(db.Model):
 
     display_name = db.Column(db.String(255))
     avatar_url = db.Column(db.String(500))
+    creator_username = db.Column(db.String(255))
+    creator_nickname = db.Column(db.String(255))
+    creator_info = db.Column(JSON)
     raw_token = db.Column(JSON)
     status = db.Column(db.String(50), default="active")
+    disconnected_at = db.Column(db.DateTime)
 
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
     )
+
+    def set_access_token(self, token: str):
+        self._access_token = self._encrypt_secret(token)
+
+    def get_access_token(self) -> str:
+        return self._decrypt_secret(self._access_token)
+
+    def set_refresh_token(self, token: str):
+        self._refresh_token = self._encrypt_secret(token)
+
+    def get_refresh_token(self) -> str:
+        return self._decrypt_secret(self._refresh_token)
+
+    @staticmethod
+    def _encrypt_secret(value):
+        if not value:
+            return None
+        try:
+            from services.secret_vault import vault
+            return vault.encrypt(value)
+        except Exception:
+            return value
+
+    @staticmethod
+    def _decrypt_secret(value):
+        if not value:
+            return None
+        try:
+            from services.secret_vault import vault
+            return vault.decrypt(value)
+        except Exception:
+            return value
+
+    @property
+    def is_expired(self) -> bool:
+        return bool(self.expires_at and datetime.utcnow() >= self.expires_at)
+
+    @property
+    def needs_refresh(self) -> bool:
+        return bool(self.expires_at and datetime.utcnow() >= self.expires_at - timedelta(minutes=10))
+
+    def has_scope(self, scope: str) -> bool:
+        scopes = (self.scope or "").replace(",", " ").split()
+        return scope in scopes
+
+
+class TikTokPost(db.Model):
+    __tablename__ = "tiktok_post"
+
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False, index=True)
+    tiktok_account_id = db.Column(db.Integer, db.ForeignKey("tiktok_oauth.id"), nullable=False, index=True)
+    publish_id = db.Column(db.String(255), index=True)
+    media_type = db.Column(db.String(20), nullable=False)
+    source_type = db.Column(db.String(30), nullable=False)
+    title = db.Column(db.String(220))
+    description = db.Column(db.Text)
+    privacy_level = db.Column(db.String(80))
+    status = db.Column(db.String(80), default="initialized")
+    status_payload = db.Column(JSON)
+    error_code = db.Column(db.String(120))
+    error_message = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class TikTokPostStatusHistory(db.Model):
+    __tablename__ = "tiktok_post_status_history"
+
+    id = db.Column(db.Integer, primary_key=True)
+    tiktok_post_id = db.Column(db.Integer, db.ForeignKey("tiktok_post.id"), nullable=False, index=True)
+    status = db.Column(db.String(80))
+    payload = db.Column(JSON)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
 
 class Company(db.Model):

--- a/services/tiktok_service.py
+++ b/services/tiktok_service.py
@@ -1,377 +1,237 @@
-"""TikTok OAuth and API Service for LUX Marketing Platform"""
+"""TikTok OAuth and Content Posting API service helpers."""
+import hashlib
+import math
 import os
 import secrets
-import requests
-import logging
 from datetime import datetime, timedelta
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse, urlunparse
 
-logger = logging.getLogger(__name__)
+import requests
+
 
 class TikTokService:
-    """Service for TikTok OAuth flow and API interactions"""
-    
-    AUTH_URL = 'https://www.tiktok.com/v2/auth/authorize/'
-    TOKEN_URL = 'https://open.tiktokapis.com/v2/oauth/token/'
-    REVOKE_URL = 'https://open.tiktokapis.com/v2/oauth/revoke/'
-    USER_INFO_URL = 'https://open.tiktokapis.com/v2/user/info/'
-    VIDEO_LIST_URL = 'https://open.tiktokapis.com/v2/video/list/'
-    VIDEO_UPLOAD_INIT_URL = 'https://open.tiktokapis.com/v2/post/publish/inbox/video/init/'
-    VIDEO_PUBLISH_URL = 'https://open.tiktokapis.com/v2/post/publish/video/init/'
-    
-    REDIRECT_URI = 'https://lux.lucifercruz.com/auth/tiktok/callback'
-    
-    SCOPES = [
-        'user.info.basic',
-        'video.list'
-    ]
-    
-    def __init__(self, client_key=None, client_secret=None):
-        self.client_key = client_key or os.getenv('TIKTOK_CLIENT_KEY')
-        self.client_secret = client_secret or os.getenv('TIKTOK_CLIENT_SECRET')
+    AUTH_URL = "https://www.tiktok.com/v2/auth/authorize/"
+    TOKEN_URL = "https://open.tiktokapis.com/v2/oauth/token/"
+    REVOKE_URL = "https://open.tiktokapis.com/v2/oauth/revoke/"
+    USER_INFO_URL = "https://open.tiktokapis.com/v2/user/info/"
+    CREATOR_INFO_URL = "https://open.tiktokapis.com/v2/post/publish/creator_info/query/"
+    VIDEO_INIT_URL = "https://open.tiktokapis.com/v2/post/publish/video/init/"
+    CONTENT_INIT_URL = "https://open.tiktokapis.com/v2/post/publish/content/init/"
+    STATUS_URL = "https://open.tiktokapis.com/v2/post/publish/status/fetch/"
 
-        if not self.client_key or not self.client_secret:
-            logger.warning("TikTok credentials missing; TikTok integration will be disabled.")
-    
+    def __init__(
+        self,
+        client_key=None,
+        client_secret=None,
+        redirect_uri=None,
+        scopes=None,
+        runtime_redirect_uri=None,
+        oauth_mode=None,
+    ):
+        self.client_key = client_key or os.getenv("TIKTOK_CLIENT_KEY")
+        self.client_secret = client_secret or os.getenv("TIKTOK_CLIENT_SECRET")
+        # Registration URI may be the TikTok console wildcard. It is never sent
+        # in OAuth requests unless it is already a concrete valid runtime URI.
+        self.redirect_uri = redirect_uri or os.getenv(
+            "TIKTOK_REDIRECT_URI", "http://127.0.0.1:*/callback/"
+        )
+        self.runtime_redirect_uri = runtime_redirect_uri or os.getenv(
+            "TIKTOK_RUNTIME_REDIRECT_URI"
+        )
+        self.oauth_mode = (oauth_mode or os.getenv("TIKTOK_OAUTH_MODE", "desktop")).lower()
+        self.scopes = scopes or os.getenv("TIKTOK_SCOPES", "user.info.basic").replace(
+            ",", " "
+        ).split()
+
     @classmethod
     def from_company(cls, company):
-        """Create service instance from company secrets"""
-        client_key = company.get_secret('TIKTOK_CLIENT_KEY') or company.get_secret('TIKTOK_API_KEY')
-        client_secret = company.get_secret('TIKTOK_CLIENT_SECRET')
-        return cls(client_key=client_key, client_secret=client_secret)
+        def secret(name):
+            return company.get_secret(name) if company and hasattr(company, "get_secret") else None
+        return cls(
+            secret("TIKTOK_CLIENT_KEY"),
+            secret("TIKTOK_CLIENT_SECRET"),
+            secret("TIKTOK_REDIRECT_URI"),
+            secret("TIKTOK_SCOPES"),
+            secret("TIKTOK_RUNTIME_REDIRECT_URI"),
+            secret("TIKTOK_OAUTH_MODE"),
+        )
 
-    def is_configured(self) -> bool:
-        return bool(self.client_key and self.client_secret)
-    
-    def generate_state(self):
-        """Generate a secure state token for CSRF protection"""
+    @staticmethod
+    def _has_wildcard_port(uri):
+        return urlparse(uri).netloc.endswith(":*")
+
+    @staticmethod
+    def _is_loopback_host(hostname):
+        return hostname in {"localhost", "127.0.0.1", "::1"}
+
+    @classmethod
+    def is_valid_redirect_uri(cls, uri, mode="desktop", allow_wildcard=False):
+        parsed = urlparse(uri or "")
+        mode = (mode or "desktop").lower()
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            return False
+        if cls._has_wildcard_port(uri):
+            return bool(
+                allow_wildcard
+                and mode == "desktop"
+                and parsed.scheme == "http"
+                and cls._is_loopback_host(parsed.hostname)
+            )
+        if mode == "desktop":
+            return (
+                parsed.port is not None
+                and parsed.scheme == "http"
+                and cls._is_loopback_host(parsed.hostname)
+            )
+        if mode == "web":
+            return parsed.scheme == "https" and not cls._is_loopback_host(parsed.hostname)
+        return False
+
+    def resolved_redirect_uri(self):
+        candidate = self.runtime_redirect_uri or self.redirect_uri
+        if self._has_wildcard_port(candidate):
+            port = os.getenv("TIKTOK_DESKTOP_CALLBACK_PORT", "3455")
+            parsed = urlparse(candidate)
+            candidate = urlunparse(
+                parsed._replace(netloc=f"{parsed.hostname}:{port}")
+            )
+        return candidate
+
+    def validate_configuration(self):
+        if not (self.client_key or self.client_secret):
+            return True, None
+        if not self.client_key or not self.client_secret:
+            return False, "TikTok OAuth requires both TIKTOK_CLIENT_KEY and TIKTOK_CLIENT_SECRET."
+        if not self.is_valid_redirect_uri(
+            self.redirect_uri,
+            self.oauth_mode,
+            allow_wildcard=self.oauth_mode == "desktop",
+        ):
+            return False, "TIKTOK_REDIRECT_URI is not valid for the configured TikTok OAuth mode."
+        runtime_uri = self.resolved_redirect_uri()
+        if "*" in urlparse(runtime_uri).netloc or not self.is_valid_redirect_uri(
+            runtime_uri,
+            self.oauth_mode,
+            allow_wildcard=False,
+        ):
+            return False, "TikTok runtime redirect URI must be concrete and valid."
+        return True, None
+
+    def is_configured(self):
+        ok, _ = self.validate_configuration()
+        return bool(ok and self.client_key and self.client_secret)
+
+    @staticmethod
+    def generate_state():
         return secrets.token_urlsafe(32)
-    
-    def build_auth_url(self, state=None, redirect_uri=None):
-        """Build TikTok OAuth authorization URL"""
-        if not self.client_key:
-            logger.warning("TikTok client_key missing; cannot build auth URL.")
-            return None, None
-        
+
+    @staticmethod
+    def generate_code_verifier():
+        return secrets.token_urlsafe(64)[:128]
+
+    @staticmethod
+    def code_challenge(verifier):
+        return hashlib.sha256(verifier.encode("utf-8")).hexdigest()
+
+    def build_auth_url(self, state=None, code_verifier=None, redirect_uri=None):
         state = state or self.generate_state()
-        redirect_uri = redirect_uri or self.REDIRECT_URI
-        
+        code_verifier = code_verifier or self.generate_code_verifier()
         params = {
-            'client_key': self.client_key,
-            'response_type': 'code',
-            'scope': ','.join(self.SCOPES),
-            'redirect_uri': redirect_uri,
-            'state': state
+            "client_key": self.client_key,
+            "response_type": "code",
+            "scope": ",".join(self.scopes),
+            "redirect_uri": redirect_uri or self.resolved_redirect_uri(),
+            "state": state,
+            "code_challenge": self.code_challenge(code_verifier),
+            "code_challenge_method": "S256",
         }
-        
-        return f"{self.AUTH_URL}?{urlencode(params)}", state
-    
-    def exchange_code_for_token(self, code, redirect_uri=None):
-        """Exchange authorization code for access token"""
-        if not self.client_key or not self.client_secret:
-            logger.warning("TikTok credentials missing; cannot exchange code for token.")
-            return {'success': False, 'error': 'TikTok integration not configured'}
-        
-        redirect_uri = redirect_uri or self.REDIRECT_URI
-        
-        data = {
-            'client_key': self.client_key,
-            'client_secret': self.client_secret,
-            'code': code,
-            'grant_type': 'authorization_code',
-            'redirect_uri': redirect_uri
+        return f"{self.AUTH_URL}?{urlencode(params)}", state, code_verifier
+
+    def _token_result(self, token_data):
+        if token_data.get("error"):
+            return {"success": False, "error": token_data.get("error_description") or token_data.get("error")}
+        now = datetime.utcnow()
+        return {
+            "success": True,
+            "access_token": token_data.get("access_token"),
+            "refresh_token": token_data.get("refresh_token"),
+            "open_id": token_data.get("open_id"),
+            "scope": token_data.get("scope") or token_data.get("scopes"),
+            "token_type": token_data.get("token_type", "Bearer"),
+            "expires_at": now + timedelta(seconds=int(token_data.get("expires_in", 86400))),
+            "refresh_expires_at": now + timedelta(seconds=int(token_data.get("refresh_expires_in", 31536000))),
         }
-        
-        try:
-            response = requests.post(self.TOKEN_URL, data=data)
-            response.raise_for_status()
-            token_data = response.json()
-            
-            if 'error' in token_data:
-                logger.error(f"TikTok token error: {token_data}")
-                return {'success': False, 'error': token_data.get('error_description', token_data.get('error'))}
-            
-            expires_in = token_data.get('expires_in', 86400)
-            refresh_expires_in = token_data.get('refresh_expires_in', 86400 * 365)
-            
-            return {
-                'success': True,
-                'access_token': token_data.get('access_token'),
-                'refresh_token': token_data.get('refresh_token'),
-                'open_id': token_data.get('open_id'),
-                'scope': token_data.get('scope'),
-                'token_type': token_data.get('token_type', 'Bearer'),
-                'expires_at': datetime.utcnow() + timedelta(seconds=expires_in),
-                'refresh_expires_at': datetime.utcnow() + timedelta(seconds=refresh_expires_in),
-                'raw_token': token_data
-            }
-            
-        except requests.exceptions.RequestException as e:
-            logger.error(f"TikTok token exchange error: {e}")
-            return {'success': False, 'error': str(e)}
-    
+
+    def exchange_code_for_token(self, code, code_verifier=None, redirect_uri=None):
+        data = {"client_key": self.client_key, "client_secret": self.client_secret, "code": code, "grant_type": "authorization_code", "redirect_uri": redirect_uri or self.resolved_redirect_uri()}
+        if code_verifier:
+            data["code_verifier"] = code_verifier
+        return self._token_result(requests.post(self.TOKEN_URL, data=data, timeout=15).json())
+
     def refresh_access_token(self, refresh_token):
-        """Refresh an expired access token"""
-        if not self.client_key or not self.client_secret:
-            logger.warning("TikTok credentials missing; cannot refresh access token.")
-            return {'success': False, 'error': 'TikTok integration not configured'}
-        
-        data = {
-            'client_key': self.client_key,
-            'client_secret': self.client_secret,
-            'grant_type': 'refresh_token',
-            'refresh_token': refresh_token
-        }
-        
-        try:
-            response = requests.post(self.TOKEN_URL, data=data)
-            response.raise_for_status()
-            token_data = response.json()
-            
-            if 'error' in token_data:
-                logger.error(f"TikTok refresh error: {token_data}")
-                return {'success': False, 'error': token_data.get('error_description', token_data.get('error'))}
-            
-            expires_in = token_data.get('expires_in', 86400)
-            refresh_expires_in = token_data.get('refresh_expires_in', 86400 * 365)
-            
-            return {
-                'success': True,
-                'access_token': token_data.get('access_token'),
-                'refresh_token': token_data.get('refresh_token'),
-                'open_id': token_data.get('open_id'),
-                'scope': token_data.get('scope'),
-                'token_type': token_data.get('token_type', 'Bearer'),
-                'expires_at': datetime.utcnow() + timedelta(seconds=expires_in),
-                'refresh_expires_at': datetime.utcnow() + timedelta(seconds=refresh_expires_in),
-                'raw_token': token_data
-            }
-            
-        except requests.exceptions.RequestException as e:
-            logger.error(f"TikTok token refresh error: {e}")
-            return {'success': False, 'error': str(e)}
-    
-    def revoke_token(self, access_token, open_id):
-        """Revoke an access token"""
-        if not self.client_key or not self.client_secret:
-            logger.warning("TikTok credentials missing; cannot revoke token.")
-            return {'success': False, 'error': 'TikTok integration not configured'}
-        
-        data = {
-            'client_key': self.client_key,
-            'client_secret': self.client_secret,
-            'token': access_token
-        }
-        
-        try:
-            response = requests.post(self.REVOKE_URL, data=data)
-            response.raise_for_status()
-            return {'success': True, 'message': 'Token revoked successfully'}
-        except requests.exceptions.RequestException as e:
-            logger.error(f"TikTok token revoke error: {e}")
-            return {'success': False, 'error': str(e)}
-    
-    def get_user_info(self, access_token, open_id):
-        """Get TikTok user profile information"""
-        headers = {
-            'Authorization': f'Bearer {access_token}'
-        }
-        
-        params = {
-            'fields': 'open_id,union_id,avatar_url,display_name'
-        }
-        
-        try:
-            response = requests.get(self.USER_INFO_URL, headers=headers, params=params)
-            response.raise_for_status()
-            data = response.json()
-            
-            if 'error' in data:
-                return {'success': False, 'error': data.get('error', {}).get('message', 'Unknown error')}
-            
-            user_data = data.get('data', {}).get('user', {})
-            return {
-                'success': True,
-                'open_id': user_data.get('open_id'),
-                'display_name': user_data.get('display_name'),
-                'avatar_url': user_data.get('avatar_url')
-            }
-            
-        except requests.exceptions.RequestException as e:
-            logger.error(f"TikTok user info error: {e}")
-            return {'success': False, 'error': str(e)}
-    
-    def list_videos(self, access_token, open_id, cursor=None, max_count=20):
-        """List user's TikTok videos"""
-        headers = {
-            'Authorization': f'Bearer {access_token}',
-            'Content-Type': 'application/json'
-        }
-        
-        params = {
-            'fields': 'id,title,video_description,duration,cover_image_url,create_time,share_url,view_count,like_count,comment_count,share_count'
-        }
-        
-        body = {
-            'max_count': min(max_count, 20)
-        }
-        if cursor:
-            body['cursor'] = cursor
-        
-        try:
-            response = requests.post(self.VIDEO_LIST_URL, headers=headers, params=params, json=body)
-            response.raise_for_status()
-            data = response.json()
-            
-            if 'error' in data and data['error'].get('code') != 'ok':
-                return {'success': False, 'error': data.get('error', {}).get('message', 'Unknown error')}
-            
-            video_data = data.get('data', {})
-            videos = video_data.get('videos', [])
-            
-            return {
-                'success': True,
-                'videos': videos,
-                'cursor': video_data.get('cursor'),
-                'has_more': video_data.get('has_more', False)
-            }
-            
-        except requests.exceptions.RequestException as e:
-            logger.error(f"TikTok list videos error: {e}")
-            return {'success': False, 'error': str(e)}
-    
-    def init_video_upload(self, access_token, video_size, chunk_size=None, total_chunk_count=None):
-        """Initialize a video upload session (Direct Post)"""
-        headers = {
-            'Authorization': f'Bearer {access_token}',
-            'Content-Type': 'application/json'
-        }
-        
-        body = {
-            'post_info': {
-                'title': '',
-                'privacy_level': 'SELF_ONLY',
-                'disable_duet': False,
-                'disable_comment': False,
-                'disable_stitch': False,
-                'video_cover_timestamp_ms': 1000
-            },
-            'source_info': {
-                'source': 'FILE_UPLOAD',
-                'video_size': video_size
-            }
-        }
-        
-        if chunk_size:
-            body['source_info']['chunk_size'] = chunk_size
-            body['source_info']['total_chunk_count'] = total_chunk_count
-        
-        try:
-            response = requests.post(self.VIDEO_PUBLISH_URL, headers=headers, json=body)
-            response.raise_for_status()
-            data = response.json()
-            
-            if 'error' in data and data['error'].get('code') != 'ok':
-                return {'success': False, 'error': data.get('error', {}).get('message', 'Unknown error')}
-            
-            return {
-                'success': True,
-                'publish_id': data.get('data', {}).get('publish_id'),
-                'upload_url': data.get('data', {}).get('upload_url')
-            }
-            
-        except requests.exceptions.RequestException as e:
-            logger.error(f"TikTok video upload init error: {e}")
-            return {'success': False, 'error': str(e)}
-    
-    def upload_video_chunk(self, upload_url, video_data, content_range=None):
-        """Upload a video chunk to TikTok"""
-        headers = {
-            'Content-Type': 'video/mp4'
-        }
-        
-        if content_range:
-            headers['Content-Range'] = content_range
-        
-        try:
-            response = requests.put(upload_url, headers=headers, data=video_data)
-            response.raise_for_status()
-            return {'success': True, 'message': 'Chunk uploaded successfully'}
-            
-        except requests.exceptions.RequestException as e:
-            logger.error(f"TikTok video chunk upload error: {e}")
-            return {'success': False, 'error': str(e)}
-    
-    def publish_video(self, access_token, title, description, video_url=None, 
-                      privacy_level='PUBLIC_TO_EVERYONE', 
-                      disable_duet=False, disable_comment=False, disable_stitch=False):
-        """Publish a video to TikTok (from URL)"""
-        headers = {
-            'Authorization': f'Bearer {access_token}',
-            'Content-Type': 'application/json'
-        }
-        
-        body = {
-            'post_info': {
-                'title': title[:150] if title else '',
-                'privacy_level': privacy_level,
-                'disable_duet': disable_duet,
-                'disable_comment': disable_comment,
-                'disable_stitch': disable_stitch
-            },
-            'source_info': {
-                'source': 'PULL_FROM_URL',
-                'video_url': video_url
-            }
-        }
-        
-        try:
-            response = requests.post(self.VIDEO_PUBLISH_URL, headers=headers, json=body)
-            response.raise_for_status()
-            data = response.json()
-            
-            if 'error' in data and data['error'].get('code') != 'ok':
-                return {'success': False, 'error': data.get('error', {}).get('message', 'Unknown error')}
-            
-            return {
-                'success': True,
-                'publish_id': data.get('data', {}).get('publish_id'),
-                'message': 'Video submitted for publishing'
-            }
-            
-        except requests.exceptions.RequestException as e:
-            logger.error(f"TikTok publish video error: {e}")
-            return {'success': False, 'error': str(e)}
-    
+        data = {"client_key": self.client_key, "client_secret": self.client_secret, "grant_type": "refresh_token", "refresh_token": refresh_token}
+        return self._token_result(requests.post(self.TOKEN_URL, data=data, timeout=15).json())
+
+    def revoke_token(self, token, open_id=None):
+        requests.post(self.REVOKE_URL, data={"client_key": self.client_key, "client_secret": self.client_secret, "token": token}, timeout=15)
+        return {"success": True}
+
+    def _post(self, url, access_token, payload=None):
+        r = requests.post(url, headers={"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"}, json=payload or {}, timeout=30)
+        data = r.json()
+        err = data.get("error") or {}
+        if err and err.get("code") not in (None, "ok"):
+            return {"success": False, "error": err.get("message") or err.get("code"), "error_code": err.get("code")}
+        return {"success": True, "data": data.get("data", data)}
+
+    def get_user_info(self, access_token, open_id=None):
+        r = requests.get(self.USER_INFO_URL, headers={"Authorization": f"Bearer {access_token}"}, params={"fields": "open_id,avatar_url,display_name"}, timeout=15)
+        user = r.json().get("data", {}).get("user", {})
+        return {"success": True, "open_id": user.get("open_id"), "display_name": user.get("display_name"), "avatar_url": user.get("avatar_url")}
+
+    def query_creator_info(self, access_token):
+        return self._post(self.CREATOR_INFO_URL, access_token)
+
+    def init_video(self, access_token, post_info, source_info):
+        return self._post(self.VIDEO_INIT_URL, access_token, {"post_info": post_info, "source_info": source_info})
+
+    def upload_video_chunk(self, upload_url, chunk, start, end, total):
+        r = requests.put(upload_url, headers={"Content-Type": "video/mp4", "Content-Range": f"bytes {start}-{end}/{total}"}, data=chunk, timeout=60)
+        r.raise_for_status()
+        return {"success": True, "content_range": f"bytes {start}-{end}/{total}"}
+
+    def init_photo(self, access_token, post_info, source_info):
+        return self._post(self.CONTENT_INIT_URL, access_token, {"post_mode": "DIRECT_POST", "media_type": "PHOTO", "post_info": post_info, "source_info": source_info})
+
+    def fetch_status(self, access_token, publish_id):
+        return self._post(self.STATUS_URL, access_token, {"publish_id": publish_id})
+
+    def list_videos(self, access_token, open_id=None, cursor=None, max_count=20):
+        r = requests.post(
+            "https://open.tiktokapis.com/v2/video/list/",
+            headers={"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"},
+            params={"fields": "id,title,video_description,duration,cover_image_url,create_time,share_url"},
+            json={"cursor": cursor, "max_count": min(int(max_count), 20)} if cursor else {"max_count": min(int(max_count), 20)},
+            timeout=30,
+        )
+        data = r.json()
+        err = data.get("error") or {}
+        if err and err.get("code") not in (None, "ok"):
+            return {"success": False, "error": err.get("message") or err.get("code")}
+        return {"success": True, **data.get("data", {})}
+
+    def publish_video(self, access_token, title, description="", video_url=None, privacy_level="SELF_ONLY", disable_duet=False, disable_comment=False, disable_stitch=False):
+        return self.init_video(access_token, {"title": (title or "")[:150], "privacy_level": privacy_level, "disable_duet": disable_duet, "disable_comment": disable_comment, "disable_stitch": disable_stitch}, {"source": "PULL_FROM_URL", "video_url": video_url})
+
     def check_publish_status(self, access_token, publish_id):
-        """Check the status of a video publish request"""
-        headers = {
-            'Authorization': f'Bearer {access_token}',
-            'Content-Type': 'application/json'
-        }
-        
-        body = {
-            'publish_id': publish_id
-        }
-        
-        status_url = 'https://open.tiktokapis.com/v2/post/publish/status/fetch/'
-        
-        try:
-            response = requests.post(status_url, headers=headers, json=body)
-            response.raise_for_status()
-            data = response.json()
-            
-            if 'error' in data and data['error'].get('code') != 'ok':
-                return {'success': False, 'error': data.get('error', {}).get('message', 'Unknown error')}
-            
-            status_data = data.get('data', {})
-            return {
-                'success': True,
-                'status': status_data.get('status'),
-                'fail_reason': status_data.get('fail_reason'),
-                'public_video_id': status_data.get('public_video_id')
-            }
-            
-        except requests.exceptions.RequestException as e:
-            logger.error(f"TikTok publish status error: {e}")
-            return {'success': False, 'error': str(e)}
+        return self.fetch_status(access_token, publish_id)
+
+
+def is_allowed_media_url(url):
+    allowed = [d.strip().lower() for d in os.getenv("TIKTOK_ALLOWED_MEDIA_DOMAINS", "localhost,127.0.0.1").split(",") if d.strip()]
+    host = (urlparse(url).hostname or "").lower()
+    return bool(host and any(host == d or host.endswith("." + d) for d in allowed))
+
+
+def chunk_plan(size, chunk_size=10 * 1024 * 1024):
+    return chunk_size, int(math.ceil(size / float(chunk_size)))

--- a/templates/tiktok_integration.html
+++ b/templates/tiktok_integration.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<title>TikTok Integration</title>
+<h1>TikTok Integration</h1>
+<div id="error" style="color:#c00"></div>
+<a id="connect" href="/api/oauth/tiktok/start"><button>Connect TikTok</button></a>
+<button id="disconnect">Disconnect</button>
+<a href="/api/oauth/tiktok/start"><button>Re-authenticate</button></a>
+<section id="status">Loading status…</section>
+<section id="creator"></section>
+<h2>TikTok Post Composer</h2>
+<form id="composer">
+  <select id="account" name="account_id"></select>
+  <select name="source"><option>FILE_UPLOAD</option><option>PULL_FROM_URL</option></select>
+  <input name="video" type="file" accept="video/mp4">
+  <input name="video_url" placeholder="Verified video URL">
+  <textarea name="photo_images" placeholder="Photo URLs, one per line"></textarea>
+  <input name="title" placeholder="Title/caption">
+  <select name="privacy_level" id="privacy"><option>SELF_ONLY</option></select>
+  <label><input name="disable_comment" type="checkbox"> Disable comments</label>
+  <label><input name="disable_duet" type="checkbox"> Disable duet</label>
+  <label><input name="disable_stitch" type="checkbox"> Disable stitch</label>
+  <input name="video_cover_timestamp_ms" type="number" value="1000">
+  <button type="submit">Submit post</button>
+</form>
+<pre id="progress"></pre>
+<script>
+const $ = (id) => document.getElementById(id);
+async function loadStatus(){
+ const r = await fetch('/api/integrations/tiktok/accounts'); const data = await r.json();
+ $('status').textContent = data.connected ? 'Connected' : 'Not connected';
+ $('account').innerHTML = (data.accounts||[]).map(a=>`<option value="${a.id}">${a.creator_username||a.display_name||a.open_id}</option>`).join('');
+ if(data.connected) loadCreator();
+}
+async function loadCreator(){
+ const r = await fetch('/api/integrations/tiktok/creator-info?account_id='+$('account').value); const data = await r.json();
+ if(!data.success){ $('error').textContent=data.error||'Creator info failed'; return; }
+ const d=data.data||{}; $('creator').innerHTML=`<h2>${d.creator_nickname||d.nickname||''}</h2><img src="${d.creator_avatar_url||d.avatar_url||''}" width="64"><p>${d.creator_username||d.username||''}</p><p>Max duration: ${d.max_video_post_duration_sec||''}</p>`;
+ const opts=d.privacy_level_options||d.privacy_options||[]; $('privacy').innerHTML=opts.map(o=>`<option>${o.privacy_level||o}</option>`).join('') || '<option>SELF_ONLY</option>';
+}
+$('disconnect').onclick=async()=>{ const r=await fetch('/api/integrations/tiktok/disconnect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({account_id:$('account').value})}); $('progress').textContent=JSON.stringify(await r.json(),null,2); loadStatus(); };
+$('composer').onsubmit=async(e)=>{ e.preventDefault(); const fd=new FormData(e.target); const endpoint=fd.get('photo_images')?'/api/integrations/tiktok/posts/photo':'/api/integrations/tiktok/posts/video'; let opt={method:'POST', body:fd}; if(endpoint.includes('photo')){ opt={method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(Object.fromEntries([...fd.entries()].map(([k,v])=>[k,k==='photo_images'?String(v).split('\n').filter(Boolean):v])))} } const r=await fetch(endpoint,opt); $('progress').textContent=JSON.stringify(await r.json(),null,2); };
+loadStatus();
+</script>

--- a/tests/test_tiktok_integration.py
+++ b/tests/test_tiktok_integration.py
@@ -1,0 +1,196 @@
+import io
+from datetime import datetime, timedelta
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from app import app, db
+from models import Company, TikTokOAuth, TikTokPost, User
+from services.tiktok_service import TikTokService
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+    monkeypatch.setenv("TIKTOK_CLIENT_KEY", "ck")
+    monkeypatch.setenv("TIKTOK_CLIENT_SECRET", "cs")
+    monkeypatch.setenv("TIKTOK_REDIRECT_URI", "http://127.0.0.1:8765/callback/")
+    monkeypatch.setenv("TIKTOK_SCOPES", "user.info.basic video.publish")
+    monkeypatch.setenv("TIKTOK_ALLOWED_MEDIA_DOMAINS", "cdn.example.com")
+    with app.app_context():
+        db.create_all()
+        company = Company(name="TikTok Test Co")
+        user = User(username="tiktok-user", email="tiktok@example.com", default_company=company)
+        db.session.add_all([company, user]); db.session.commit()
+        user.default_company_id = company.id; db.session.commit()
+        with app.test_client() as c:
+            with c.session_transaction() as sess:
+                sess["_user_id"] = str(user.id)
+                sess["_fresh"] = True
+            c.user_id = user.id; c.company_id = company.id
+            yield c
+        db.session.remove(); db.drop_all()
+
+
+def account(user_id, company_id, **kw):
+    a = TikTokOAuth(user_id=user_id, company_id=company_id, open_id=kw.get("open_id", "open"), scope=kw.get("scope", "user.info.basic video.publish"), expires_at=kw.get("expires_at", datetime.utcnow()+timedelta(hours=1)), status="active", creator_info=kw.get("creator_info", {"privacy_level_options": ["SELF_ONLY"]}))
+    a.set_access_token("access-secret"); a.set_refresh_token("refresh-secret")
+    db.session.add(a); db.session.commit(); return a
+
+
+def test_pkce_verifier_challenge_generation():
+    verifier = TikTokService.generate_code_verifier()
+    challenge = TikTokService.code_challenge(verifier)
+    assert len(verifier) >= 43
+    assert len(challenge) == 64
+    assert challenge == TikTokService.code_challenge(verifier)
+
+
+def test_oauth_url_generation(client):
+    r = client.get("/api/oauth/tiktok/start")
+    assert r.status_code == 302
+    q = parse_qs(urlparse(r.location).query)
+    assert r.location.startswith(TikTokService.AUTH_URL)
+    assert q["client_key"] == ["ck"]
+    assert q["response_type"] == ["code"]
+    assert q["redirect_uri"] == ["http://127.0.0.1:8765/callback/"]
+    assert q["code_challenge_method"] == ["S256"]
+    assert len(q["code_challenge"][0]) == 64
+
+
+def test_state_mismatch_rejection(client):
+    with client.session_transaction() as s:
+        s["tiktok_oauth_state"] = "good"
+    r = client.get("/api/oauth/tiktok/callback?code=x&state=bad")
+    assert r.status_code == 400
+    assert r.json["error"] == "state_mismatch"
+
+
+def test_tiktok_callback_error_handling(client):
+    r = client.get("/api/oauth/tiktok/callback?error=access_denied&error_description=nope")
+    assert r.status_code == 400
+    assert r.json["error"] == "access_denied"
+
+
+def test_successful_token_exchange(client, monkeypatch):
+    with client.session_transaction() as s:
+        s["tiktok_oauth_state"] = "state"; s["tiktok_pkce_verifier"] = "verifier"; s["tiktok_oauth_company_id"] = client.company_id
+    monkeypatch.setattr(TikTokService, "exchange_code_for_token", lambda self, code, code_verifier=None, redirect_uri=None: {"success": True, "access_token": "at", "refresh_token": "rt", "open_id": "oid", "scope": "user.info.basic video.publish", "expires_at": datetime.utcnow()+timedelta(hours=1)})
+    monkeypatch.setattr(TikTokService, "get_user_info", lambda self, at, oid=None: {"success": True, "display_name": "Creator", "avatar_url": "https://cdn.example.com/a.png"})
+    r = client.get("/api/oauth/tiktok/callback?code=abc&state=state")
+    assert r.status_code == 302
+    saved = TikTokOAuth.query.filter_by(open_id="oid").first()
+    assert saved and saved.get_access_token() == "at"
+
+
+def test_creator_info_query_and_token_secrecy(client, monkeypatch):
+    account(client.user_id, client.company_id)
+    monkeypatch.setattr(TikTokService, "query_creator_info", lambda self, token: {"success": True, "data": {"creator_username": "lux", "privacy_level_options": ["SELF_ONLY"], "max_video_post_duration_sec": 600}})
+    r = client.get("/api/integrations/tiktok/creator-info")
+    assert r.status_code == 200 and r.json["success"]
+    assert "access-secret" not in r.get_data(as_text=True)
+    assert "refresh-secret" not in r.get_data(as_text=True)
+
+
+def test_missing_tiktok_token(client):
+    r = client.get("/api/integrations/tiktok/creator-info")
+    assert r.status_code == 404
+
+
+def test_expired_token_refresh(client, monkeypatch):
+    account(client.user_id, client.company_id, expires_at=datetime.utcnow()-timedelta(minutes=1))
+    monkeypatch.setattr(TikTokService, "refresh_access_token", lambda self, rt: {"success": True, "access_token": "new", "refresh_token": "newr", "expires_at": datetime.utcnow()+timedelta(hours=2), "scope": "user.info.basic video.publish"})
+    monkeypatch.setattr(TikTokService, "query_creator_info", lambda self, token: {"success": True, "data": {"creator_username": "lux", "privacy_level_options": ["SELF_ONLY"]}})
+    r = client.get("/api/integrations/tiktok/creator-info")
+    assert r.status_code == 200
+    assert TikTokOAuth.query.first().get_access_token() == "new"
+
+
+def test_video_file_upload_init_and_content_range(client, monkeypatch):
+    account(client.user_id, client.company_id)
+    calls = {}
+    monkeypatch.setattr(TikTokService, "init_video", lambda self, token, post_info, source_info: calls.setdefault("init", {"success": True, "data": {"publish_id": "p1", "upload_url": "https://upload"}}))
+    def upload(self, url, chunk, start, end, total):
+        calls["range"] = f"bytes {start}-{end}/{total}"; return {"success": True}
+    monkeypatch.setattr(TikTokService, "upload_video_chunk", upload)
+    r = client.post("/api/integrations/tiktok/posts/video", data={"source": "FILE_UPLOAD", "privacy_level": "SELF_ONLY", "video": (io.BytesIO(b"12345"), "v.mp4")}, content_type="multipart/form-data")
+    assert r.status_code == 200 and r.json["publish_id"] == "p1"
+    assert calls["range"] == "bytes 0-4/5"
+
+
+def test_video_pull_from_url_init(client, monkeypatch):
+    account(client.user_id, client.company_id)
+    monkeypatch.setattr(TikTokService, "init_video", lambda self, token, post_info, source_info: {"success": True, "data": {"publish_id": "p2"}})
+    r = client.post("/api/integrations/tiktok/posts/video", json={"source": "PULL_FROM_URL", "video_url": "https://cdn.example.com/v.mp4", "privacy_level": "SELF_ONLY"})
+    assert r.status_code == 200 and r.json["publish_id"] == "p2"
+
+
+def test_photo_content_init(client, monkeypatch):
+    account(client.user_id, client.company_id)
+    monkeypatch.setattr(TikTokService, "init_photo", lambda self, token, post_info, source_info: {"success": True, "data": {"publish_id": "ph1"}})
+    r = client.post("/api/integrations/tiktok/posts/photo", json={"photo_images": ["https://cdn.example.com/a.jpg"], "privacy_level": "SELF_ONLY"})
+    assert r.status_code == 200 and r.json["publish_id"] == "ph1"
+
+
+def test_status_fetch(client, monkeypatch):
+    a = account(client.user_id, client.company_id)
+    db.session.add(TikTokPost(company_id=client.company_id, user_id=client.user_id, tiktok_account_id=a.id, publish_id="p1", media_type="video", source_type="pull_from_url")); db.session.commit()
+    monkeypatch.setattr(TikTokService, "fetch_status", lambda self, token, publish_id: {"success": True, "data": {"status": "PUBLISH_COMPLETE"}})
+    r = client.get("/api/integrations/tiktok/posts/p1/status")
+    assert r.status_code == 200 and r.json["data"]["status"] == "PUBLISH_COMPLETE"
+
+
+def test_invalid_privacy_missing_scope_unverified_url_rejections(client):
+    account(client.user_id, client.company_id, scope="user.info.basic")
+    r = client.post("/api/integrations/tiktok/posts/video", json={"source": "PULL_FROM_URL", "video_url": "https://cdn.example.com/v.mp4", "privacy_level": "SELF_ONLY"})
+    assert r.status_code == 400 and "video.publish" in r.json["error"]
+    TikTokOAuth.query.delete(); db.session.commit()
+    account(client.user_id, client.company_id)
+    assert client.post("/api/integrations/tiktok/posts/video", json={"source": "PULL_FROM_URL", "video_url": "https://evil.example/v.mp4", "privacy_level": "SELF_ONLY"}).status_code == 400
+    assert client.post("/api/integrations/tiktok/posts/video", json={"source": "PULL_FROM_URL", "video_url": "https://cdn.example.com/v.mp4", "privacy_level": "PUBLIC_TO_EVERYONE"}).status_code == 400
+
+
+def test_disconnect_flow_and_tenant_isolation(client, monkeypatch):
+    a = account(client.user_id, client.company_id)
+    other_co = Company(name="Other"); other_user = User(username="other", email="other@example.com", default_company=other_co)
+    db.session.add_all([other_co, other_user]); db.session.commit()
+    other = account(other_user.id, other_co.id, open_id="other")
+    monkeypatch.setattr(TikTokService, "revoke_token", lambda *args, **kwargs: {"success": True})
+    r = client.post("/api/integrations/tiktok/disconnect", json={"account_id": a.id})
+    assert r.status_code == 200 and r.json["success"]
+    assert db.session.get(TikTokOAuth, a.id).status == "disconnected"
+    assert db.session.get(TikTokOAuth, other.id).status == "active"
+
+
+def test_wildcard_registration_resolves_to_concrete_runtime_redirect(monkeypatch):
+    monkeypatch.setenv("TIKTOK_CLIENT_KEY", "ck")
+    monkeypatch.setenv("TIKTOK_CLIENT_SECRET", "cs")
+    monkeypatch.setenv("TIKTOK_REDIRECT_URI", "http://127.0.0.1:*/callback/")
+    monkeypatch.setenv("TIKTOK_DESKTOP_CALLBACK_PORT", "3455")
+    svc = TikTokService()
+    ok, error = svc.validate_configuration()
+    auth_url, _, _ = svc.build_auth_url(state="s", code_verifier="v")
+    redirect = parse_qs(urlparse(auth_url).query)["redirect_uri"][0]
+    assert ok, error
+    assert redirect == "http://127.0.0.1:3455/callback/"
+    assert "*" not in redirect
+
+
+def test_web_mode_requires_https_concrete_non_loopback(monkeypatch):
+    monkeypatch.setenv("TIKTOK_CLIENT_KEY", "ck")
+    monkeypatch.setenv("TIKTOK_CLIENT_SECRET", "cs")
+    monkeypatch.setenv("TIKTOK_OAUTH_MODE", "web")
+    monkeypatch.setenv("TIKTOK_REDIRECT_URI", "https://app.example.com/api/oauth/tiktok/callback")
+    svc = TikTokService()
+    assert svc.validate_configuration()[0]
+    assert parse_qs(urlparse(svc.build_auth_url(state="s", code_verifier="v")[0]).query)["redirect_uri"][0].startswith("https://app.example.com/")
+
+
+def test_invalid_enabled_redirect_configuration_rejected(monkeypatch):
+    monkeypatch.setenv("TIKTOK_CLIENT_KEY", "ck")
+    monkeypatch.setenv("TIKTOK_CLIENT_SECRET", "cs")
+    monkeypatch.setenv("TIKTOK_REDIRECT_URI", "http://example.com:*/callback/")
+    svc = TikTokService()
+    ok, error = svc.validate_configuration()
+    assert not ok
+    assert "TIKTOK_REDIRECT_URI" in error

--- a/tiktok_auth.py
+++ b/tiktok_auth.py
@@ -1,438 +1,242 @@
-"""
-TikTok OAuth Integration for LUX Marketing Platform
-Provides OAuth authentication and API integration with TikTok.
-"""
-
+"""TikTok OAuth Login Kit and Content Posting API routes."""
 import os
-import logging
 from datetime import datetime
 
-from flask import Blueprint, redirect, request, url_for, flash, jsonify, session
-from flask_login import login_required, current_user
+from flask import Blueprint, jsonify, redirect, request, session, render_template
+from flask_login import current_user, login_required
+from werkzeug.utils import secure_filename
 
 from extensions import db
-from models import TikTokOAuth, Company
+from models import Company, TikTokOAuth, TikTokPost, TikTokPostStatusHistory
+from services.tiktok_service import TikTokService, chunk_plan, is_allowed_media_url
 
-logger = logging.getLogger(__name__)
 
-try:
-    from services.tiktok_service import TikTokService
-except ImportError as exc:
-    logger.warning("TikTokService unavailable: %s", exc)
-    TikTokService = None
+tiktok_bp = Blueprint("tiktok", __name__)
 
-tiktok_bp = Blueprint('tiktok', __name__, url_prefix='/auth/tiktok')
 
 def get_current_company():
-    """Get current user's active company"""
-    if current_user.is_authenticated:
-        return current_user.get_default_company()
-    return None
+    return current_user.get_default_company() if current_user.is_authenticated else None
+
 
 def get_tiktok_service(company=None):
-    """Get TikTok service instance with company credentials"""
-    if TikTokService is None:
-        logger.warning("TikTok integration disabled: TikTokService not available.")
-        return None
-    if company:
-        return TikTokService.from_company(company)
-    return TikTokService()
+    service = TikTokService.from_company(company) if company else TikTokService()
+    if not service.client_key:
+        service.client_key = os.getenv("TIKTOK_CLIENT_KEY")
+    if not service.client_secret:
+        service.client_secret = os.getenv("TIKTOK_CLIENT_SECRET")
+    return service
 
 
-def _ensure_tiktok_configured(service):
-    if not service or not service.is_configured():
-        logger.warning("TikTok integration disabled: missing credentials.")
-        return False
-    return True
-
-
-@tiktok_bp.route('/connect')
-@login_required
-def connect():
-    """Initiate TikTok OAuth flow"""
+def _account(account_id=None):
     company = get_current_company()
-    if not company:
-        flash('Please select a company first.', 'error')
-        return redirect(url_for('main.dashboard'))
-    
-    try:
-        service = get_tiktok_service(company)
-        if not _ensure_tiktok_configured(service):
-            flash('TikTok API credentials not configured. Please add your TikTok credentials in Settings → API Keys & Secrets.', 'error')
-            return redirect(url_for('main.company_settings', company_id=company.id))
-
-        auth_url, state = service.build_auth_url()
-        if not auth_url:
-            flash('TikTok integration not configured. Please add credentials in Settings → API Keys & Secrets.', 'error')
-            return redirect(url_for('main.company_settings', company_id=company.id))
-        
-        session['tiktok_oauth_state'] = state
-        session['tiktok_oauth_company_id'] = company.id
-        
-        logger.info(f"Initiating TikTok OAuth for user {current_user.id}, company {company.id}")
-        return redirect(auth_url)
-        
-    except Exception as e:
-        logger.error(f"TikTok connect error: {e}")
-        flash(f'Failed to connect to TikTok: {str(e)}', 'error')
-        return redirect(url_for('main.dashboard'))
+    q = TikTokOAuth.query.filter_by(user_id=current_user.id, company_id=company.id, status="active")
+    if account_id:
+        q = q.filter_by(id=account_id)
+    return company, q.first()
 
 
-@tiktok_bp.route('/callback')
+def _safe_error(message):
+    return str(message or "TikTok request failed")[:500]
+
+
+def _token_json(account):
+    return {"id": account.id, "open_id": account.open_id, "display_name": account.display_name, "creator_username": account.creator_username, "creator_nickname": account.creator_nickname, "avatar_url": account.avatar_url, "scopes": account.scope, "expires_at": account.expires_at.isoformat() if account.expires_at else None}
+
+
+def _ensure_fresh(account, company):
+    if not account.needs_refresh:
+        return True, None
+    refresh = account.get_refresh_token()
+    if not refresh:
+        account.status = "expired"; db.session.commit()
+        return False, "TikTok authorization expired. Please reconnect."
+    result = get_tiktok_service(company).refresh_access_token(refresh)
+    if not result.get("success"):
+        account.status = "expired"; db.session.commit()
+        return False, "TikTok authorization expired or revoked. Please reconnect."
+    account.set_access_token(result["access_token"])
+    if result.get("refresh_token"):
+        account.set_refresh_token(result["refresh_token"])
+    account.expires_at = result.get("expires_at")
+    account.refresh_expires_at = result.get("refresh_expires_at")
+    account.scope = result.get("scope") or account.scope
+    db.session.commit()
+    return True, None
+
+
+@tiktok_bp.get("/api/oauth/tiktok/start")
 @login_required
-def callback():
-    """Handle TikTok OAuth callback"""
-    code = request.args.get('code')
-    state = request.args.get('state')
-    error = request.args.get('error')
-    error_description = request.args.get('error_description')
-    
+def oauth_start():
+    company = get_current_company()
+    service = get_tiktok_service(company)
+    if not service.is_configured():
+        return jsonify({"success": False, "error": "TikTok OAuth is not configured"}), 503
+    auth_url, state, verifier = service.build_auth_url()
+    session["tiktok_oauth_state"] = state
+    session["tiktok_pkce_verifier"] = verifier
+    session["tiktok_oauth_company_id"] = company.id if company else None
+    return redirect(auth_url)
+
+
+@tiktok_bp.get("/api/oauth/tiktok/callback")
+@login_required
+def oauth_callback():
+    error = request.args.get("error")
     if error:
-        logger.error(f"TikTok OAuth error: {error} - {error_description}")
-        flash(f'TikTok authorization failed: {error_description or error}', 'error')
-        return redirect(url_for('main.dashboard'))
-    
-    stored_state = session.pop('tiktok_oauth_state', None)
-    company_id = session.pop('tiktok_oauth_company_id', None)
-    
-    if not stored_state or state != stored_state:
-        logger.error("TikTok OAuth state mismatch - possible CSRF attack")
-        flash('Security validation failed. Please try again.', 'error')
-        return redirect(url_for('main.dashboard'))
-    
+        return jsonify({"success": False, "error": error, "error_description": request.args.get("error_description")}), 400
+    if request.args.get("state") != session.pop("tiktok_oauth_state", None):
+        return jsonify({"success": False, "error": "state_mismatch"}), 400
+    code = request.args.get("code")
     if not code:
-        flash('No authorization code received from TikTok.', 'error')
-        return redirect(url_for('main.dashboard'))
-    
-    company = db.session.get(Company, company_id) if company_id else get_current_company()
-    if not company:
-        flash('Could not determine company for TikTok connection.', 'error')
-        return redirect(url_for('main.dashboard'))
-    
-    try:
-        service = get_tiktok_service(company)
-        if not _ensure_tiktok_configured(service):
-            flash('TikTok integration not configured. Please add credentials in Settings → API Keys & Secrets.', 'error')
-            return redirect(url_for('main.company_settings', company_id=company.id))
-        result = service.exchange_code_for_token(code)
-        
-        if not result.get('success'):
-            flash(f'Failed to get TikTok tokens: {result.get("error")}', 'error')
-            return redirect(url_for('main.dashboard'))
-        
-        user_info = service.get_user_info(result['access_token'], result['open_id'])
-        
-        existing = TikTokOAuth.query.filter_by(
-            user_id=current_user.id,
-            open_id=result['open_id']
-        ).first()
-        
-        if existing:
-            existing.set_access_token(result['access_token'])
-            existing.set_refresh_token(result.get('refresh_token'))
-            existing.expires_at = result.get('expires_at')
-            existing.refresh_expires_at = result.get('refresh_expires_at')
-            existing.scope = result.get('scope')
-            existing.raw_token = result.get('raw_token')
-            existing.status = 'active'
-            existing.updated_at = datetime.utcnow()
-            
-            if user_info.get('success'):
-                existing.display_name = user_info.get('display_name')
-                existing.avatar_url = user_info.get('avatar_url')
-            
-            db.session.commit()
-            flash('TikTok account reconnected successfully!', 'success')
-        else:
-            oauth_record = TikTokOAuth(
-                user_id=current_user.id,
-                company_id=company.id,
-                open_id=result['open_id'],
-                expires_at=result.get('expires_at'),
-                refresh_expires_at=result.get('refresh_expires_at'),
-                scope=result.get('scope'),
-                token_type=result.get('token_type', 'Bearer'),
-                raw_token=result.get('raw_token'),
-                display_name=user_info.get('display_name') if user_info.get('success') else None,
-                avatar_url=user_info.get('avatar_url') if user_info.get('success') else None,
-                status='active'
-            )
-            oauth_record.set_access_token(result['access_token'])
-            oauth_record.set_refresh_token(result.get('refresh_token'))
-            db.session.add(oauth_record)
-            db.session.commit()
-            flash('TikTok account connected successfully!', 'success')
-        
-        logger.info(f"TikTok OAuth completed for user {current_user.id}")
-        return redirect(url_for('main.company_settings', company_id=company.id))
-        
-    except Exception as e:
-        logger.error(f"TikTok callback error: {e}")
-        flash(f'Failed to complete TikTok connection: {str(e)}', 'error')
-        return redirect(url_for('main.dashboard'))
+        return jsonify({"success": False, "error": "missing_code"}), 400
+    company = db.session.get(Company, session.pop("tiktok_oauth_company_id", None)) or get_current_company()
+    verifier = session.pop("tiktok_pkce_verifier", None)
+    service = get_tiktok_service(company)
+    result = service.exchange_code_for_token(code, code_verifier=verifier)
+    if not result.get("success"):
+        return jsonify({"success": False, "error": _safe_error(result.get("error"))}), 502
+    info = service.get_user_info(result["access_token"], result.get("open_id"))
+    account = TikTokOAuth.query.filter_by(company_id=company.id, user_id=current_user.id, open_id=result["open_id"]).first() or TikTokOAuth(company_id=company.id, user_id=current_user.id, open_id=result["open_id"])
+    account.set_access_token(result["access_token"]); account.set_refresh_token(result.get("refresh_token"))
+    account.expires_at = result.get("expires_at"); account.refresh_expires_at = result.get("refresh_expires_at")
+    account.scope = result.get("scope"); account.status = "active"; account.disconnected_at = None
+    if info.get("success"):
+        account.display_name = info.get("display_name"); account.avatar_url = info.get("avatar_url")
+    db.session.add(account); db.session.commit()
+    return redirect("/integrations/tiktok")
 
 
-@tiktok_bp.route('/disconnect', methods=['POST'])
+@tiktok_bp.get("/api/integrations/tiktok/accounts")
+@login_required
+def accounts():
+    company = get_current_company()
+    rows = TikTokOAuth.query.filter_by(company_id=company.id, user_id=current_user.id, status="active").all() if company else []
+    return jsonify({"connected": bool(rows), "accounts": [_token_json(r) for r in rows]})
+
+
+@tiktok_bp.post("/api/integrations/tiktok/disconnect")
 @login_required
 def disconnect():
-    """Disconnect TikTok account"""
-    company = get_current_company()
-    
+    company, account = _account(request.json.get("account_id") if request.is_json and request.json else None)
+    if not account:
+        return jsonify({"success": False, "error": "TikTok account not connected"}), 404
     try:
-        oauth_record = TikTokOAuth.query.filter_by(
-            user_id=current_user.id,
-            company_id=company.id if company else None
-        ).first()
-        
-        if oauth_record:
-            try:
-                service = get_tiktok_service(company)
-                if not _ensure_tiktok_configured(service):
-                    return jsonify({'success': False, 'error': 'TikTok integration not configured'}), 503
-                service.revoke_token(oauth_record.get_access_token(), oauth_record.open_id)
-            except Exception as e:
-                logger.warning(f"Failed to revoke TikTok token: {e}")
-            
-            db.session.delete(oauth_record)
-            db.session.commit()
-            
-            return jsonify({'success': True, 'message': 'TikTok account disconnected'})
-        else:
-            return jsonify({'success': False, 'error': 'No TikTok account connected'})
-            
-    except Exception as e:
-        logger.error(f"TikTok disconnect error: {e}")
-        return jsonify({'success': False, 'error': str(e)})
+        get_tiktok_service(company).revoke_token(account.get_access_token(), account.open_id)
+    except Exception:
+        pass
+    account.status = "disconnected"; account.disconnected_at = datetime.utcnow(); db.session.commit()
+    return jsonify({"success": True})
 
 
-@tiktok_bp.route('/refresh', methods=['POST'])
+@tiktok_bp.get("/api/integrations/tiktok/creator-info")
 @login_required
-def refresh():
-    """Refresh TikTok access token"""
-    company = get_current_company()
-    
-    try:
-        oauth_record = TikTokOAuth.query.filter_by(
-            user_id=current_user.id,
-            company_id=company.id if company else None,
-            status='active'
-        ).first()
-        
-        if not oauth_record:
-            return jsonify({'success': False, 'error': 'No TikTok account connected'})
-        
-        if not oauth_record.get_refresh_token():
-            return jsonify({'success': False, 'error': 'No refresh token available'})
-        
-        service = get_tiktok_service(company)
-        if not _ensure_tiktok_configured(service):
-            return jsonify({'success': False, 'error': 'TikTok integration not configured'}), 503
-        result = service.refresh_access_token(oauth_record.get_refresh_token())
-        
-        if not result.get('success'):
-            oauth_record.status = 'expired'
-            db.session.commit()
-            return jsonify({'success': False, 'error': result.get('error')})
-        
-        oauth_record.set_access_token(result['access_token'])
-        if result.get('refresh_token'):
-            oauth_record.set_refresh_token(result['refresh_token'])
-        oauth_record.expires_at = result.get('expires_at')
-        oauth_record.refresh_expires_at = result.get('refresh_expires_at')
-        oauth_record.raw_token = result.get('raw_token')
-        oauth_record.last_refreshed_at = datetime.utcnow()
-        oauth_record.updated_at = datetime.utcnow()
+def creator_info():
+    company, account = _account(request.args.get("account_id"))
+    if not account: return jsonify({"success": False, "error": "Missing TikTok token"}), 404
+    ok, err = _ensure_fresh(account, company)
+    if not ok: return jsonify({"success": False, "error": err}), 401
+    result = get_tiktok_service(company).query_creator_info(account.get_access_token())
+    if result.get("success"):
+        data = result.get("data", {})
+        account.creator_info = data; account.creator_username = data.get("creator_username") or data.get("username"); account.creator_nickname = data.get("creator_nickname") or data.get("nickname"); account.avatar_url = data.get("creator_avatar_url") or data.get("avatar_url") or account.avatar_url
         db.session.commit()
-        
-        return jsonify({
-            'success': True,
-            'message': 'Token refreshed successfully',
-            'expires_at': oauth_record.expires_at.isoformat() if oauth_record.expires_at else None
-        })
-        
-    except Exception as e:
-        logger.error(f"TikTok refresh error: {e}")
-        return jsonify({'success': False, 'error': str(e)})
+    return jsonify(result)
 
 
-@tiktok_bp.route('/status')
+def _validate_post(account, privacy):
+    if not account.has_scope("video.publish"):
+        return "TikTok account is missing required video.publish scope."
+    if not account.creator_info:
+        return "Creator info must be queried before posting."
+    opts = account.creator_info.get("privacy_level_options") or account.creator_info.get("privacy_options") or []
+    allowed = [o.get("privacy_level") if isinstance(o, dict) else o for o in opts]
+    if allowed and privacy not in allowed:
+        return "Invalid privacy level for this TikTok creator."
+    return None
+
+
+@tiktok_bp.post("/api/integrations/tiktok/posts/video")
 @login_required
-def status():
-    """Get TikTok connection status"""
-    company = get_current_company()
-    
-    try:
-        oauth_record = TikTokOAuth.query.filter_by(
-            user_id=current_user.id,
-            company_id=company.id if company else None
-        ).first()
-        
-        if not oauth_record:
-            return jsonify({
-                'connected': False,
-                'message': 'No TikTok account connected'
-            })
-        
-        return jsonify({
-            'connected': True,
-            'status': oauth_record.status,
-            'display_name': oauth_record.display_name,
-            'avatar_url': oauth_record.avatar_url,
-            'open_id': oauth_record.open_id,
-            'expires_at': oauth_record.expires_at.isoformat() if oauth_record.expires_at else None,
-            'is_expired': oauth_record.is_expired,
-            'needs_refresh': oauth_record.needs_refresh,
-            'scope': oauth_record.scope
-        })
-        
-    except Exception as e:
-        logger.error(f"TikTok status error: {e}")
-        return jsonify({'connected': False, 'error': str(e)})
+def post_video():
+    company, account = _account(request.form.get("account_id") or (request.json or {}).get("account_id") if request.is_json else None)
+    if not account: return jsonify({"success": False, "error": "Missing TikTok token"}), 404
+    ok, err = _ensure_fresh(account, company)
+    if not ok: return jsonify({"success": False, "error": err}), 401
+    data = request.form if request.form else (request.json or {})
+    privacy = data.get("privacy_level", "SELF_ONLY")
+    invalid = _validate_post(account, privacy)
+    if invalid: return jsonify({"success": False, "error": invalid}), 400
+    post_info = {"title": data.get("title", "")[:150], "privacy_level": privacy, "disable_comment": str(data.get("disable_comment", False)).lower() == "true", "disable_duet": str(data.get("disable_duet", False)).lower() == "true", "disable_stitch": str(data.get("disable_stitch", False)).lower() == "true", "video_cover_timestamp_ms": int(data.get("video_cover_timestamp_ms", 1000))}
+    source_type = data.get("source", "PULL_FROM_URL")
+    if source_type == "FILE_UPLOAD":
+        f = request.files.get("video")
+        if not f or f.mimetype not in ("video/mp4", "application/octet-stream") or not secure_filename(f.filename).lower().endswith(".mp4"):
+            return jsonify({"success": False, "error": "Only MP4/H.264 video uploads are supported."}), 400
+        blob = f.read(); size = len(blob); chunk_size, count = chunk_plan(size)
+        source_info = {"source": "FILE_UPLOAD", "video_size": size, "chunk_size": chunk_size, "total_chunk_count": count}
+    else:
+        video_url = data.get("video_url")
+        if not video_url or not is_allowed_media_url(video_url): return jsonify({"success": False, "error": "Video URL domain is not verified/allowed."}), 400
+        source_info = {"source": "PULL_FROM_URL", "video_url": video_url}
+    result = get_tiktok_service(company).init_video(account.get_access_token(), post_info, source_info)
+    if not result.get("success"): return jsonify(result), 502
+    d = result.get("data", {})
+    if source_type == "FILE_UPLOAD" and d.get("upload_url"):
+        svc = get_tiktok_service(company)
+        for i in range(count):
+            start = i * chunk_size; end = min(start + chunk_size, size) - 1
+            svc.upload_video_chunk(d["upload_url"], blob[start:end+1], start, end, size)
+    post = TikTokPost(company_id=company.id, user_id=current_user.id, tiktok_account_id=account.id, publish_id=d.get("publish_id"), media_type="video", source_type=source_type.lower(), title=post_info["title"], privacy_level=privacy, status="initialized", status_payload=d)
+    db.session.add(post); db.session.commit()
+    return jsonify({"success": True, "publish_id": post.publish_id, "post_id": post.id, "warning": "Unaudited TikTok clients may be restricted to private posting until audit approval."})
 
 
-tiktok_api_bp = Blueprint('tiktok_api', __name__, url_prefix='/api/tiktok')
-
-
-@tiktok_api_bp.route('/videos')
+@tiktok_bp.post("/api/integrations/tiktok/posts/photo")
 @login_required
-def list_videos():
-    """List user's TikTok videos"""
-    company = get_current_company()
-    cursor = request.args.get('cursor')
-    
-    try:
-        oauth_record = TikTokOAuth.query.filter_by(
-            user_id=current_user.id,
-            company_id=company.id if company else None,
-            status='active'
-        ).first()
-        
-        if not oauth_record:
-            return jsonify({'success': False, 'error': 'TikTok not connected'})
-        
-        if oauth_record.is_expired:
-            return jsonify({'success': False, 'error': 'TikTok token expired. Please refresh or reconnect.'})
-        
-        service = get_tiktok_service(company)
-        if not _ensure_tiktok_configured(service):
-            return jsonify({'success': False, 'error': 'TikTok integration not configured'}), 503
-        result = service.list_videos(oauth_record.get_access_token(), oauth_record.open_id, cursor=cursor)
-        
-        return jsonify(result)
-        
-    except Exception as e:
-        logger.error(f"TikTok list videos error: {e}")
-        return jsonify({'success': False, 'error': str(e)})
+def post_photo():
+    company, account = _account((request.json or {}).get("account_id"))
+    if not account: return jsonify({"success": False, "error": "Missing TikTok token"}), 404
+    ok, err = _ensure_fresh(account, company)
+    if not ok: return jsonify({"success": False, "error": err}), 401
+    data = request.json or {}; privacy = data.get("privacy_level", "SELF_ONLY")
+    invalid = _validate_post(account, privacy)
+    if invalid: return jsonify({"success": False, "error": invalid}), 400
+    images = data.get("photo_images") or []
+    if not images or any(not is_allowed_media_url(u) for u in images): return jsonify({"success": False, "error": "Photo URL domain is not verified/allowed."}), 400
+    result = get_tiktok_service(company).init_photo(account.get_access_token(), {"title": data.get("title", "")[:150], "description": data.get("description", ""), "privacy_level": privacy, "disable_comment": bool(data.get("disable_comment")), "auto_add_music": bool(data.get("auto_add_music"))}, {"source": "PULL_FROM_URL", "photo_cover_index": int(data.get("photo_cover_index", 0)), "photo_images": images})
+    if not result.get("success"): return jsonify(result), 502
+    d = result.get("data", {})
+    post = TikTokPost(company_id=company.id, user_id=current_user.id, tiktok_account_id=account.id, publish_id=d.get("publish_id"), media_type="photo", source_type="pull_from_url", title=data.get("title"), description=data.get("description"), privacy_level=privacy, status="initialized", status_payload=d)
+    db.session.add(post); db.session.commit()
+    return jsonify({"success": True, "publish_id": post.publish_id, "post_id": post.id})
 
 
-@tiktok_api_bp.route('/publish', methods=['POST'])
+@tiktok_bp.get("/api/integrations/tiktok/posts/<publish_id>/status")
 @login_required
-def publish_video():
-    """Publish a video to TikTok (explicit user action required)"""
-    company = get_current_company()
-    data = request.get_json()
-    
-    if not data:
-        return jsonify({'success': False, 'error': 'No data provided'})
-    
-    video_url = data.get('video_url')
-    title = data.get('title', '')
-    description = data.get('description', '')
-    privacy_level = data.get('privacy_level', 'PUBLIC_TO_EVERYONE')
-    
-    if not video_url:
-        return jsonify({'success': False, 'error': 'Video URL is required'})
-    
-    try:
-        oauth_record = TikTokOAuth.query.filter_by(
-            user_id=current_user.id,
-            company_id=company.id if company else None,
-            status='active'
-        ).first()
-        
-        if not oauth_record:
-            return jsonify({'success': False, 'error': 'TikTok not connected'})
-        
-        if oauth_record.is_expired:
-            return jsonify({'success': False, 'error': 'TikTok token expired. Please refresh or reconnect.'})
-        
-        service = get_tiktok_service(company)
-        if not _ensure_tiktok_configured(service):
-            return jsonify({'success': False, 'error': 'TikTok integration not configured'}), 503
-        result = service.publish_video(
-            access_token=oauth_record.get_access_token(),
-            title=title,
-            description=description,
-            video_url=video_url,
-            privacy_level=privacy_level
-        )
-        
-        return jsonify(result)
-        
-    except Exception as e:
-        logger.error(f"TikTok publish error: {e}")
-        return jsonify({'success': False, 'error': str(e)})
+def post_status(publish_id):
+    company, account = _account(request.args.get("account_id"))
+    post = TikTokPost.query.filter_by(company_id=company.id, publish_id=publish_id).first() if company else None
+    if not account or not post or post.tiktok_account_id != account.id: return jsonify({"success": False, "error": "Post not found"}), 404
+    ok, err = _ensure_fresh(account, company)
+    if not ok: return jsonify({"success": False, "error": err}), 401
+    result = get_tiktok_service(company).fetch_status(account.get_access_token(), publish_id)
+    if result.get("success"):
+        data = result.get("data", {}); post.status = data.get("status", post.status); post.status_payload = data; db.session.add(TikTokPostStatusHistory(tiktok_post_id=post.id, status=post.status, payload=data)); db.session.commit()
+    return jsonify(result)
 
 
-@tiktok_api_bp.route('/publish/status/<publish_id>')
+@tiktok_bp.get("/integrations/tiktok")
 @login_required
-def check_publish_status(publish_id):
-    """Check the status of a video publish request"""
-    company = get_current_company()
-    
-    try:
-        oauth_record = TikTokOAuth.query.filter_by(
-            user_id=current_user.id,
-            company_id=company.id if company else None,
-            status='active'
-        ).first()
-        
-        if not oauth_record:
-            return jsonify({'success': False, 'error': 'TikTok not connected'})
-        
-        service = get_tiktok_service(company)
-        if not _ensure_tiktok_configured(service):
-            return jsonify({'success': False, 'error': 'TikTok integration not configured'}), 503
-        result = service.check_publish_status(oauth_record.get_access_token(), publish_id)
-        
-        return jsonify(result)
-        
-    except Exception as e:
-        logger.error(f"TikTok publish status error: {e}")
-        return jsonify({'success': False, 'error': str(e)})
+def tiktok_page():
+    return render_template("tiktok_integration.html")
 
-
-@tiktok_api_bp.route('/user/info')
+# Backward-compatible aliases
+@tiktok_bp.get("/auth/tiktok/connect")
 @login_required
-def get_user_info():
-    """Get connected TikTok user info"""
-    company = get_current_company()
-    
-    try:
-        oauth_record = TikTokOAuth.query.filter_by(
-            user_id=current_user.id,
-            company_id=company.id if company else None,
-            status='active'
-        ).first()
-        
-        if not oauth_record:
-            return jsonify({'success': False, 'error': 'TikTok not connected'})
-        
-        if oauth_record.is_expired:
-            return jsonify({'success': False, 'error': 'TikTok token expired'})
-        
-        service = get_tiktok_service(company)
-        if not _ensure_tiktok_configured(service):
-            return jsonify({'success': False, 'error': 'TikTok integration not configured'}), 503
-        result = service.get_user_info(oauth_record.get_access_token(), oauth_record.open_id)
-        
-        if result.get('success'):
-            oauth_record.display_name = result.get('display_name')
-            oauth_record.avatar_url = result.get('avatar_url')
-            db.session.commit()
-        
-        return jsonify(result)
-        
-    except Exception as e:
-        logger.error(f"TikTok user info error: {e}")
-        return jsonify({'success': False, 'error': str(e)})
+def connect_alias(): return redirect("/api/oauth/tiktok/start")
+@tiktok_bp.get("/auth/tiktok/status")
+@login_required
+def status_alias(): return accounts()
+@tiktok_bp.post("/auth/tiktok/disconnect")
+@login_required
+def disconnect_alias(): return disconnect()


### PR DESCRIPTION
### Motivation
- Introduce TikTok OAuth and content-posting support so users can connect TikTok accounts and publish media from the app. 
- Validate runtime redirect URIs and PKCE flows to support desktop and web OAuth modes safely. 
- Store tokens securely and track post/publish status to support refresh/revoke workflows and auditing.

### Description
- Add a new `services/tiktok_service.py` implementing OAuth PKCE, redirect URI validation, token exchange/refresh/revoke, API wrappers (`init_video`, `init_photo`, `fetch_status`, etc.), and helper functions `is_allowed_media_url` and `chunk_plan`.
- Extend models in `models.py` with `TikTokOAuth` token encryption accessors (`set_*`/`get_*`), token metadata and helper properties, plus new `TikTokPost` and `TikTokPostStatusHistory` tables for tracking posts and status history.
- Replace and expand the TikTok routes in `tiktok_auth.py` to provide API endpoints for starting the OAuth flow (`/api/oauth/tiktok/start`), callback (`/api/oauth/tiktok/callback`), account listing, disconnect, creator-info, posting endpoints (`/api/integrations/tiktok/posts/*`), status polling, and a simple UI at `/integrations/tiktok`; include backward-compatible aliases.
- Register the TikTok blueprint in `app.py` only when configuration validates and optionally fail startup if environment variables are set but invalid; add a `tiktok_integration.html` template for the web UI.
- Add comprehensive integration unit tests in `tests/test_tiktok_integration.py` covering PKCE, auth URL generation, callback handling, token refresh, file upload chunking, photo posting, status fetch, disconnect flow, and redirect URI validation.

### Testing
- Ran the new test module with `pytest tests/test_tiktok_integration.py`, and the tests passed.
- The changed endpoints and service methods were exercised by the unit tests which asserted expected behaviors for OAuth flow, token lifecycle, posting flows, and validation rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a494c18a5b8832299bc9846435518ce)