### PR TITLE
Fix PWA SMS protected media links

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -26,10 +26,10 @@ import queue as _queue_module
 import re
 import threading
 from datetime import datetime, timezone
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from flask import (Blueprint, Response, abort, current_app, g, jsonify,
-                   render_template, request, session)
+                   render_template, request, session, stream_with_context)
 
 from extensions import db
 
@@ -522,6 +522,29 @@ def _is_archived_conversation(conv):
     return bool(tags.intersection({"archived", "resolved", "closed"}))
 
 
+def _is_twilio_protected_url(url: str) -> bool:
+    """Return True for Twilio-hosted media/recording URLs that require provider auth."""
+    if not url:
+        return False
+    parsed = urlparse(url)
+    host = (parsed.netloc or "").lower()
+    return host == "api.twilio.com" or host.endswith(".twilio.com")
+
+
+def _proxied_message_media_url(message_id: int, index: int) -> str:
+    return f"/api/inbox/messages/{message_id}/media/{index}"
+
+
+def _safe_message_media_urls(m):
+    safe = []
+    for idx, url in enumerate(m.media_urls or []):
+        if _is_twilio_protected_url(url):
+            safe.append(_proxied_message_media_url(m.id, idx))
+        else:
+            safe.append(url)
+    return safe
+
+
 def _msg_to_dict(m):
     return {
         "id":           m.id,
@@ -529,7 +552,7 @@ def _msg_to_dict(m):
         "body":         m.body or "",
         "status":       m.status or "received",
         "is_auto_reply": m.is_auto_reply,
-        "media_urls":   m.media_urls or [],
+        "media_urls":   _safe_message_media_urls(m),
         "created_at":   m.created_at.isoformat() if m.created_at else None,
         "twilio_sid":   m.twilio_sid,
     }
@@ -1636,6 +1659,55 @@ def list_messages():
         .limit(limit)
         .all())
     return jsonify({"success": True, "messages": [_msg_to_dict(m) for m in rows], "total": len(rows)})
+
+
+@inbox_pwa_bp.route("/api/inbox/messages/<int:message_id>/media/<int:media_index>")
+def api_inbox_message_media(message_id, media_index):
+    """Authenticated SMS/MMS media proxy so Twilio credentials stay server-side."""
+    user = _require_auth()
+    company = _require_company(user)
+    denied = _require_pwa_communications_access(user, company)
+    if denied:
+        return denied
+    from models import TwilioConversation, TwilioMessage
+    from services.comms_permissions import filter_conversations_for_user
+
+    msg = (TwilioMessage.query
+        .join(TwilioConversation, TwilioConversation.id == TwilioMessage.conversation_id)
+        .filter(TwilioMessage.id == message_id, TwilioMessage.company_id == company.id)
+        .first_or_404())
+    filter_conversations_for_user(
+        TwilioConversation.query.filter_by(id=msg.conversation_id, company_id=company.id), user, company.id
+    ).first_or_404()
+
+    media_urls = msg.media_urls or []
+    if media_index < 0 or media_index >= len(media_urls):
+        return jsonify({"success": False, "error": "Media attachment not found."}), 404
+    media_url = media_urls[media_index]
+    if not _is_twilio_protected_url(media_url):
+        return jsonify({"success": False, "error": "Only protected provider media is available through this proxy."}), 400
+
+    sid, token = _twilio_recording_auth(company.id)
+    if not sid or not token:
+        return jsonify({"success": False, "error": "Media playback is not configured. Ask an admin to verify Twilio credentials."}), 503
+    try:
+        import requests
+        upstream = requests.get(media_url, auth=(sid, token), timeout=20, stream=True)
+        upstream.raise_for_status()
+    except Exception:
+        logger.exception("Twilio message media proxy failed", extra={"company_id": company.id, "message_id": message_id})
+        return jsonify({"success": False, "error": "Media attachment could not be loaded. Please try again or contact support."}), 502
+
+    filename = quote((urlparse(media_url).path.rstrip('/').split('/')[-1] or f"message-{message_id}-media-{media_index}"))
+    headers = {"Content-Disposition": f"inline; filename*=UTF-8''{filename}"}
+    content_length = upstream.headers.get("Content-Length")
+    if content_length:
+        headers["Content-Length"] = content_length
+    return Response(
+        stream_with_context(upstream.iter_content(chunk_size=64 * 1024)),
+        mimetype=upstream.headers.get("Content-Type", "application/octet-stream"),
+        headers=headers,
+    )
 
 
 # ── API: single conversation + messages ───────────────────────────────────────

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -1732,11 +1732,12 @@ function renderMessages(msgs) {
         if (!url) return;
         const lc = url.toLowerCase().split('?')[0];
         if (/\.(jpg|jpeg|png|gif|webp)$/.test(lc) || url.includes('image')) {
-          mediaHtml += `<img class="msg-img" src="${url}" alt="MMS image" loading="lazy"
-                             onclick="openLightbox('${url.replace(/'/g,"\\'")}')">`;
+          const safeUrl = safeHref(url);
+          mediaHtml += `<img class="msg-img" src="${safeUrl}" alt="MMS image" loading="lazy"
+                             onclick="openLightbox('${jsStringEscape(safeUrl)}')">`;
         } else {
           const name = url.split('/').pop().split('?')[0] || 'Attachment';
-          mediaHtml += `<a class="msg-file-link" href="${url}" target="_blank" rel="noopener">📎 ${esc(name)}</a>`;
+          mediaHtml += `<a class="msg-file-link" href="${safeHref(url)}" target="_blank" rel="noopener noreferrer">📎 ${esc(name)}</a>`;
         }
       });
       mediaHtml += '</div>';
@@ -1744,7 +1745,7 @@ function renderMessages(msgs) {
 
     // If text-only and media present, skip empty text bubble
     const bodyHtml = (m.body || '').trim()
-      ? `<div class="bubble ${dir} ${ar}">${esc(m.body)}</div>`
+      ? `<div class="bubble ${dir} ${ar}">${renderMessageText(m.body)}</div>`
       : '';
 
     html += `<div class="msg-row ${dir}">
@@ -2451,6 +2452,57 @@ function normalizeSmsBody(str) {
     text = lines.map(line => line.trim()).join('');
   }
   return text;
+}
+
+function safeHref(url) {
+  const raw = String(url || '').trim();
+  if (!raw) return '#';
+  if (raw.startsWith('/')) return raw;
+  try {
+    const parsed = new URL(raw, window.location.origin);
+    if (['http:', 'https:', 'mailto:', 'tel:'].includes(parsed.protocol)) return parsed.href;
+  } catch (e) {}
+  return '#';
+}
+
+function jsStringEscape(str) {
+  return String(str || '')
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
+}
+
+function isProtectedProviderUrl(url) {
+  try {
+    const host = new URL(url, window.location.origin).hostname.toLowerCase();
+    return host === 'api.twilio.com' || host.endsWith('.twilio.com');
+  } catch (e) { return false; }
+}
+
+function renderMessageText(text) {
+  const normalized = normalizeSmsBody(text || '');
+  const urlRe = /https?:\/\/[^\s<]+/gi;
+  let out = '';
+  let last = 0;
+  normalized.replace(urlRe, (match, offset) => {
+    out += esc(normalized.slice(last, offset));
+    const trimmed = match.replace(/[),.;!?]+$/, '');
+    const trailing = match.slice(trimmed.length);
+    if (isProtectedProviderUrl(trimmed)) {
+      out += esc(trimmed);
+    } else {
+      const href = safeHref(trimmed);
+      const internal = href.startsWith(window.location.origin + '/') || href.startsWith('/');
+      const title = internal ? 'Open LUXit link with your current signed-in session' : 'External site controls any username or password prompt';
+      out += `<a href="${esc(href)}" target="_blank" rel="noopener noreferrer" title="${esc(title)}">${esc(trimmed)}</a>`;
+    }
+    out += esc(trailing);
+    last = offset + match.length;
+    return match;
+  });
+  out += esc(normalized.slice(last));
+  return out;
 }
 
 function esc(str) {

--- a/tests/test_pwa_phone_system.py
+++ b/tests/test_pwa_phone_system.py
@@ -1225,3 +1225,36 @@ def test_send_sms_blocks_cross_number_sender_leakage(app, world, monkeypatch):
         assert result["success"] is False
         assert "does not match" in result["error"]
         assert TwilioMessage.query.filter_by(conversation_id=conv.id, direction="outbound").count() == 0
+
+
+def test_twilio_message_media_url_is_proxied_in_conversation_payload(client, app, world):
+    login(client, world["alice"])
+    with app.app_context():
+        conv = TwilioConversation(
+            company_id=world["co_a"],
+            from_number="+15551112222",
+            to_number="+15550001000",
+            contact_name="Media Customer",
+            last_message_at=datetime.utcnow(),
+        )
+        db.session.add(conv)
+        db.session.flush()
+        msg = TwilioMessage(
+            conversation_id=conv.id,
+            company_id=world["co_a"],
+            direction="inbound",
+            from_number="+15551112222",
+            to_number="+15550001000",
+            body="photo",
+            media_urls=["https://api.twilio.com/2010-04-01/Accounts/ACtest/Messages/MM123/Media/ME123"],
+            created_at=datetime.utcnow(),
+        )
+        db.session.add(msg)
+        db.session.commit()
+        conv_id = conv.id
+
+    resp = client.get(f"/api/inbox/conversations/{conv_id}")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["messages"][0]["media_urls"] == [f"/api/inbox/messages/{payload['messages'][0]['id']}/media/0"]
+    assert "api.twilio.com" not in payload["messages"][0]["media_urls"][0]

--- a/tests/test_pwa_template_regressions.py
+++ b/tests/test_pwa_template_regressions.py
@@ -41,3 +41,35 @@ def test_pwa_keyboard_viewport_contract():
     assert "body.pwa-keyboard-open .pwa-bottom-nav" in html
     assert "body.has-pwa-bottom-nav.pwa-keyboard-open #shell" in nav
     assert "body.has-pwa-bottom-nav #shell { bottom:" not in nav
+
+
+def test_pwa_external_links_render_safely_with_new_tab_warning():
+    html = (ROOT / "templates" / "inbox_pwa" / "index.html").read_text()
+
+    assert "function renderMessageText" in html
+    assert "target=\"_blank\"" in html
+    assert "rel=\"noopener noreferrer\"" in html
+    assert "External site controls any username or password prompt" in html
+
+
+def test_pwa_twilio_media_urls_are_not_auto_embedded_from_provider():
+    html = (ROOT / "templates" / "inbox_pwa" / "index.html").read_text()
+
+    assert "function isProtectedProviderUrl" in html
+    assert "host === 'api.twilio.com'" in html
+    assert "host.endsWith('.twilio.com')" in html
+
+
+def test_pwa_luxit_internal_links_use_signed_in_session_hint():
+    html = (ROOT / "templates" / "inbox_pwa" / "index.html").read_text()
+
+    assert "Open LUXit link with your current signed-in session" in html
+    assert "window.location.origin" in html
+
+
+def test_frontend_does_not_hard_code_twilio_credentials():
+    html = (ROOT / "templates" / "inbox_pwa" / "index.html").read_text()
+
+    forbidden = ["TWILIO_AUTH_TOKEN", "auth_token", "Account SID", "ACtest", "api.twilio.com/2010"]
+    for value in forbidden:
+        assert value not in html


### PR DESCRIPTION
### Motivation
- Users clicking links or attachments in SMS threads were sometimes shown a browser username/password prompt because raw provider (Twilio) media/recording URLs were exposed to the PWA and could trigger HTTP auth flows.  
- Provider credentials must never be leaked to the frontend, and message rendering must avoid auto-embedding links that cause auth prompts.  
- The PWA message renderer must sanitize and safely open external links in a new tab while preserving LUXit internal-session behavior for internal links.  

### Description
- Added server-side detection for Twilio/provider-hosted URLs via `_is_twilio_protected_url` and a helper `_safe_message_media_urls` to rewrite protected media to proxied paths before sending JSON payloads.  
- Implemented an authenticated proxy endpoint `GET /api/inbox/messages/<message_id>/media/<media_index>` that verifies user/company permissions, fetches Twilio media server-side using `requests` with Twilio credentials, and streams the content back to the client without exposing credentials.  
- Updated message serialization in `_msg_to_dict` to return proxied media URLs for protected provider media instead of raw `api.twilio.com` links.  
- Hardened the PWA frontend message renderer with `safeHref`, `jsStringEscape`, `isProtectedProviderUrl`, and `renderMessageText` to sanitize URLs, avoid auto-embedding protected provider URLs, use `target="_blank" rel="noopener noreferrer"`, and add an explanatory title for external links; image lightbox and attachment anchors now use sanitized/escaped URLs.  
- Added regression tests to ensure safe external link rendering, Twilio media URL proxying in the conversation payload, internal-link session hinting, and that Twilio credentials are not hard-coded in client templates (`tests/test_pwa_template_regressions.py` and `tests/test_pwa_phone_system.py`).  

### Testing
- Verified the server module compiles with `python -m py_compile inbox_pwa.py` and compilation succeeded.  
- Ran targeted tests with `pytest -q tests/test_pwa_template_regressions.py tests/test_pwa_phone_system.py::test_twilio_message_media_url_is_proxied_in_conversation_payload` and all exercised tests passed.  
- Confirmed the new media proxy and client rendering changes in unit tests which asserted proxied media paths replace raw Twilio URLs and that `target="_blank" rel="noopener noreferrer"` and no Twilio secrets are present in PWA templates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4ee59d13808322907838d3e3d1d0f4)