### PR TITLE
Fix iOS PWA keyboard viewport behavior

### DIFF
--- a/templates/inbox_pwa/_bottom_nav.html
+++ b/templates/inbox_pwa/_bottom_nav.html
@@ -62,7 +62,8 @@
     animation: pwa-tab-progress .8s ease-in-out infinite alternate;
   }
   @keyframes pwa-tab-progress { from { transform: translateX(0); } to { transform: translateX(165%); } }
-  body.has-pwa-bottom-nav #shell { bottom: calc(68px + env(safe-area-inset-bottom)); height: auto; }
+  body.has-pwa-bottom-nav:not(.pwa-keyboard-open) #shell { height: calc(var(--vvh, 100dvh) - 68px - env(safe-area-inset-bottom)); }
+  body.has-pwa-bottom-nav.pwa-keyboard-open #shell { height: var(--vvh, 100dvh); }
   body.has-pwa-bottom-nav .shell { padding-bottom: calc(96px + env(safe-area-inset-bottom)); }
   .pwa-safe-top-control { min-width: 44px; min-height: 44px; padding: 8px; }
 </style>

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -87,14 +87,18 @@
     /* ── Shell ──────────────────────────────────────── */
     #shell {
       display: flex;
-      height: 100dvh;
-      height: -webkit-fill-available; /* iOS Safari */
+      height: var(--vvh, 100dvh);
+      min-height: 0;
       padding-top: var(--safe-top);
       padding-bottom: var(--safe-bot);
       position: fixed;
-      top: 0; left: 0; right: 0; bottom: 0;
+      top: 0; left: 0; right: 0;
       width: 100%;
       overflow: hidden;
+      transform: translateY(var(--vv-offset-top, 0px));
+    }
+    @supports not (height: 100dvh) {
+      #shell { height: var(--vvh, -webkit-fill-available); }
     }
 
     /* ── Sidebar ────────────────────────────────────── */
@@ -299,11 +303,11 @@
 
     /* Composer */
     .composer {
-      padding: 10px 12px calc(10px + var(--safe-bot) + var(--keyboard-offset, 0px)); border-top: 1px solid var(--border);
+      padding: 10px 12px calc(10px + var(--safe-bot)); border-top: 1px solid var(--border);
       background: var(--surface); flex-shrink: 0;
       display: flex; gap: 8px; align-items: flex-end;
-      /* always anchored at the bottom of the visible area */
       position: sticky; bottom: 0; z-index: 20;
+      will-change: transform;
     }
     .composer-wrap { flex: 1; position: relative; }
     #msgInput {
@@ -324,7 +328,9 @@
     }
     #sendBtn:hover { background: #6d28d9; }
     #sendBtn:disabled { background: var(--muted); cursor: not-allowed; }
-    body.pwa-keyboard-open .pwa-bottom-nav { transform: translateY(110%); pointer-events: none; }
+    body.pwa-keyboard-open .pwa-bottom-nav { transform: translateY(calc(110% + var(--safe-bot))); opacity: 0; pointer-events: none; visibility: hidden; }
+    body.pwa-keyboard-open { overflow: hidden; touch-action: none; }
+    body.pwa-keyboard-open #messages, body.pwa-keyboard-open #msgInput { touch-action: pan-y; }
     #optOutBanner {
       display: none; padding: 8px 16px; text-align: center;
       background: rgba(239,68,68,.1); border-top: 1px solid rgba(239,68,68,.3);
@@ -561,8 +567,8 @@
       #sidebar { width: 100%; max-width: 100%; border-right: none; min-width: 0; }
       #main { display: none; width: 100%; }
       #shell.thread-open #sidebar { display: none; }
-      #shell.thread-open #main  { display: flex; flex: 1; min-width: 0; overflow: hidden; }
-      #shell.thread-open #thread { display: flex !important; flex: 1; min-height: 0; }
+      #shell.thread-open #main  { display: flex; flex: 1; min-width: 0; min-height: 0; overflow: hidden; }
+      #shell.thread-open #thread { display: flex !important; flex: 1 1 0; min-height: 0; height: 100%; }
       .btn-back { display: flex; }
     }
     @media (min-width: 641px) { #thread { display: flex !important; } }
@@ -1595,25 +1601,46 @@ function updateUnreadBadge(count) {
   el.classList.toggle('show', count > 0);
 }
 
-/* ── Keyboard resize (Android Chrome visual viewport fix) ─────── */
+/* ── Keyboard / visual viewport resize (iOS Safari + installed PWA) ─────── */
 function setupKeyboardResize() {
-  const shell = document.getElementById('shell');
-  function applyHeight() {
+  const root = document.documentElement;
+  let lastKeyboardOpen = false;
+
+  function isTextComposerFocused() {
+    return document.activeElement && document.activeElement.id === 'msgInput';
+  }
+
+  function applyViewport() {
     const vv = window.visualViewport;
-    const h = vv ? vv.height : window.innerHeight;
+    const viewportHeight = vv ? vv.height : window.innerHeight;
+    const offsetTop = vv ? vv.offsetTop : 0;
     const keyboardOffset = vv ? Math.max(0, window.innerHeight - vv.height - vv.offsetTop) : 0;
-    shell.style.height = h + 'px';
-    document.documentElement.style.setProperty('--keyboard-offset', keyboardOffset + 'px');
-    document.body.classList.toggle('pwa-keyboard-open', keyboardOffset > 80);
-    // Scroll messages to bottom when keyboard closes/opens
-    if (state.activeConvId) scrollThreadToBottom();
+    const keyboardOpen = keyboardOffset > 80 || (isTextComposerFocused() && window.innerHeight - viewportHeight > 80);
+
+    root.style.setProperty('--vvh', viewportHeight + 'px');
+    root.style.setProperty('--vv-offset-top', offsetTop + 'px');
+    root.style.setProperty('--keyboard-offset', keyboardOffset + 'px');
+    document.body.classList.toggle('pwa-keyboard-open', keyboardOpen);
+
+    if (state.activeConvId && keyboardOpen && !lastKeyboardOpen) {
+      requestAnimationFrame(scrollThreadToBottom);
+    }
+    lastKeyboardOpen = keyboardOpen;
   }
+
   if (window.visualViewport) {
-    window.visualViewport.addEventListener('resize',  applyHeight);
-    window.visualViewport.addEventListener('scroll',  applyHeight);
+    window.visualViewport.addEventListener('resize', applyViewport, { passive: true });
+    window.visualViewport.addEventListener('scroll', applyViewport, { passive: true });
   }
-  window.addEventListener('resize', applyHeight);
-  applyHeight();
+  window.addEventListener('resize', applyViewport, { passive: true });
+  document.getElementById('msgInput')?.addEventListener('focus', () => requestAnimationFrame(applyViewport));
+  document.getElementById('msgInput')?.addEventListener('blur', () => setTimeout(applyViewport, 80));
+  document.addEventListener('touchmove', (event) => {
+    if (!document.body.classList.contains('pwa-keyboard-open')) return;
+    if (event.target.closest('#messages') || event.target.closest('#msgInput')) return;
+    event.preventDefault();
+  }, { passive: false });
+  applyViewport();
 }
 
 /* ── Open conversation ────────────────────────────────────────── */

--- a/tests/test_pwa_template_regressions.py
+++ b/tests/test_pwa_template_regressions.py
@@ -26,3 +26,18 @@ def test_desktop_sidebar_shows_communications_hub():
     assert "Mobile Inbox PWA" not in html
     assert "Communications Hub" in html
     assert "comms_hub" in html
+
+
+def test_pwa_keyboard_viewport_contract():
+    html = (ROOT / "templates" / "inbox_pwa" / "index.html").read_text()
+    nav = (ROOT / "templates" / "inbox_pwa" / "_bottom_nav.html").read_text()
+
+    assert "window.visualViewport" in html
+    assert "--vvh" in html
+    assert "100dvh" in html
+    assert "env(safe-area-inset-bottom" in html
+    assert "scrollIntoView" not in html
+    assert "pwa-keyboard-open" in html
+    assert "body.pwa-keyboard-open .pwa-bottom-nav" in html
+    assert "body.has-pwa-bottom-nav.pwa-keyboard-open #shell" in nav
+    assert "body.has-pwa-bottom-nav #shell { bottom:" not in nav


### PR DESCRIPTION
### Motivation

- The PWA mixed fixed/sticky layout, reserved bottom-nav space, and a keyboard padding variable which caused the composer to jump, be pushed away from the keyboard, or be covered when the iOS visual viewport changed.  
- The Visual Viewport handling was insufficient for iOS Safari / installed PWA contexts and it scrolled too aggressively on every viewport event instead of keeping the conversation sized to the visible viewport and only scrolling to the latest message when the keyboard opens.  

### Description

- Use the Visual Viewport API to drive a `--vvh` and `--vv-offset-top` CSS contract and prefer `100dvh` where available so the app shell matches the visible viewport on iOS and desktop (`templates/inbox_pwa/index.html`).  
- Keep the composer visually anchored above the keyboard without adding a keyboard padding hack by removing the keyboard-dependent padding and anchoring the composer via `position: sticky` and `will-change: transform` so it follows viewport translation instead of being pushed (`templates/inbox_pwa/index.html`).  
- Hide/collapse the shared bottom navigation while the keyboard is open and prevent body scrolling during composition; preserve `env(safe-area-inset-bottom)` for safe-area spacing (`templates/inbox_pwa/index.html`, `templates/inbox_pwa/_bottom_nav.html`).  
- Rework VisualViewport listeners to set CSS variables, detect keyboard open state robustly, and only auto-scroll the thread to the latest message when the keyboard transitions open; avoid `scrollIntoView()` for the composer (`templates/inbox_pwa/index.html`).  
- Tweak mobile flex sizing so the conversation and thread panels resize to the visual viewport rather than overflowing (`templates/inbox_pwa/index.html`).  
- Add a regression test that enforces the keyboard/viewport contract (VisualViewport usage, `100dvh`, `env(safe-area-inset-bottom)`, no `scrollIntoView()`, and bottom-nav collapse) (`tests/test_pwa_template_regressions.py`).  
- Files changed: `templates/inbox_pwa/index.html`, `templates/inbox_pwa/_bottom_nav.html`, `tests/test_pwa_template_regressions.py`.

### Testing

- Ran `pytest tests/test_pwa_template_regressions.py -q` and the suite passed (`4 passed`).  
- The new regression test asserts presence of `window.visualViewport`, `--vvh`, `100dvh`, `env(safe-area-inset-bottom)`, absence of `scrollIntoView`, and bottom-nav keyboard-open handling.  
- No automated UI screenshot tests were added; manual verification expectations are described in the PR notes and include: keyboard-closed view with bottom-nav visible, keyboard-open view with bottom-nav hidden and composer directly above keyboard, and stable layout when pressing the iOS keyboard Done button.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4ec0385bd8832295ec76972264c9c7)