### PR TITLE
Google Contacts reconnect detection and PWA Push repair

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -2471,6 +2471,9 @@ def push_subscribe():
             endpoint=endpoint,
             p256dh=p256dh,
             auth_key=auth_key,
+            user_agent=request.headers.get('User-Agent'),
+            device_label=payload.get('device_label') or payload.get('deviceName') or device_key,
+            is_active=True,
         )
         db.session.add(sub)
     else:
@@ -2491,7 +2494,8 @@ def push_subscribe():
             device.last_seen_at = datetime.utcnow()
     db.session.commit()
     logger.info("Push subscription saved for user %d", user.id)
-    return jsonify({"success": True, "device_key": device_key})
+    active_subscriptions = PushSubscription.query.filter_by(user_id=user.id, company_id=company.id, is_active=True).count()
+    return jsonify({"success": True, "device_key": device_key, "active_subscription": active_subscriptions > 0, "active_subscriptions": active_subscriptions})
 
 
 @inbox_pwa_bp.route("/api/push/unsubscribe", methods=["POST"])
@@ -3058,7 +3062,7 @@ def gc_status():
     user = _require_auth()
     if isinstance(user, tuple):
         return user
-    from services.google_contacts import get_token, is_token_expired
+    from services.google_contacts import get_token, token_needs_reconnect
     tok = get_token(user.id)
     if not tok:
         return jsonify({
@@ -3071,10 +3075,11 @@ def gc_status():
         })
     return jsonify({
         "connected":       True,
-        "oauth_expired":   is_token_expired(tok),
+        "oauth_expired":   token_needs_reconnect(tok),
         "last_sync_at":    tok.last_sync_at.strftime("%b %-d %H:%M") if tok.last_sync_at else None,
         "contacts_synced": tok.contacts_synced or 0,
         "sync_error":      getattr(tok, "sync_error", None),
+        "reconnect_required": token_needs_reconnect(tok),
         "connect_url":     "/twilio/google-contacts/connect",
     })
 

--- a/services/google_contacts.py
+++ b/services/google_contacts.py
@@ -113,6 +113,38 @@ def exchange_code(user_id: int, code: str) -> dict:
     return data
 
 
+def _token_error_requires_reconnect(message: str | None) -> bool:
+    """True when Google says the stored OAuth grant can no longer refresh.
+
+    These errors should not be auto-cleared by retrying sync because the user
+    must grant consent again to issue a new refresh token.
+    """
+    msg = (message or "").lower()
+    return any(marker in msg for marker in (
+        "invalid_grant",
+        "token has been expired or revoked",
+        "token expired",
+        "refresh token",
+        "invalid or revoked",
+        "invalid_token",
+    ))
+
+
+def _mark_reconnect_required(tok, message: str):
+    from extensions import db
+    tok.sync_error = message
+    db.session.commit()
+
+
+def token_needs_reconnect(tok) -> bool:
+    """Return true when the stored token state requires a fresh OAuth consent."""
+    if not tok:
+        return False
+    if is_token_expired(tok):
+        return True
+    return _token_error_requires_reconnect(getattr(tok, "sync_error", None))
+
+
 def _store_token(user_id: int, data: dict):
     from extensions import db
     from models import GoogleOAuthToken
@@ -143,7 +175,11 @@ def _refresh_if_needed(tok) -> str:
     }, timeout=15)
     data = resp.json()
     if "error" in data:
-        raise RuntimeError(f"Google token refresh failed: {data.get('error_description', data['error'])}")
+        detail = data.get("error_description") or data.get("error") or "refresh failed"
+        message = f"Google token refresh failed: {detail}"
+        if _token_error_requires_reconnect(f"{data.get('error')} {detail}"):
+            _mark_reconnect_required(tok, message)
+        raise RuntimeError(message)
 
     tok.access_token = data["access_token"]
     expires_in = int(data.get("expires_in", 3600))
@@ -213,7 +249,7 @@ def _fetch_all_contacts(access_token: str) -> dict:
 
         resp = requests.get(PEOPLE_API, headers=headers, params=params, timeout=20)
         if resp.status_code == 401:
-            raise RuntimeError("Google token invalid or revoked.")
+            raise RuntimeError("Google token invalid or revoked. Reconnect Google Contacts to grant consent again.")
         resp.raise_for_status()
         body = resp.json()
 
@@ -414,13 +450,14 @@ def sync_contacts(user_id: int, company_id: int) -> dict:
         phone_map    = _fetch_all_contacts(access_token)
     except Exception as exc:
         err_msg = str(exc)
+        reconnect_required = _token_error_requires_reconnect(err_msg)
         logger.error("Google Contacts fetch error for user %s: %s", user_id, exc)
         try:
             tok.sync_error = err_msg
             db.session.commit()
         except Exception:
             db.session.rollback()
-        return {"synced": 0, "matched": 0, "error": err_msg}
+        return {"synced": 0, "matched": 0, "error": err_msg, "reconnect_required": reconnect_required}
 
     # Populate the local Contact cache for every Google phone number, not only
     # numbers that already have an SMS conversation. This makes PWA contact

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -943,7 +943,11 @@
     <div class="settings-section-label" style="margin-top:20px;">Push Diagnostics</div>
     <div class="settings-toggle-row" style="flex-direction:column;align-items:stretch;gap:6px;">
       <pre id="pushDiagnostics" style="white-space:pre-wrap;font-size:.72rem;background:#05070c;border:1px solid var(--border);border-radius:10px;padding:10px;color:var(--text);max-height:220px;overflow:auto;">Loading…</pre>
-      <button class="btn-small" onclick="refreshPushDiagnostics()">Refresh diagnostics</button>
+      <div style="display:flex;gap:6px;flex-wrap:wrap;">
+        <button class="btn-small" onclick="refreshPushDiagnostics()">Refresh diagnostics</button>
+        <button id="repairPushBtn" class="btn-small" onclick="repairPushNotifications()" style="display:none;">Repair Push Notifications</button>
+      </div>
+      <small id="pushRepairReason" style="color:var(--muted);"></small>
       <small style="color:var(--muted);">If this shows silent:false, remaining sound issues are OS/browser notification-channel settings.</small>
     </div>
 
@@ -2008,15 +2012,15 @@ async function loadGoogleContactsStatus() {
 
     if (!d.connected) {
       label.textContent = 'Not connected — names will not show';
-      if (connectBtn) connectBtn.style.display = 'inline-flex';
+      if (connectBtn) { connectBtn.textContent = 'Connect'; connectBtn.style.display = 'inline-flex'; }
       if (syncBtn)    syncBtn.style.display    = 'none';
       return;
     }
 
-    if (d.oauth_expired) {
+    if (d.oauth_expired || d.reconnect_required) {
       label.textContent = 'Session expired — reconnect to sync';
       label.style.color = '#f59e0b';
-      if (connectBtn) connectBtn.style.display = 'inline-flex';
+      if (connectBtn) { connectBtn.textContent = 'Reconnect Google Contacts'; connectBtn.style.display = 'inline-flex'; }
       if (syncBtn)    syncBtn.style.display    = 'none';
       return;
     }
@@ -2025,7 +2029,7 @@ async function loadGoogleContactsStatus() {
     label.textContent = `Connected · ${d.contacts_synced || 0} contacts · ${lastSync}`;
     label.style.color = '';
     if (syncBtn)    syncBtn.style.display    = 'inline-flex';
-    if (connectBtn) connectBtn.style.display = 'none';
+    if (connectBtn) { connectBtn.textContent = 'Connect'; connectBtn.style.display = 'none'; }
 
     if (d.sync_error) {
       if (errBanner) {
@@ -2156,9 +2160,68 @@ async function refreshPushDiagnostics() {
       lastNotificationVibrate: localDebug.lastNotificationVibrate || null,
       badgeCount: localDebug.badgeCount ?? null,
       serverDecision: api.decision,
+      activeSubscriptions: api.active_subscriptions || 0,
       deviceInstructions: api.device_instructions,
     }, null, 2);
+    updatePushRepairUi(api);
   } catch(e) { el.textContent = JSON.stringify({error:e.message, localDebug}, null, 2); }
+}
+
+function iosPushBlockReason() {
+  const ua = navigator.userAgent || '';
+  const isIOS = /iPhone|iPad|iPod/i.test(ua) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+  if (!isIOS) return '';
+  const standalone = window.matchMedia?.('(display-mode: standalone)').matches || window.navigator.standalone === true;
+  if (!standalone) return 'iOS blocks Web Push unless LUXit is installed to the Home Screen and opened from the app icon.';
+  if (!('PushManager' in window)) return 'iOS Web Push is unavailable in this browser/version. Use Safari on iOS 16.4+ from the installed Home Screen app.';
+  return '';
+}
+
+function updatePushRepairUi(api={}) {
+  const btn = document.getElementById('repairPushBtn');
+  const reason = document.getElementById('pushRepairReason');
+  if (!btn) return;
+  const permission = ('Notification' in window) ? Notification.permission : 'unsupported';
+  const shouldRepair = permission === 'granted' && Number(api.active_subscriptions || 0) === 0;
+  const iosReason = iosPushBlockReason();
+  btn.style.display = shouldRepair ? 'inline-flex' : 'none';
+  if (reason) reason.textContent = iosReason || (shouldRepair ? 'Permission is granted, but no active backend subscription is linked to this user/device.' : '');
+}
+
+async function repairPushNotifications() {
+  const btn = document.getElementById('repairPushBtn');
+  const reason = document.getElementById('pushRepairReason');
+  try {
+    if (!VAPID_PUBLIC) throw new Error(`Push setup incomplete. Missing: ${VAPID_MISSING.join(', ') || 'VAPID_PUBLIC_KEY'}`);
+    if (!('Notification' in window)) throw new Error('This browser does not support Notifications.');
+    if (Notification.permission !== 'granted') throw new Error(`Notification permission is ${Notification.permission}; allow notifications before repair.`);
+    const iosReason = iosPushBlockReason();
+    if (iosReason) throw new Error(iosReason);
+    if (!('serviceWorker' in navigator)) throw new Error('This browser does not support service workers.');
+    if (!('PushManager' in window)) throw new Error('This browser does not support PushManager/Web Push.');
+    if (btn) { btn.disabled = true; btn.textContent = 'Repairing…'; }
+    let reg = await navigator.serviceWorker.getRegistration();
+    if (!reg) reg = await navigator.serviceWorker.register(`/static/sw.js?v=${encodeURIComponent(PWA_VERSION)}`);
+    await reg.update().catch(() => {});
+    await navigator.serviceWorker.ready;
+    let sub = await reg.pushManager.getSubscription();
+    if (!sub) {
+      sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC) });
+    }
+    const subscription = sub.toJSON();
+    subscription.device_key = pwaDeviceKey();
+    subscription.device_label = localStorage.getItem('luxitPwaDeviceName') || `${browserLabel()} ${deviceTypeLabel()}`;
+    const saved = await apiFetch('/api/push/subscribe', 'POST', subscription);
+    if (!saved?.success) throw new Error(saved?.error || 'Backend did not save the subscription.');
+    await registerPwaDevice('heartbeat');
+    toast('Push notifications repaired', 'success');
+    await refreshPushDiagnostics();
+  } catch (e) {
+    if (reason) reason.textContent = e.message;
+    toast('Push repair failed: ' + e.message, 'error');
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = 'Repair Push Notifications'; }
+  }
 }
 function installPwaNavPerformanceHandlers() {
   document.querySelectorAll('[data-pwa-nav]').forEach(a => a.addEventListener('click', () => {

--- a/twilio_sms.py
+++ b/twilio_sms.py
@@ -3020,7 +3020,7 @@ def google_contacts_sync():
 def google_contacts_status():
     """Return connection status as JSON — includes sync error and expiry state."""
     from flask_login import current_user
-    from services.google_contacts import get_token, is_token_expired
+    from services.google_contacts import get_token, token_needs_reconnect
     tok = get_token(current_user.id)
     if not tok:
         return jsonify({
@@ -3032,10 +3032,11 @@ def google_contacts_status():
         })
     return jsonify({
         "connected":       True,
-        "oauth_expired":   is_token_expired(tok),
+        "oauth_expired":   token_needs_reconnect(tok),
         "last_sync_at":    tok.last_sync_at.strftime("%b %-d %H:%M") if tok.last_sync_at else None,
         "contacts_synced": tok.contacts_synced or 0,
         "sync_error":      getattr(tok, "sync_error", None),
+        "reconnect_required": token_needs_reconnect(tok),
     })
 
 


### PR DESCRIPTION
### Motivation
- Detect and surface Google Contacts OAuth states that require a fresh consent (expired/revoked refresh tokens) so users can reconnect rather than repeatedly failing syncs. 
- Preserve the `sync_error` state until the user re-authenticates so failures are visible and only cleared after a successful OAuth exchange. 
- Repair PWA push when the browser permission is granted but the backend shows zero active subscriptions by re-registering/creating a subscription and linking it to the current user/device. 

### Description
- Add token helpers in `services/google_contacts.py`: `_token_error_requires_reconnect`, `_mark_reconnect_required`, and `token_needs_reconnect`, update `_refresh_if_needed` to mark reconnect-required errors, improve 401/error messages, and return `reconnect_required` from `sync_contacts`. 
- Expose reconnect-required state in APIs by switching status endpoints to use `token_needs_reconnect` and including `reconnect_required` in JSON responses in `inbox_pwa.py` and `twilio_sms.py`. 
- Update the PWA UI `templates/inbox_pwa/index.html` to show a `Reconnect Google Contacts` CTA when appropriate and add a `Repair Push Notifications` button plus client logic (`iosPushBlockReason`, `updatePushRepairUi`, `repairPushNotifications`) that (re)registers the SW, gets/creates a `PushManager` subscription, posts it to the backend with `device_key`/label, and reruns diagnostics. 
- Ensure backend subscribe endpoint in `inbox_pwa.py` saves `user_agent`, `device_label`, sets `is_active=True`, updates `PWADevice.push_enabled`, and returns `active_subscription`/`active_subscriptions` counts after saving. 

### Testing
- Compiled affected modules with `python3 -m py_compile services/google_contacts.py inbox_pwa.py twilio_sms.py` and the compilation succeeded. 
- Ran targeted unit tests with `python3 -m pytest tests/test_pwa_communications_completion.py::test_google_contacts_sync_creates_contact_cache_fields_and_links_conversation tests/test_pwa_phone_system.py::test_staff_mobile_inbox_google_contacts_callback_returns_to_pwa tests/test_pwa_phone_system.py::test_staff_mobile_inbox_google_contacts_callback_handles_sync_exception -q` and all 3 tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4eeb3d44048322b35aadba766d378d)