### PR TITLE
PWA push sound/forwarding/autoreply + centralize SMS sending (sendConversationSms)

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -421,73 +421,6 @@ def _twilio_send_error_message_LEGACY(exc) -> str:
     return raw
 
 
-def _send_sms_internal(ta, to_number: str, body: str, conversation_id=None, from_number: str | None = None):
-    """Send SMS via Twilio — mirrors twilio_sms._send_sms.
-
-    Keep customer SMS content isolated from notification/log text. Only
-    ``sms_body`` is sent to Twilio and persisted as the message body.
-    """
-    from models import TwilioMessage
-    sms_body = _sanitize_body(body)
-    from services.license_service import PHONE_PWA_FEATURE, has_feature
-    if getattr(ta, "company_id", None) and not has_feature(ta.company_id, PHONE_PWA_FEATURE):
-        return None, "Phone/PWA Communications license is not active."
-    try:
-        from twilio.rest import Client
-        sid = ta.get_account_sid() if hasattr(ta, 'get_account_sid') else ta._account_sid
-        tok = ta.get_auth_token()  if hasattr(ta, 'get_auth_token')  else ta._auth_token
-        client = Client(sid, tok)
-        kwargs = {"body": sms_body, "to": to_number}
-        if from_number:
-            kwargs["from_"] = from_number
-        elif ta.messaging_service_sid:
-            kwargs["messaging_service_sid"] = ta.messaging_service_sid
-        elif ta.from_phone:
-            kwargs["from_"] = ta.from_phone
-        else:
-            return None, "No From number or Messaging Service SID configured."
-        msg = client.messages.create(**kwargs)
-        provider_status = (getattr(msg, "status", None) or "sent").lower()
-        dispatched_status = provider_status if provider_status in {"sent", "delivered", "failed", "undelivered"} else "sent"
-        record = TwilioMessage(
-            conversation_id=conversation_id,
-            company_id=ta.company_id,
-            twilio_sid=msg.sid,
-            direction="outbound",
-            from_number=from_number or ta.from_phone or ta.messaging_service_sid,
-            to_number=to_number,
-            body=sms_body,
-            status=dispatched_status,
-            raw_payload={"provider_status": provider_status},
-        )
-        db.session.add(record)
-        db.session.commit()
-        logger.info("PWA Inbox outbound SMS dispatched: sid=%s status=%s to=%s", msg.sid, dispatched_status, to_number)
-        return record, None
-    except Exception as exc:
-        logger.error("PWA Inbox SMS send error: %s", exc)
-        error = _twilio_send_error_message(exc)
-        if conversation_id:
-            try:
-                failed = TwilioMessage(
-                    conversation_id=conversation_id,
-                    company_id=ta.company_id,
-                    direction="outbound",
-                    from_number=from_number or ta.from_phone or ta.messaging_service_sid,
-                    to_number=to_number,
-                    body=sms_body,
-                    status="failed",
-                    error_code=str(getattr(exc, "code", "") or getattr(exc, "status", "") or "") or None,
-                    error_message=error,
-                )
-                db.session.add(failed)
-                db.session.commit()
-            except Exception:
-                db.session.rollback()
-                logger.exception("Unable to persist failed outbound SMS record", extra={"conversation_id": conversation_id})
-        return None, error
-
-
 def retry_queued_outbound_messages(company_id: int, limit: int = 100, dry_run: bool = False) -> dict:
     """Admin-safe retry for legacy PWA outbound rows stuck as queued without a Twilio SID."""
     from models import TwilioConversation, TwilioMessage
@@ -515,7 +448,6 @@ def retry_queued_outbound_messages(company_id: int, limit: int = 100, dry_run: b
     errors = []
     for row in rows:
         conv = row.conversation
-        from_number = row.from_number or getattr(conv, "to_number", None) or getattr(ta, "from_phone", None)
         to_number = row.to_number or getattr(conv, "from_number", None)
         if not to_number:
             row.status = "failed"
@@ -524,45 +456,21 @@ def retry_queued_outbound_messages(company_id: int, limit: int = 100, dry_run: b
             errors.append({"id": row.id, "error": row.error_message})
             db.session.commit()
             continue
-        sent, err = _dispatch_existing_outbound_message(ta, row, to_number, from_number)
-        if err:
+        from twilio_sms import sendConversationSms
+        result = sendConversationSms(conv.id, row.body or "", twilio_account=ta, to_number=to_number)
+        if not result.get("success"):
+            row.status = "failed"
+            row.error_message = result.get("error") or "SMS retry failed."
+            db.session.commit()
             failed += 1
-            errors.append({"id": row.id, "error": err})
+            errors.append({"id": row.id, "error": row.error_message})
         else:
+            row.status = "sent"
+            row.error_message = None
+            row.raw_payload = {"retried_from_queue": True, "resent_via": "sendConversationSms"}
+            db.session.commit()
             retried += 1
     return {"success": failed == 0, "matched": len(rows), "retried": retried, "failed": failed, "errors": errors[:20]}
-
-
-def _dispatch_existing_outbound_message(ta, row, to_number: str, from_number: str | None):
-    try:
-        from twilio.rest import Client
-        sid = ta.get_account_sid() if hasattr(ta, "get_account_sid") else ta._account_sid
-        tok = ta.get_auth_token() if hasattr(ta, "get_auth_token") else ta._auth_token
-        client = Client(sid, tok)
-        kwargs = {"body": _sanitize_body(row.body or ""), "to": to_number}
-        if from_number:
-            kwargs["from_"] = from_number
-        elif ta.messaging_service_sid:
-            kwargs["messaging_service_sid"] = ta.messaging_service_sid
-        else:
-            raise RuntimeError("No From number or Messaging Service SID configured.")
-        msg = client.messages.create(**kwargs)
-        provider_status = (getattr(msg, "status", None) or "sent").lower()
-        row.twilio_sid = msg.sid
-        row.from_number = from_number or ta.from_phone or ta.messaging_service_sid
-        row.to_number = to_number
-        row.status = provider_status if provider_status in {"sent", "delivered", "failed", "undelivered"} else "sent"
-        row.error_message = None
-        row.raw_payload = {"provider_status": provider_status, "retried_from_queue": True}
-        db.session.commit()
-        return row, None
-    except Exception as exc:
-        error = _twilio_send_error_message(exc)
-        row.status = "failed"
-        row.error_code = str(getattr(exc, "code", "") or getattr(exc, "status", "") or "") or None
-        row.error_message = error
-        db.session.commit()
-        return None, error
 
 
 def _conv_to_dict(conv, brief=True):
@@ -656,7 +564,7 @@ def pwa_index():
         os.environ.get("LUXIT_ASSET_VERSION")
         or os.environ.get("GIT_SHA")
         or os.environ.get("RENDER_GIT_COMMIT")
-        or "20260702-push-sound-diagnostics"
+        or "20260705-push-sound-forwarding-bh-autoreply"
     )
     return render_template(
         "inbox_pwa/index.html",
@@ -686,7 +594,7 @@ def pwa_calls():
         os.environ.get("LUXIT_ASSET_VERSION")
         or os.environ.get("GIT_SHA")
         or os.environ.get("RENDER_GIT_COMMIT")
-        or "20260702-push-sound-diagnostics"
+        or "20260705-push-sound-forwarding-bh-autoreply"
     )
     return render_template("inbox_pwa/calls.html", user=user, company=company, pwa_version=pwa_version)
 
@@ -1819,11 +1727,14 @@ def send_message(conv_id):
             "twilio_not_configured",
         )
 
-    record, err = _send_sms_internal(ta, conv.from_number, body, conversation_id=conv.id, from_number=conv.to_number)
-    if err:
+    from twilio_sms import sendConversationSms
+    result = sendConversationSms(conv.id, body, twilio_account=ta)
+    if not result.get("success"):
         logger.error("send_message failed: user=%d company=%d conv=%d to=%s error=%s",
-                     user.id, company.id, conv_id, conv.from_number, err)
-        return _json_error(err, 502, "provider_failure")
+                     user.id, company.id, conv_id, conv.from_number, result.get("error"))
+        return _json_error(result.get("error") or "SMS send failed", 502, "provider_failure")
+    from models import TwilioMessage
+    record = TwilioMessage.query.filter_by(conversation_id=conv.id, direction="outbound").order_by(TwilioMessage.id.desc()).first()
 
     # Update conversation preview
     conv.last_message_at      = datetime.utcnow()
@@ -1906,11 +1817,14 @@ def new_conversation():
         db.session.add(conv)
         db.session.flush()
 
-    record, err = _send_sms_internal(ta, to_num, body, conversation_id=conv.id, from_number=ta.from_phone)
-    if err:
+    from twilio_sms import sendConversationSms
+    result = sendConversationSms(conv.id, body, twilio_account=ta, to_number=to_num)
+    if not result.get("success"):
         logger.error("new_conversation send failed user=%d company=%d to=%s: %s",
-                     user.id, company.id, to_num, err)
-        return _json_error(err, 502, "provider_failure")
+                     user.id, company.id, to_num, result.get("error"))
+        return _json_error(result.get("error") or "SMS send failed", 502, "provider_failure")
+    from models import TwilioMessage
+    record = TwilioMessage.query.filter_by(conversation_id=conv.id, direction="outbound").order_by(TwilioMessage.id.desc()).first()
 
     conv.last_message_at      = datetime.utcnow()
     conv.last_message_preview = f"You: {body[:150]}"
@@ -2192,15 +2106,19 @@ def _push_debug_decision(user, event_type: str, *, requested_silent: bool, in_bu
         return {"send": False, "reason": "outside_business_hours_and_after_hours_push_disabled", "event_type": canonical}
     quiet = _now_in_user_quiet_hours(user)
     sound_enabled = getattr(user, "notification_sounds_enabled", True) is not False
-    silent = bool(requested_silent or quiet or not sound_enabled)
+    allow_silent_override = os.environ.get("LUXIT_ALLOW_SILENT_PUSH", "").lower() in {"1", "true", "yes"}
+    would_silence = bool(requested_silent or quiet or not sound_enabled)
+    silent = bool(would_silence and allow_silent_override)
     vibration_enabled = getattr(user, "pwa_vibration_enabled", True) is not False
     return {
         "send": True,
         "reason": "quiet_hours" if quiet else ("sound_preference_disabled" if not sound_enabled else "alert_enabled"),
+        "would_silence_without_lock": would_silence,
+        "silent_override_locked": would_silence and not allow_silent_override,
         "event_type": canonical,
         "silent": silent,
-        "vibrate": [200, 100, 200] if (vibration_enabled and not silent) else [],
-        "sound": None if silent else "default",
+        "vibrate": [200, 100, 200] if vibration_enabled else [],
+        "sound": "default",
         "renotify": True,
     }
 
@@ -2364,13 +2282,16 @@ def send_pwa_push_notification(company_id: int, *, user_ids, title: str, body: s
             "url": link,
             "tag": tag,
             "renotify": True,
-            "requireInteraction": False,
+            "requireInteraction": event_type in {"incoming_sms", "missed_call", "voicemail"},
             "eventType": decision["event_type"],
             "icon": "/static/icons/icon-192.png",
             "badge": "/static/icons/badge-72.png",
             "sound": decision["sound"],
             "silent": bool(decision["silent"]),
             "vibrate": decision["vibrate"],
+            "channel_id": "high_priority_messages",
+            "channelId": "high_priority_messages",
+            "importance": "high",
             "data": {
                 "company_id": company_id,
                 "phone_number_id": phone_number_id,
@@ -2378,6 +2299,9 @@ def send_pwa_push_notification(company_id: int, *, user_ids, title: str, body: s
                 "silent": bool(decision["silent"]),
                 "debug_reason": decision["reason"],
                 "badgeCount": badge_count,
+                "channel_id": "high_priority_messages",
+                "channelId": "high_priority_messages",
+                "importance": "high",
             },
             "badgeCount": badge_count,
         }
@@ -2386,7 +2310,9 @@ def send_pwa_push_notification(company_id: int, *, user_ids, title: str, body: s
             "user_id": user.id, "company_id": company_id, "phone_number_id": phone_number_id,
             "event_type": decision["event_type"], "silent": payload["silent"], "sound": payload["sound"],
             "vibrate": payload["vibrate"], "renotify": payload["renotify"], "tag": payload["tag"],
-            "badgeCount": badge_count, "push_provider_result": result,
+            "badgeCount": badge_count, "channel": payload["channelId"], "importance": payload["importance"],
+            "sw_version": os.environ.get("LUXIT_ASSET_VERSION") or os.environ.get("GIT_SHA") or os.environ.get("RENDER_GIT_COMMIT") or "20260705-push-sound-forwarding-bh-autoreply",
+            "push_provider_result": result,
         })
         total += result.get("sent", 0)
         errors.extend(result.get("errors", []))
@@ -2423,7 +2349,7 @@ def pwa_push_debug():
         "notification_permission": "client-reported",
         "active_subscription": active_subscriptions > 0,
         "active_subscriptions": active_subscriptions,
-        "service_worker_version": os.environ.get("LUXIT_ASSET_VERSION") or os.environ.get("GIT_SHA") or os.environ.get("RENDER_GIT_COMMIT") or "20260702-push-sound-diagnostics",
+        "service_worker_version": os.environ.get("LUXIT_ASSET_VERSION") or os.environ.get("GIT_SHA") or os.environ.get("RENDER_GIT_COMMIT") or "20260705-push-sound-forwarding-bh-autoreply",
         "decision": decision,
         "device_instructions": [
             "Android: Chrome/LUXit PWA notification channel cannot be Silent or Low Importance.",

--- a/migrations/20260705_pwa_sound_forwarding_autoreply.sql
+++ b/migrations/20260705_pwa_sound_forwarding_autoreply.sql
@@ -1,0 +1,18 @@
+-- LUXit PWA sound diagnostics, per-line call forwarding, and business-hours SMS auto reply.
+-- Safe additive migration for existing production databases.
+
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS call_forwarding_enabled BOOLEAN DEFAULT FALSE;
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS call_forwarding_number VARCHAR(20);
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS business_hours_auto_reply_enabled BOOLEAN DEFAULT FALSE;
+ALTER TABLE twilio_phone_number ADD COLUMN IF NOT EXISTS business_hours_auto_reply_text TEXT;
+
+ALTER TABLE twilio_call_log ADD COLUMN IF NOT EXISTS forwarded BOOLEAN DEFAULT FALSE;
+ALTER TABLE twilio_call_log ADD COLUMN IF NOT EXISTS forwarded_to VARCHAR(20);
+ALTER TABLE twilio_call_log ADD COLUMN IF NOT EXISTS final_status VARCHAR(50);
+ALTER TABLE twilio_call_log ADD COLUMN IF NOT EXISTS contact_id INTEGER;
+ALTER TABLE twilio_call_log ADD COLUMN IF NOT EXISTS duration INTEGER DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS ix_twilio_phone_number_company_active
+    ON twilio_phone_number (company_id, is_active);
+CREATE INDEX IF NOT EXISTS ix_twilio_call_log_company_phone_status
+    ON twilio_call_log (company_id, phone_number_id, status);

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,5 +1,5 @@
 /* LUXit Inbox — Service Worker */
-const SW_VERSION = new URL(self.location.href).searchParams.get('v') || '20260702-pwa-sms-send-fix';
+const SW_VERSION = new URL(self.location.href).searchParams.get('v') || '20260705-push-sound-forwarding-bh-autoreply';
 const CACHE = `luxit-inbox-${SW_VERSION}`;
 const APP_SHELL = [
   '/app/inbox',
@@ -39,6 +39,8 @@ async function storePushDebug(payload, options) {
     lastNotificationTag: options.tag || '',
     lastNotificationRenotify: options.renotify === true,
     lastNotificationVibrate: options.vibrate || [],
+    lastNotificationChannelId: options.channel_id || options.channelId || '',
+    lastNotificationImportance: options.importance || '',
     badgeCount: payload.badgeCount ?? (payload.data && payload.data.badgeCount) ?? null,
   };
   const clientsList = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
@@ -85,11 +87,14 @@ self.addEventListener('push', e => {
     tag:     data.tag || `luxit-${data.eventType || (data.data && data.data.event_type) || 'notification'}`,
     data:    Object.assign({ url: data.url || '/app/inbox' }, data.data || {}),
     renotify: data.renotify !== false,
-    requireInteraction: data.requireInteraction === true,
-    vibrate: data.silent === true ? [] : (data.vibrate || [200, 100, 200]),
-    silent:  data.silent === true,
+    requireInteraction: data.requireInteraction !== false,
+    vibrate: [200, 100, 200],
+    silent:  false,
     // Android Chrome/PWA uses the app/channel default sound when silent is false.
     sound:   data.sound || 'default',
+    channel_id: 'high_priority_messages',
+    channelId: 'high_priority_messages',
+    importance: data.importance || 'high',
     actions: [{ action: 'open', title: 'Open Inbox' }],
   };
   if (notificationOptions.renotify && !notificationOptions.tag) {

--- a/tests/test_pwa_communications_completion.py
+++ b/tests/test_pwa_communications_completion.py
@@ -342,9 +342,9 @@ def test_service_worker_and_in_app_alerts_honor_silent_sound_vibration_flags():
     assert "vibrateIfEnabled([80, 40, 80])" in index
     assert "playSound('sms-'" in index
     assert "navigator.setAppBadge" in index and "navigator.clearAppBadge" in index
-    assert "silent:  data.silent === true" in sw
+    assert "silent:  false" in sw
     assert "renotify: data.renotify !== false" in sw
-    assert "vibrate: data.silent === true ? [] : (data.vibrate || [200, 100, 200])" in sw
+    assert "vibrate: [200, 100, 200]" in sw
 
 
 def test_call_missed_voicemail_and_reminder_notifications_emit_push_and_sse(pwa_app, monkeypatch):
@@ -431,7 +431,8 @@ def test_push_payload_non_silent_vibration_badge_and_quiet_hours(pwa_app, monkey
         user.pwa_quiet_hours_end = "23:59"
         db.session.commit()
         inbox_pwa.send_pwa_push_notification(ids["company"], user_ids=[ids["staff"]], title="Quiet", body="Body", event_type="voicemail", phone_number_id=ids["line"])
-        assert payloads[-1]["silent"] is True
+        assert payloads[-1]["silent"] is False
+        assert payloads[-1]["data"]["debug_reason"] == "quiet_hours"
 
 
 def test_push_debug_uses_logged_in_pwa_user_session(pwa_app):
@@ -474,3 +475,26 @@ def test_push_debug_returns_clear_auth_and_permission_responses(pwa_app):
     forbidden = client.get("/api/pwa/push/debug")
     assert forbidden.status_code == 403
     assert forbidden.get_json()["error"] == "Mobile inbox access is not enabled for this account."
+
+
+def test_pwa_sound_forwarding_autoreply_static_requirements():
+    sw = open("static/sw.js", encoding="utf-8").read()
+    html = open("templates/inbox_pwa/index.html", encoding="utf-8").read()
+    nav = open("templates/inbox_pwa/_bottom_nav.html", encoding="utf-8").read()
+    migration = open("migrations/20260705_pwa_sound_forwarding_autoreply.sql", encoding="utf-8").read()
+    assert "20260705-push-sound-forwarding-bh-autoreply" in sw
+    assert "silent:  false" in sw
+    assert "renotify: data.renotify !== false" in sw
+    assert "[200, 100, 200]" in sw
+    assert "high_priority_messages" in sw and "channel_id" in sw and "importance" in sw
+    assert "requireInteraction: data.requireInteraction !== false" in sw
+    assert "PUSH_DIAGNOSTICS" in sw and "lastNotificationSilent" in sw
+    assert "Call Forwarding" in html and "Business-hours SMS auto reply" in html
+    assert "Push Diagnostics" in html and "lastNotificationSilent" in html
+    assert "installPwaNavPerformanceHandlers" in html
+    assert "pwa-tab-loading" in nav
+    assert "env(safe-area-inset-bottom)" in nav
+    assert "visualViewport" in html
+    assert "call_forwarding_enabled" in migration
+    assert "business_hours_auto_reply_enabled" in migration
+    assert "final_status" in migration

--- a/tests/test_pwa_phone_system.py
+++ b/tests/test_pwa_phone_system.py
@@ -1181,3 +1181,47 @@ def test_pwa_device_approval_disabled_allows_registered_device(client, app, worl
     assert reg.get_json()["device"]["approved_status"] == "approved"
     ok = client.get("/api/inbox/conversations", headers={"X-PWA-Device-Key": "auto-approved-device"})
     assert ok.status_code == 200
+
+
+def test_resolve_sms_sender_and_send_sms_use_inbound_to_number_not_messaging_service(app, world, monkeypatch):
+    import twilio_sms
+    monkeypatch.setattr("services.license_service.has_feature", lambda *a, **k: True)
+    with app.app_context():
+        ta = TwilioAccount.query.filter_by(company_id=world["co_a"]).first()
+        ta.messaging_service_sid = "MG_should_not_be_used_for_replies"
+        pn = add_phone_number(world["co_a"], "+15550009991")
+        conv = TwilioConversation(
+            company_id=world["co_a"],
+            phone_number_id=pn.id,
+            from_number="+15551119991",
+            to_number="+15550009991",
+        )
+        db.session.add(conv)
+        db.session.commit()
+        result = twilio_sms.sendConversationSms(conv.id, "Reply from same line", twilio_account=ta, is_auto_reply=True)
+        assert result["success"] is True
+        outbound = TwilioMessage.query.filter_by(conversation_id=conv.id, direction="outbound").one()
+        assert twilio_sms.resolve_sms_sender(conv) == "+15550009991"
+        assert outbound.from_number == "+15550009991"
+        assert outbound.from_number != ta.messaging_service_sid
+
+
+def test_send_sms_blocks_cross_number_sender_leakage(app, world, monkeypatch):
+    import twilio_sms
+    monkeypatch.setattr("services.license_service.has_feature", lambda *a, **k: True)
+    with app.app_context():
+        ta = TwilioAccount.query.filter_by(company_id=world["co_a"]).first()
+        line_a = add_phone_number(world["co_a"], "+15550009992")
+        add_phone_number(world["co_a"], "+15550009993")
+        conv = TwilioConversation(
+            company_id=world["co_a"],
+            phone_number_id=line_a.id,
+            from_number="+15551119992",
+            to_number="+15550009993",
+        )
+        db.session.add(conv)
+        db.session.commit()
+        result = twilio_sms.sendConversationSms(conv.id, "Wrong-line reply", twilio_account=ta, is_auto_reply=True)
+        assert result["success"] is False
+        assert "does not match" in result["error"]
+        assert TwilioMessage.query.filter_by(conversation_id=conv.id, direction="outbound").count() == 0

--- a/twilio_sms.py
+++ b/twilio_sms.py
@@ -140,6 +140,8 @@ class _NumberScopedTwilioConfig:
         "business_hours_auto_reply_enabled",
         "business_hours_auto_reply_text",
         "call_forward_to",
+        "call_forwarding_enabled",
+        "call_forwarding_number",
         "voice_forwarding_enabled",
         "voicemail_greeting_text",
         "voicemail_greeting_audio_url",
@@ -610,12 +612,37 @@ def _get_or_create_conversation(
     return conv
 
 
-def _send_sms(ta, to_number: str, body: str,
-              conversation_id: int = None, is_auto_reply: bool = False,
-              rule_id: int = None) -> dict:
-    """Send an outbound SMS and persist the TwilioMessage record."""
-    from models import TwilioMessage
+def resolve_sms_sender(inbound_message) -> str:
+    """Canonical conversational SMS sender resolver.
+
+    For every reply/forward/auto-reply associated with an inbound message, the
+    sender must be the business line that received that inbound message:
+    ``sender = inbound_message.to_number``.
+    """
+    if isinstance(inbound_message, dict):
+        return (inbound_message.get("to_number") or inbound_message.get("To") or "").strip()
+    return (getattr(inbound_message, "to_number", None) or getattr(inbound_message, "To", None) or "").strip()
+
+
+def sendConversationSms(conversation_id: int, message: str, *,
+                        to_number: str = None, twilio_account=None,
+                        is_auto_reply: bool = False, rule_id: int = None) -> dict:
+    """Single entry point for all conversational SMS sends.
+
+    Every outbound reply/forward/auto-reply resolves its sender from the
+    inbound conversation via ``resolve_sms_sender(conversation)``. No caller is
+    allowed to provide a parallel sender override, MessagingServiceSid, or
+    fallback sender pool.
+    """
+    from models import TwilioMessage, TwilioConversation, TwilioPhoneNumber
     from flask import current_app
+    conv = db.session.get(TwilioConversation, conversation_id) if conversation_id else None
+    if not conv:
+        return {"success": False, "error": "Conversation is required for SMS send."}
+    ta = twilio_account or _get_twilio_account(conv.company_id)
+    if not ta:
+        return {"success": False, "error": "Twilio account is not configured for this conversation."}
+    to_number = to_number or conv.from_number
     try:
         from services.license_service import PHONE_PWA_FEATURE, has_feature
         if getattr(ta, "company_id", None) and not has_feature(ta.company_id, PHONE_PWA_FEATURE):
@@ -627,39 +654,41 @@ def _send_sms(ta, to_number: str, body: str,
     client = _build_client(ta)
     if not client:
         return {"success": False, "error": "Twilio client could not be created."}
-    body = _sanitize_body(body)
+    body = _sanitize_body(message)
     try:
+        canonical_sender = resolve_sms_sender(conv)
+        if not canonical_sender:
+            return {"success": False, "error": "No inbound phone line is available for this SMS reply."}
+        pn = TwilioPhoneNumber.query.filter_by(company_id=ta.company_id, phone_number=canonical_sender, is_active=True).first()
+        if not pn:
+            return {"success": False, "error": "Sender phone line is not active for this company."}
+        if conv and pn.id != conv.phone_number_id and conv.phone_number_id is not None:
+            return {"success": False, "error": "Sender phone line does not match the conversation."}
         kwargs = {
             "body": body,
             "to":   to_number,
+            "from_": canonical_sender,
         }
-        if ta.messaging_service_sid:
-            kwargs["messaging_service_sid"] = ta.messaging_service_sid
-        elif ta.from_phone:
-            kwargs["from_"] = ta.from_phone
-        else:
-            return {"success": False, "error": "No From number or Messaging Service SID configured."}
 
         if current_app.config.get("TESTING"):
             msg = type("TwilioTestMessage", (), {"sid": f"SMTEST{int(datetime.utcnow().timestamp())}", "status": "sent"})()
         else:
             msg = client.messages.create(**kwargs)
 
-        if conversation_id:
-            record = TwilioMessage(
-                conversation_id=conversation_id,
-                company_id=ta.company_id,
-                twilio_sid=msg.sid,
-                direction="outbound",
-                from_number=ta.from_phone or ta.messaging_service_sid,
-                to_number=to_number,
-                body=body,
-                status=msg.status,
-                is_auto_reply=is_auto_reply,
-                rule_id=rule_id,
-            )
-            db.session.add(record)
-            db.session.commit()
+        record = TwilioMessage(
+            conversation_id=conversation_id,
+            company_id=ta.company_id,
+            twilio_sid=msg.sid,
+            direction="outbound",
+            from_number=canonical_sender,
+            to_number=to_number,
+            body=body,
+            status=msg.status,
+            is_auto_reply=is_auto_reply,
+            rule_id=rule_id,
+        )
+        db.session.add(record)
+        db.session.commit()
         logger.info("Outbound SMS sent: sid=%s to=%s", msg.sid, to_number)
         try:
             from services.posthog_client import track_event
@@ -811,7 +840,7 @@ def _send_number_configured_auto_reply(conv, ta, *, in_business=None) -> bool:
     if recent:
         logger.info("[auto-reply company=%s conv=%s] configured number auto reply skipped due to cooldown", ta.company_id, conv.id)
         return False
-    result = _send_sms(ta, conv.from_number, response_body, conversation_id=conv.id, is_auto_reply=True)
+    result = sendConversationSms(conv.id, response_body, twilio_account=ta, is_auto_reply=True)
     logger.info("[auto-reply company=%s conv=%s] configured number auto reply sent success=%s", ta.company_id, conv.id, result.get("success"))
     return bool(result.get("success"))
 
@@ -959,8 +988,7 @@ def _apply_auto_reply_rules(conv, body: str, ta) -> bool:
         if rule.action == "opt_out" or rule.trigger_type == "stop_keyword":
             conv.is_opted_out = True
             if rule.response:
-                result = _send_sms(ta, conv.from_number, rule.response,
-                                   conversation_id=conv.id, is_auto_reply=True, rule_id=rule.id)
+                result = sendConversationSms(conv.id, rule.response, twilio_account=ta, is_auto_reply=True, rule_id=rule.id)
                 logger.info("%s opt-out reply sent: success=%s", _tag, result.get("success"))
             rule.match_count = (rule.match_count or 0) + 1
             db.session.commit()
@@ -974,8 +1002,7 @@ def _apply_auto_reply_rules(conv, body: str, ta) -> bool:
             rule.match_count = (rule.match_count or 0) + 1
             db.session.commit()
             if rule.response and not reply_sent:
-                result = _send_sms(ta, conv.from_number, rule.response,
-                                   conversation_id=conv.id, is_auto_reply=True, rule_id=rule.id)
+                result = sendConversationSms(conv.id, rule.response, twilio_account=ta, is_auto_reply=True, rule_id=rule.id)
                 reply_sent = result.get("success", False)
                 logger.info("%s tag rule reply: success=%s err=%s", _tag, result.get("success"), result.get("error"))
             # Continue — after_hours must still have a chance to fire
@@ -987,8 +1014,7 @@ def _apply_auto_reply_rules(conv, body: str, ta) -> bool:
             if reply_sent:
                 logger.debug("%s rule id=%s skipped — reply already sent", _tag, rule.id)
                 continue
-            result = _send_sms(ta, conv.from_number, response_body,
-                               conversation_id=conv.id, is_auto_reply=True, rule_id=rule.id)
+            result = sendConversationSms(conv.id, response_body, twilio_account=ta, is_auto_reply=True, rule_id=rule.id)
             rule.match_count = (rule.match_count or 0) + 1
             db.session.commit()
             reply_sent = result.get("success", False)
@@ -1173,20 +1199,19 @@ def inbound_sms():
             if not target_number.startswith("+"):
                 target_number = "+" + target_number
             relay_body = relay_match.group(2).strip()
+            admin_conv = _get_or_create_conversation(ta.company_id, ta.sms_forward_to, to_number, getattr(pn, "id", None))
             if not relay_body:
                 logger.warning("Owner relay: empty message body to %s — ignored", target_number)
-                _send_sms(ta, ta.sms_forward_to,
-                          f"[{company_name}] Reply not sent — message was empty.")
+                sendConversationSms(admin_conv.id, f"[{company_name}] Reply not sent — message was empty.", twilio_account=ta)
                 return '<Response></Response>', 200, {"Content-Type": "text/xml"}
             target_conv = _get_or_create_conversation(ta.company_id, target_number, to_number)
-            result = _send_sms(ta, target_number, relay_body, conversation_id=target_conv.id)
+            result = sendConversationSms(target_conv.id, relay_body, twilio_account=ta, to_number=target_number)
             logger.info(
                 "Owner relay: %s → %s (success=%s err=%s)",
                 from_number, target_number, result.get("success"), result.get("error")
             )
             if not result.get("success"):
-                _send_sms(ta, ta.sms_forward_to,
-                          f"[{company_name}] Failed to send to {target_number}: {result.get('error')}")
+                sendConversationSms(admin_conv.id, f"[{company_name}] Failed to send to {target_number}: {result.get('error')}", twilio_account=ta)
             return '<Response></Response>', 200, {"Content-Type": "text/xml"}
 
         # r <message> — reply to the most recent customer conversation
@@ -1203,19 +1228,18 @@ def inbound_sms():
                 .first()
             )
             if last_conv:
-                result = _send_sms(ta, last_conv.from_number, relay_body,
-                                   conversation_id=last_conv.id)
+                result = sendConversationSms(last_conv.id, relay_body, twilio_account=ta)
                 logger.info(
                     "Owner 'r' relay → %s (success=%s err=%s)",
                     last_conv.from_number, result.get("success"), result.get("error"),
                 )
                 if not result.get("success"):
-                    _send_sms(ta, ta.sms_forward_to,
-                              f"[{company_name}] Failed to reply to {last_conv.from_number}: {result.get('error')}")
+                    admin_conv = _get_or_create_conversation(ta.company_id, ta.sms_forward_to, to_number, getattr(pn, "id", None))
+                    sendConversationSms(admin_conv.id, f"[{company_name}] Failed to reply to {last_conv.from_number}: {result.get('error')}", twilio_account=ta)
             else:
                 logger.warning("Owner 'r' relay: no recent conversation found")
-                _send_sms(ta, ta.sms_forward_to,
-                          f"[{company_name}] No recent customer conversation found to reply to.")
+                admin_conv = _get_or_create_conversation(ta.company_id, ta.sms_forward_to, to_number, getattr(pn, "id", None))
+                sendConversationSms(admin_conv.id, f"[{company_name}] No recent customer conversation found to reply to.", twilio_account=ta)
             return '<Response></Response>', 200, {"Content-Type": "text/xml"}
 
         # Unrecognised command — send help back to admin
@@ -1231,7 +1255,8 @@ def inbound_sms():
             f"r +1XXXXXXXXXX your message\n"
             f"  → Shorthand reply to specific customer"
         )
-        _send_sms(ta, ta.sms_forward_to, help_msg)
+        admin_conv = _get_or_create_conversation(ta.company_id, ta.sms_forward_to, to_number, getattr(pn, "id", None))
+        sendConversationSms(admin_conv.id, help_msg, twilio_account=ta)
         return '<Response></Response>', 200, {"Content-Type": "text/xml"}
 
     try:
@@ -1327,7 +1352,7 @@ def inbound_sms():
                     f"Reply using:\n"
                     f"reply {from_number} your message"
                 )
-                _send_sms(ta, ta.sms_forward_to, fwd_body, conversation_id=conv.id)
+                sendConversationSms(conv.id, fwd_body, twilio_account=ta, to_number=ta.sms_forward_to)
                 logger.info(
                     "SMS forwarded: customer=%s → admin=%s company=%s",
                     from_number, ta.sms_forward_to, company_name,
@@ -1344,13 +1369,7 @@ def inbound_sms():
             attribute_inbound_reply(ta.company_id, from_number, body, conv.id)
             campaign_reply = process_keyword_rules(ta.company_id, body, conv, ta)
             if campaign_reply:
-                _send_sms(
-                    ta,
-                    from_number,
-                    campaign_reply,
-                    conversation_id=conv.id,
-                    is_auto_reply=True,
-                )
+                sendConversationSms(conv.id, campaign_reply, twilio_account=ta, is_auto_reply=True)
         except Exception as campaign_rule_exc:
             logger.exception("Error in campaign SMS keyword engine: %s", campaign_rule_exc)
 
@@ -1641,7 +1660,8 @@ def _inbound_call_impl():
         try:
             can_send, reason = _can_send_call_auto_sms(ta.company_id, from_number)
             if can_send:
-                result = _send_sms(ta, from_number, after_hours_sms_body)
+                sms_conv = _get_or_create_conversation(ta.company_id, from_number, to_number, getattr(pn, "id", None))
+                result = sendConversationSms(sms_conv.id, after_hours_sms_body, twilio_account=ta, is_auto_reply=True)
                 if result.get("success"):
                     log.missed_text_sent = True
                     db.session.commit()
@@ -1655,7 +1675,8 @@ def _inbound_call_impl():
         try:
             can_send, reason = _can_send_call_auto_sms(ta.company_id, from_number)
             if can_send:
-                result = _send_sms(ta, from_number, ta.business_hours_auto_reply_text)
+                sms_conv = _get_or_create_conversation(ta.company_id, from_number, to_number, getattr(pn, "id", None))
+                result = sendConversationSms(sms_conv.id, ta.business_hours_auto_reply_text, twilio_account=ta, is_auto_reply=True)
                 if result.get("success"):
                     log.missed_text_sent = True
                     db.session.commit()
@@ -1730,7 +1751,11 @@ def _inbound_call_impl():
             f"</Response>"
         )
 
-    if in_hours and (route in (None, "ring_pwa")):
+    if configured_call_forward_to and (ta.voice_forwarding_enabled or getattr(ta, "call_forwarding_enabled", False)):
+        # Explicit per-line call forwarding wins over browser ringing. This
+        # applies only to voice webhooks; SMS routing never reads these fields.
+        twiml = _dial_twiml(configured_call_forward_to)
+    elif in_hours and (route in (None, "ring_pwa")):
         if log:
             log.status = "ringing"
             db.session.commit()
@@ -1777,13 +1802,8 @@ def _inbound_call_impl():
         twiml = _dial_twiml(forward_to, fallback_to)
     elif route == "voicemail":
         twiml = _voicemail_twiml(after_hours=not in_hours)
-    elif in_hours and (ta.voice_forwarding_enabled or getattr(ta, "call_forwarding_enabled", False)) and configured_call_forward_to:
-        twiml = _dial_twiml(configured_call_forward_to)
     elif not in_hours and ta.after_hours_voicemail_enabled:
         twiml = _voicemail_twiml(after_hours=True)
-    elif configured_call_forward_to and (ta.voice_forwarding_enabled or getattr(ta, "call_forwarding_enabled", False)):
-        # Always forward regardless of hours when explicitly configured
-        twiml = _dial_twiml(configured_call_forward_to)
     else:
         twiml = _voicemail_twiml()
 
@@ -1846,7 +1866,8 @@ def voice_no_answer():
     if ta and sms_body and from_number:
         can_send, reason = _can_send_call_auto_sms(ta.company_id, from_number)
         if can_send:
-            result = _send_sms(ta, from_number, sms_body)
+            sms_conv = _get_or_create_conversation(ta.company_id, from_number, to_number, getattr(pn, "id", None))
+            result = sendConversationSms(sms_conv.id, sms_body, twilio_account=ta, is_auto_reply=True)
             if result.get("success"):
                 log = TwilioCallLog.query.filter_by(twilio_sid=call_sid).first()
                 if log and not log.missed_text_sent:
@@ -2500,7 +2521,7 @@ def send_message():
     if not conv:
         conv = _get_or_create_conversation(company.id, to_number, ta.from_phone or "")
 
-    result = _send_sms(ta, to_number, body, conversation_id=conv.id)
+    result = sendConversationSms(conv.id, body, twilio_account=ta, to_number=to_number)
     if result.get("success"):
         conv.last_message_at      = datetime.utcnow()
         conv.last_message_preview = f"You: {body[:150]}"


### PR DESCRIPTION
### Motivation
- Add push sound/vibration diagnostics and Android channel metadata, per-line call forwarding, and business-hours SMS auto-reply support for the PWA inbox.
- Prevent accidental sender leakage from MessagingService SIDs and unify all conversational SMS sending behind a single safe entrypoint.
- Surface richer debug diagnostics in the service worker and server-side push debug endpoint so device behavior can be diagnosed reliably.

### Description
- Introduce `sendConversationSms` and `resolve_sms_sender` in `twilio_sms.py` and rewire all outbound SMS paths (`inbox_pwa.py`, Twilio webhooks, auto-reply flows, owner relay paths, and legacy send endpoints) to use this centralized API which enforces that the outbound `from_number` matches the inbound conversation's receiving line.
- Remove/replace legacy internal send helpers in `inbox_pwa.py` and replace queue retry logic to call `twilio_sms.sendConversationSms` and persist status/error info accordingly.
- Add per-phone-number columns and call-log fields via a safe additive SQL migration `migrations/20260705_pwa_sound_forwarding_autoreply.sql` to support `call_forwarding_enabled`, `call_forwarding_number`, `business_hours_auto_reply_*`, forwarded flags, `final_status`, `contact_id`, and `duration`, plus helpful indexes.
- Update voice routing to prefer explicit per-line call forwarding when configured and add fields/logic so voice and SMS auto-replies create conversations and send replies via `sendConversationSms`.
- Change PWA push semantics and diagnostics: bump SW/service-worker version to `20260705-push-sound-forwarding-bh-autoreply`, add `channel_id`/`channelId`/`importance` metadata and make notifications non-silent by default while adding server-side locking/override for silent behavior via `LUXIT_ALLOW_SILENT_PUSH`; enhance `_push_debug_decision` to report `would_silence_without_lock` and `silent_override_locked`.
- Update `static/sw.js` to surface push diagnostics (including channel and importance) to clients and to store the last push debug state in the cache for retrieval.
- Add/adjust unit tests to validate the new SW strings, push payload flags, and SMS sender resolution and cross-number sender protections.

### Testing
- Ran the updated PWA unit tests and phone-system tests with `pytest tests/test_pwa_communications_completion.py tests/test_pwa_phone_system.py`, which exercise push payload generation, service-worker static expectations, SMS send paths, and sender-matching protections, and they passed locally.
- Existing inbox and webhook flows exercised by the modified tests (push debug, auto-reply, owner relay, and send endpoints) all returned expected success/failure cases in the automated suite.
- Migration file `migrations/20260705_pwa_sound_forwarding_autoreply.sql` was added and validated by file presence checks in tests but not executed against production in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4ad6327a788322ad0daa588bb8faf3)