### PR TITLE
Fix PWA push subscription repair diagnostics

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -587,7 +587,7 @@ def pwa_index():
         os.environ.get("LUXIT_ASSET_VERSION")
         or os.environ.get("GIT_SHA")
         or os.environ.get("RENDER_GIT_COMMIT")
-        or "20260705-push-sound-forwarding-bh-autoreply"
+        or "20260709-push-subscription-repair-diagnostics"
     )
     return render_template(
         "inbox_pwa/index.html",
@@ -617,7 +617,7 @@ def pwa_calls():
         os.environ.get("LUXIT_ASSET_VERSION")
         or os.environ.get("GIT_SHA")
         or os.environ.get("RENDER_GIT_COMMIT")
-        or "20260705-push-sound-forwarding-bh-autoreply"
+        or "20260709-push-subscription-repair-diagnostics"
     )
     return render_template("inbox_pwa/calls.html", user=user, company=company, pwa_version=pwa_version)
 
@@ -2383,7 +2383,7 @@ def send_pwa_push_notification(company_id: int, *, user_ids, title: str, body: s
             "event_type": decision["event_type"], "silent": payload["silent"], "sound": payload["sound"],
             "vibrate": payload["vibrate"], "renotify": payload["renotify"], "tag": payload["tag"],
             "badgeCount": badge_count, "channel": payload["channelId"], "importance": payload["importance"],
-            "sw_version": os.environ.get("LUXIT_ASSET_VERSION") or os.environ.get("GIT_SHA") or os.environ.get("RENDER_GIT_COMMIT") or "20260705-push-sound-forwarding-bh-autoreply",
+            "sw_version": os.environ.get("LUXIT_ASSET_VERSION") or os.environ.get("GIT_SHA") or os.environ.get("RENDER_GIT_COMMIT") or "20260709-push-subscription-repair-diagnostics",
             "push_provider_result": result,
         })
         total += result.get("sent", 0)
@@ -2415,13 +2415,24 @@ def pwa_push_debug():
     in_business = str(request.args.get("in_business_hours", "1")).lower() not in {"0", "false", "no"}
     decision = _push_debug_decision(user, event_type, requested_silent=False, in_business_hours=in_business)
     from models import PushSubscription
-    active_subscriptions = PushSubscription.query.filter_by(company_id=company.id, user_id=user.id, is_active=True).count()
+    device_key = (request.headers.get("X-PWA-Device-Key") or request.args.get("device_key") or "").strip()
+    active_query = PushSubscription.query.filter_by(company_id=company.id, user_id=user.id, is_active=True)
+    active_subscriptions = active_query.count()
+    device_active_subscriptions = active_query.filter_by(device_key=device_key).count() if device_key else 0
+    subscriptions = active_query.order_by(PushSubscription.updated_at.desc(), PushSubscription.id.desc()).limit(10).all()
+    missing = _web_push_missing_settings()
     return jsonify({
         "success": True,
         "notification_permission": "client-reported",
         "active_subscription": active_subscriptions > 0,
         "active_subscriptions": active_subscriptions,
-        "service_worker_version": os.environ.get("LUXIT_ASSET_VERSION") or os.environ.get("GIT_SHA") or os.environ.get("RENDER_GIT_COMMIT") or "20260705-push-sound-forwarding-bh-autoreply",
+        "device_key": device_key,
+        "device_active_subscription": device_active_subscriptions > 0,
+        "device_active_subscriptions": device_active_subscriptions,
+        "vapid_configured": not missing,
+        "vapid_public_key_present": bool(os.environ.get("VAPID_PUBLIC_KEY")),
+        "vapid_missing": missing,
+        "service_worker_version": os.environ.get("LUXIT_ASSET_VERSION") or os.environ.get("GIT_SHA") or os.environ.get("RENDER_GIT_COMMIT") or "20260709-push-subscription-repair-diagnostics",
         "decision": decision,
         "device_instructions": [
             "Android: Chrome/LUXit PWA notification channel cannot be Silent or Low Importance.",
@@ -2429,12 +2440,17 @@ def pwa_push_debug():
             "iPhone: install to Home Screen, then enable Settings > Notifications > LUXit > Sounds.",
             "Disable Focus / Do Not Disturb during notification sound tests.",
         ],
+        "subscriptions": [{
+            "id": sub.id,
+            "device_key": sub.device_key,
+            "endpoint_host": (sub.endpoint or "").split("/")[2] if "/" in (sub.endpoint or "") else "",
+            "endpoint_tail": (sub.endpoint or "")[-18:],
+            "is_active": sub.is_active,
+            "updated_at": sub.updated_at.isoformat() if sub.updated_at else None,
+        } for sub in subscriptions],
         "user": {"id": user.id, "email": user.email, "username": user.username},
         "company": {"id": company.id, "name": company.name},
         "mobile_inbox_access": True,
-        "active_subscription": active_subscriptions > 0,
-        "active_subscriptions": active_subscriptions,
-        "decision": decision,
     })
 
 
@@ -2454,12 +2470,15 @@ def push_subscribe():
 
     payload  = request.get_json() or {}
     endpoint = payload.get("endpoint", "")
-    device_key = payload.get("device_key") or payload.get("deviceKey")
-    p256dh   = payload.get("keys", {}).get("p256dh", "")
-    auth_key = payload.get("keys", {}).get("auth", "")
+    device_key = (payload.get("device_key") or payload.get("deviceKey") or request.headers.get("X-PWA-Device-Key") or "").strip()
+    keys = payload.get("keys") or {}
+    p256dh   = keys.get("p256dh", "")
+    auth_key = keys.get("auth", "")
 
     if not endpoint:
-        return jsonify({"success": False, "error": "endpoint required"}), 400
+        return jsonify({"success": False, "error": "endpoint required", "code": "MISSING_ENDPOINT"}), 400
+    if not p256dh or not auth_key:
+        return jsonify({"success": False, "error": "subscription keys p256dh and auth are required", "code": "MISSING_SUBSCRIPTION_KEYS"}), 400
 
     from models import PushSubscription
     sub = PushSubscription.query.filter_by(endpoint=endpoint).first()
@@ -2489,13 +2508,41 @@ def push_subscribe():
     if device_key:
         from models import PWADevice
         device = PWADevice.query.filter_by(company_id=company.id, user_id=user.id, device_key=device_key).first()
-        if device:
+        if not device:
+            device = PWADevice(
+                company_id=company.id,
+                user_id=user.id,
+                device_key=device_key,
+                device_name=payload.get('device_label') or payload.get('deviceName') or device_key,
+                browser=(request.user_agent.browser or None),
+                push_enabled=True,
+                last_seen_at=datetime.utcnow(),
+            )
+            db.session.add(device)
+        else:
             device.push_enabled = True
             device.last_seen_at = datetime.utcnow()
     db.session.commit()
-    logger.info("Push subscription saved for user %d", user.id)
-    active_subscriptions = PushSubscription.query.filter_by(user_id=user.id, company_id=company.id, is_active=True).count()
-    return jsonify({"success": True, "device_key": device_key, "active_subscription": active_subscriptions > 0, "active_subscriptions": active_subscriptions})
+    active_query = PushSubscription.query.filter_by(user_id=user.id, company_id=company.id, is_active=True)
+    active_subscriptions = active_query.count()
+    device_active_subscriptions = active_query.filter_by(device_key=device_key).count() if device_key else 0
+    logger.info("Push subscription saved", extra={
+        "user_id": user.id,
+        "company_id": company.id,
+        "device_key": device_key,
+        "endpoint_host": endpoint.split("/")[2] if "/" in endpoint else "",
+        "active_subscriptions": active_subscriptions,
+        "device_active_subscriptions": device_active_subscriptions,
+    })
+    return jsonify({
+        "success": True,
+        "device_key": device_key,
+        "endpoint_saved": True,
+        "active_subscription": active_subscriptions > 0,
+        "active_subscriptions": active_subscriptions,
+        "device_active_subscription": device_active_subscriptions > 0,
+        "device_active_subscriptions": device_active_subscriptions,
+    })
 
 
 @inbox_pwa_bp.route("/api/push/unsubscribe", methods=["POST"])

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,5 +1,5 @@
 /* LUXit Inbox — Service Worker */
-const SW_VERSION = new URL(self.location.href).searchParams.get('v') || '20260705-push-sound-forwarding-bh-autoreply';
+const SW_VERSION = new URL(self.location.href).searchParams.get('v') || '20260709-push-subscription-repair-diagnostics';
 const CACHE = `luxit-inbox-${SW_VERSION}`;
 const APP_SHELL = [
   '/app/inbox',

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -1144,6 +1144,14 @@ const VAPID_PUBLIC = document.documentElement.dataset.vapid ?? '';
 const VAPID_MISSING = (document.documentElement.dataset.vapidMissing || '').split(',').filter(Boolean);
 const CONV_CACHE_KEY = 'luxitInboxConversations';
 
+async function currentVapidPublicKey() {
+  if (VAPID_PUBLIC) return VAPID_PUBLIC;
+  const status = await apiFetch('/api/pwa/push/public-key');
+  if (status?.publicKey) return status.publicKey;
+  const missing = (status?.missing?.length ? status.missing : VAPID_MISSING).join(', ') || 'VAPID_PUBLIC_KEY';
+  throw new Error(`Push setup incomplete. Missing: ${missing}`);
+}
+
 
 function pwaDeviceKey() {
   let key = localStorage.getItem('luxitPwaDeviceKey');
@@ -1323,13 +1331,11 @@ function checkNotifPrompt() {
 }
 
 async function requestPush() {
-  if (!VAPID_PUBLIC) {
-    let missing = VAPID_MISSING.length ? VAPID_MISSING.join(', ') : 'VAPID_PUBLIC_KEY';
-    try {
-      const status = await apiFetch('/api/pwa/push/status');
-      missing = (status.missing && status.missing.length) ? status.missing.join(', ') : missing;
-    } catch (e) {}
-    toast(`Push setup incomplete. Missing: ${missing}`, 'error');
+  let vapidPublic;
+  try {
+    vapidPublic = await currentVapidPublicKey();
+  } catch (e) {
+    toast(e.message, 'error');
     return;
   }
   const perm = await Notification.requestPermission();
@@ -1339,7 +1345,7 @@ async function requestPush() {
     const reg = await navigator.serviceWorker.ready;
     const sub = await reg.pushManager.subscribe({
       userVisibleOnly: true,
-      applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC),
+      applicationServerKey: urlBase64ToUint8Array(vapidPublic),
     });
     const subscription = sub.toJSON();
     subscription.device_key = pwaDeviceKey();
@@ -2161,6 +2167,11 @@ async function refreshPushDiagnostics() {
       badgeCount: localDebug.badgeCount ?? null,
       serverDecision: api.decision,
       activeSubscriptions: api.active_subscriptions || 0,
+      deviceKey: api.device_key || pwaDeviceKey(),
+      deviceActiveSubscriptions: api.device_active_subscriptions || 0,
+      vapidPublicKeyPresent: !!api.vapid_public_key_present,
+      vapidMissing: api.vapid_missing || [],
+      subscriptions: api.subscriptions || [],
       deviceInstructions: api.device_instructions,
     }, null, 2);
     updatePushRepairUi(api);
@@ -2192,7 +2203,7 @@ async function repairPushNotifications() {
   const btn = document.getElementById('repairPushBtn');
   const reason = document.getElementById('pushRepairReason');
   try {
-    if (!VAPID_PUBLIC) throw new Error(`Push setup incomplete. Missing: ${VAPID_MISSING.join(', ') || 'VAPID_PUBLIC_KEY'}`);
+    const vapidPublic = await currentVapidPublicKey();
     if (!('Notification' in window)) throw new Error('This browser does not support Notifications.');
     if (Notification.permission !== 'granted') throw new Error(`Notification permission is ${Notification.permission}; allow notifications before repair.`);
     const iosReason = iosPushBlockReason();
@@ -2206,13 +2217,16 @@ async function repairPushNotifications() {
     await navigator.serviceWorker.ready;
     let sub = await reg.pushManager.getSubscription();
     if (!sub) {
-      sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC) });
+      sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlBase64ToUint8Array(vapidPublic) });
     }
     const subscription = sub.toJSON();
     subscription.device_key = pwaDeviceKey();
     subscription.device_label = localStorage.getItem('luxitPwaDeviceName') || `${browserLabel()} ${deviceTypeLabel()}`;
     const saved = await apiFetch('/api/push/subscribe', 'POST', subscription);
     if (!saved?.success) throw new Error(saved?.error || 'Backend did not save the subscription.');
+    if (Number(saved.device_active_subscriptions || saved.active_subscriptions || 0) < 1) {
+      throw new Error('Backend accepted the subscription but diagnostics still reports zero active subscriptions for this device.');
+    }
     await registerPwaDevice('heartbeat');
     toast('Push notifications repaired', 'success');
     await refreshPushDiagnostics();

--- a/tests/test_pwa_communications_completion.py
+++ b/tests/test_pwa_communications_completion.py
@@ -435,6 +435,44 @@ def test_push_payload_non_silent_vibration_badge_and_quiet_hours(pwa_app, monkey
         assert payloads[-1]["data"]["debug_reason"] == "quiet_hours"
 
 
+
+def test_push_subscribe_creates_device_and_debug_counts_device_subscription(pwa_app):
+    app, client, ids = pwa_app
+    login(client, ids["staff"])
+    resp = client.post("/api/pwa/push/subscribe", json={
+        "endpoint": "https://push.example/sub/device-debug",
+        "keys": {"p256dh": "p", "auth": "a"},
+        "device_key": "repair-device",
+        "device_label": "Repair Phone",
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert data["active_subscriptions"] == 1
+    assert data["device_active_subscriptions"] == 1
+
+    debug = client.get("/api/pwa/push/debug", headers={"X-PWA-Device-Key": "repair-device"})
+    assert debug.status_code == 200
+    payload = debug.get_json()
+    assert payload["active_subscriptions"] == 1
+    assert payload["device_active_subscriptions"] == 1
+    assert payload["device_key"] == "repair-device"
+    assert payload["vapid_public_key_present"] in {True, False}
+    assert payload["subscriptions"][0]["device_key"] == "repair-device"
+
+    with app.app_context():
+        from models import PWADevice
+        device = PWADevice.query.filter_by(company_id=ids["company"], user_id=ids["staff"], device_key="repair-device").one()
+        assert device.push_enabled is True
+
+
+def test_push_subscribe_rejects_incomplete_browser_subscription(pwa_app):
+    app, client, ids = pwa_app
+    login(client, ids["staff"])
+    resp = client.post("/api/pwa/push/subscribe", json={"endpoint": "https://push.example/sub/missing-keys"})
+    assert resp.status_code == 400
+    assert resp.get_json()["code"] == "MISSING_SUBSCRIPTION_KEYS"
+
 def test_push_debug_uses_logged_in_pwa_user_session(pwa_app):
     app, client, ids = pwa_app
     login(client, ids["staff"])
@@ -482,7 +520,7 @@ def test_pwa_sound_forwarding_autoreply_static_requirements():
     html = open("templates/inbox_pwa/index.html", encoding="utf-8").read()
     nav = open("templates/inbox_pwa/_bottom_nav.html", encoding="utf-8").read()
     migration = open("migrations/20260705_pwa_sound_forwarding_autoreply.sql", encoding="utf-8").read()
-    assert "20260705-push-sound-forwarding-bh-autoreply" in sw
+    assert "20260709-push-subscription-repair-diagnostics" in sw
     assert "silent:  false" in sw
     assert "renotify: data.renotify !== false" in sw
     assert "[200, 100, 200]" in sw


### PR DESCRIPTION
### Motivation
- Users reported `Notification.permission === 'granted'` but `activeSubscriptions === 0` which meant the PWA was ready to play audible push but no backend subscription was saved/linked to the device.  
- Existing diagnostics and repair flow did not surface VAPID configuration, device-scoped counts, or why `pushManager.subscribe()`/POST persistence might be failing.  
- The deployed clients use an older fallback service-worker version token which makes it hard to tell whether a new SW is installed; update needed for reliable diagnostics and repair UX.

### Description
- Updated the PWA/service-worker fallback version token to `20260709-push-subscription-repair-diagnostics` in `inbox_pwa.py` and `static/sw.js` so clients can verify the new SW.  
- Expanded the debug endpoint `GET /api/pwa/push/debug` to return `device_key`, `device_active_subscriptions`, `vapid_configured`, `vapid_public_key_present`, `vapid_missing`, and a masked `subscriptions` list so diagnostics can confirm user/company/device subscription linkage (changes in `inbox_pwa.py`).  
- Hardened `POST /api/pwa/push/subscribe` to require browser subscription keys (`p256dh` and `auth`), accept `X-PWA-Device-Key` as a fallback for `device_key`, create a `PWADevice` when missing and mark it `push_enabled`, persist the `PushSubscription`, and return both user-level and device-level active counts after `db.session.commit()` (changes in `inbox_pwa.py`).  
- Improved client-side flows in `templates/inbox_pwa/index.html` to fetch the live VAPID public key when the embedded attribute is absent, to use the live key for `pushManager.subscribe()`/repair, to include the local `device_key` when posting the subscription, and to fail loudly if the backend returns zero device subscriptions after saving.  
- Added server logging metadata on subscription save and added regression tests that assert device creation, device-scoped debug counts, and rejection of incomplete subscriptions (changes in `tests/test_pwa_communications_completion.py`).

### Testing
- Ran `pytest -q tests/test_pwa_communications_completion.py -q` and it completed successfully.  
- Ran `pytest -q tests/test_comms_permissions_architecture.py::test_pwa_notifications_and_push_subscription_are_scoped_by_number tests/test_comms_permissions_architecture.py::test_pwa_push_test_reports_missing_configuration_cleanly tests/test_pwa_phone_system.py::test_staff_mobile_inbox_user_can_subscribe_to_push -q` and all tests passed.  
- Ran the new focused test `pytest -q tests/test_pwa_communications_completion.py::test_push_subscribe_creates_device_and_debug_counts_device_subscription -q` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4ef4fa49c08322a4af2aa4ab58ab20)