### PR TITLE
Google Contacts: incremental sync, dry-run preview, merge auditing, schema and PWA UI updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -747,6 +747,9 @@ def create_app() -> Flask:
                     ("email_subscribed", "BOOLEAN DEFAULT TRUE"),
                     ("imported_batch_id", "INTEGER"),
                     ("imported_list", "VARCHAR(255)"),
+                    ("external_google_contact_id", "VARCHAR(255)"),
+                    ("avatar_url", "VARCHAR(500)"),
+                    ("updated_at", "TIMESTAMP"),
                 ],
                 "contact_import_batch": [
                     ("company_id", "INTEGER"),
@@ -765,6 +768,17 @@ def create_app() -> Flask:
                 ],
                 "user": [
                     ("notification_sounds_enabled", "BOOLEAN DEFAULT TRUE"),
+                ],
+                "google_oauth_token": [
+                    ("contacts_created", "INTEGER DEFAULT 0"),
+                    ("contacts_updated", "INTEGER DEFAULT 0"),
+                    ("contacts_merged", "INTEGER DEFAULT 0"),
+                    ("contacts_skipped", "INTEGER DEFAULT 0"),
+                    ("last_successful_sync_at", "TIMESTAMP"),
+                    ("last_sync_duration_ms", "INTEGER"),
+                    ("last_sync_status", "VARCHAR(30)"),
+                    ("google_account_email", "VARCHAR(255)"),
+                    ("google_sync_token", "TEXT"),
                 ],
                 "push_subscription": [
                     ("user_agent", "TEXT"),

--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -3125,6 +3125,14 @@ def gc_status():
         "oauth_expired":   token_needs_reconnect(tok),
         "last_sync_at":    tok.last_sync_at.strftime("%b %-d %H:%M") if tok.last_sync_at else None,
         "contacts_synced": tok.contacts_synced or 0,
+        "contacts_created": getattr(tok, "contacts_created", 0) or 0,
+        "contacts_updated": getattr(tok, "contacts_updated", 0) or 0,
+        "contacts_merged": getattr(tok, "contacts_merged", 0) or 0,
+        "contacts_skipped": getattr(tok, "contacts_skipped", 0) or 0,
+        "last_successful_sync_at": tok.last_successful_sync_at.strftime("%b %-d %H:%M") if getattr(tok, "last_successful_sync_at", None) else None,
+        "last_sync_duration_ms": getattr(tok, "last_sync_duration_ms", None),
+        "sync_status": getattr(tok, "last_sync_status", None),
+        "google_account_email": getattr(tok, "google_account_email", None),
         "sync_error":      getattr(tok, "sync_error", None),
         "reconnect_required": token_needs_reconnect(tok),
         "connect_url":     "/twilio/google-contacts/connect",
@@ -3141,5 +3149,7 @@ def gc_sync():
     if not company:
         return jsonify({"error": "No company found."}), 400
     from services.google_contacts import sync_contacts
-    result = sync_contacts(user.id, company.id)
+    payload = request.get_json(silent=True) or {}
+    dry_run = request.args.get("dry_run") in {"1", "true", "yes"} or bool(payload.get("dry_run"))
+    result = sync_contacts(user.id, company.id, dry_run=dry_run)
     return jsonify(result)

--- a/models.py
+++ b/models.py
@@ -810,6 +810,8 @@ class Contact(db.Model):
     company = db.Column(db.String(255))
     phone = db.Column(db.String(50))
     normalized_phone = db.Column(db.String(32), index=True)
+    external_google_contact_id = db.Column(db.String(255), nullable=True, index=True)
+    avatar_url = db.Column(db.String(500), nullable=True)
     tags = db.Column(db.String(255))
     is_active = db.Column(db.Boolean, default=True)
     is_subscribed = db.Column(db.Boolean, default=True)
@@ -844,6 +846,7 @@ class Contact(db.Model):
     marketing_preferences_updated_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
     marketing_preferences_updated_at = db.Column(db.DateTime)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 
 class ContactImportBatch(db.Model):
@@ -2529,6 +2532,8 @@ class DemoRequest(db.Model):
     email = db.Column(db.String(200), nullable=False)
     phone = db.Column(db.String(50))
     normalized_phone = db.Column(db.String(32), index=True)
+    external_google_contact_id = db.Column(db.String(255), nullable=True, index=True)
+    avatar_url = db.Column(db.String(500), nullable=True)
     company_name = db.Column(db.String(200))
     job_title = db.Column(db.String(200))
     team_size = db.Column(db.String(50))
@@ -3675,10 +3680,70 @@ class GoogleOAuthToken(db.Model):
     token_expiry   = db.Column(db.DateTime, nullable=True)
     last_sync_at   = db.Column(db.DateTime, nullable=True)
     contacts_synced = db.Column(db.Integer, default=0)
+    contacts_created = db.Column(db.Integer, default=0)
+    contacts_updated = db.Column(db.Integer, default=0)
+    contacts_merged = db.Column(db.Integer, default=0)
+    contacts_skipped = db.Column(db.Integer, default=0)
+    last_successful_sync_at = db.Column(db.DateTime, nullable=True)
+    last_sync_duration_ms = db.Column(db.Integer, nullable=True)
+    last_sync_status = db.Column(db.String(30), nullable=True)
+    google_account_email = db.Column(db.String(255), nullable=True)
+    google_sync_token = db.Column(db.Text, nullable=True)
     sync_error     = db.Column(db.Text, nullable=True)
     created_at     = db.Column(db.DateTime, default=datetime.utcnow)
 
     user = db.relationship("User", backref=db.backref("google_oauth_token", uselist=False))
+
+
+
+
+class GoogleContactsSyncJob(db.Model):
+    """Audit trail for every Google Contacts sync/preview run."""
+    __tablename__ = "google_contacts_sync_job"
+
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False, index=True)
+    google_account_email = db.Column(db.String(255), nullable=True)
+    status = db.Column(db.String(30), default="running", nullable=False, index=True)
+    dry_run = db.Column(db.Boolean, default=False, nullable=False)
+    started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    completed_at = db.Column(db.DateTime, nullable=True)
+    duration_ms = db.Column(db.Integer, nullable=True)
+    contacts_retrieved = db.Column(db.Integer, default=0, nullable=False)
+    contacts_created = db.Column(db.Integer, default=0, nullable=False)
+    contacts_updated = db.Column(db.Integer, default=0, nullable=False)
+    contacts_merged = db.Column(db.Integer, default=0, nullable=False)
+    contacts_skipped = db.Column(db.Integer, default=0, nullable=False)
+    errors = db.Column(JSON, default=list)
+    api_failures = db.Column(JSON, default=list)
+    oauth_failures = db.Column(JSON, default=list)
+    preview_payload = db.Column(JSON, default=dict)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class ContactMergeAudit(db.Model):
+    """Permanent audit record for Audience contact merges."""
+    __tablename__ = "contact_merge_audit"
+
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    source_contact_id = db.Column(db.Integer, nullable=False, index=True)
+    destination_contact_id = db.Column(db.Integer, nullable=False, index=True)
+    merge_reason = db.Column(db.String(255), nullable=True)
+    google_resource_id = db.Column(db.String(255), nullable=True)
+    phone_match = db.Column(db.Boolean, default=False, nullable=False)
+    email_match = db.Column(db.Boolean, default=False, nullable=False)
+    match_confidence = db.Column(db.Integer, default=0, nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True, index=True)
+    sync_job_id = db.Column(db.Integer, db.ForeignKey("google_contacts_sync_job.id"), nullable=True, index=True)
+    updated_fields = db.Column(JSON, default=list)
+    preserved_fields = db.Column(JSON, default=list)
+    skipped_fields = db.Column(JSON, default=list)
+    fields_before = db.Column(JSON, default=dict)
+    fields_after = db.Column(JSON, default=dict)
+    reference_mappings = db.Column(JSON, default=list)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
 # ============================================================

--- a/services/google_contacts.py
+++ b/services/google_contacts.py
@@ -9,6 +9,8 @@ and writes the Google display name into contact_name.
 import logging
 import os
 import re
+import time
+import unicodedata
 import urllib.parse
 from datetime import datetime, timedelta
 
@@ -28,27 +30,40 @@ REVOKE_URL = "https://oauth2.googleapis.com/revoke"
 # ---------------------------------------------------------------------------
 
 def normalize_phone(raw: str) -> str:
-    """Return E.164 string for US numbers, or best-effort for others.
+    """Return a canonical E.164-ish phone number where possible.
 
-    Handles all common US formats:
-      4155551212          → +14155551212
-      14155551212         → +14155551212
-      (415) 555-1212      → +14155551212
-      1-415-555-1212      → +14155551212
-      415.555.1212        → +14155551212
-      +14155551212        → +14155551212  (already E.164)
-      +447911123456       → +447911123456  (international pass-through)
+    Handles domestic +1 forms, 001 international prefixes, punctuation, spaces,
+    parentheses, hyphens, and common extension markers. Non-US international
+    numbers are preserved with their country code when enough digits exist.
     """
-    digits = re.sub(r"\D", "", raw or "")
+    value = (raw or "").strip()
+    if not value:
+        return ""
+    value = re.sub(r"(?i)(?:ext\.?|extension|x)\s*\d+\s*$", "", value).strip()
+    international_prefix = value.startswith("+")
+    digits = re.sub(r"\D", "", value)
+    if digits.startswith("001") and len(digits) > 11:
+        digits = digits[3:]
+    elif digits.startswith("00") and len(digits) > 10:
+        digits = digits[2:]
     if len(digits) == 10:
         return "+1" + digits
     if len(digits) == 11 and digits.startswith("1"):
         return "+" + digits
-    return "+" + digits if digits else (raw or "")
+    if international_prefix and 8 <= len(digits) <= 15:
+        return "+" + digits
+    if 8 <= len(digits) <= 15:
+        return "+" + digits
+    return "+" + digits if digits else value
 
 
 # Keep old name as alias for backward compatibility
 _normalize = normalize_phone
+
+
+def normalize_email(raw: str | None) -> str:
+    """Normalize email addresses for matching without exposing OAuth secrets."""
+    return unicodedata.normalize("NFKC", raw or "").strip().lower()
 
 
 def _all_forms(phone: str) -> list:
@@ -230,9 +245,9 @@ def disconnect(user_id: int):
 # Contact fetch
 # ---------------------------------------------------------------------------
 
-def _fetch_all_contacts(access_token: str) -> dict:
+def _fetch_all_contacts(access_token: str, sync_token: str | None = None) -> dict:
     """
-    Return dict: normalized_phone -> display_name
+    Return dict: normalized_phone -> Google contact data.
     Handles pagination automatically.
     """
     phone_map = {}
@@ -241,11 +256,15 @@ def _fetch_all_contacts(access_token: str) -> dict:
 
     while True:
         params = {
-            "personFields": "names,phoneNumbers",
+            "personFields": "names,phoneNumbers,emailAddresses,organizations,photos",
             "pageSize":     1000,
         }
         if page_token:
             params["pageToken"] = page_token
+        elif sync_token:
+            params["syncToken"] = sync_token
+        else:
+            params["requestSyncToken"] = "true"
 
         resp = requests.get(PEOPLE_API, headers=headers, params=params, timeout=20)
         if resp.status_code == 401:
@@ -256,22 +275,46 @@ def _fetch_all_contacts(access_token: str) -> dict:
         for person in body.get("connections", []):
             names = person.get("names", [])
             phones = person.get("phoneNumbers", [])
-            if not names or not phones:
+            emails = person.get("emailAddresses", [])
+            orgs = person.get("organizations", [])
+            photos = person.get("photos", [])
+            if not phones and not emails:
                 continue
 
-            name = (names[0].get("displayName") or
-                    f"{names[0].get('givenName','')} {names[0].get('familyName','')}".strip())
-            if not name:
-                continue
+            primary_name = names[0] if names else {}
+            name = (primary_name.get("displayName") or
+                    f"{primary_name.get('givenName','')} {primary_name.get('familyName','')}".strip())
+            data = {
+                "resource_name": person.get("resourceName"),
+                "name": name or "",
+                "first_name": primary_name.get("givenName") or "",
+                "last_name": primary_name.get("familyName") or "",
+                "email": (emails[0].get("value") if emails else "") or "",
+                "company": (orgs[0].get("name") if orgs else "") or "",
+                "avatar_url": (photos[0].get("url") if photos else "") or "",
+                "phones": [ph.get("value", "") for ph in phones if ph.get("value")],
+            }
+            if not data["first_name"] and name:
+                parts = name.split(" ", 1)
+                data["first_name"] = parts[0]
+                data["last_name"] = parts[1] if len(parts) > 1 else ""
 
+            added_phone = False
             for ph in phones:
                 raw = ph.get("value", "")
                 normalized = normalize_phone(raw)
                 if normalized and normalized not in phone_map:
-                    phone_map[normalized] = name
+                    phone_map[normalized] = {**data, "phone": raw, "normalized_phone": normalized}
+                    added_phone = True
+            if not added_phone and data.get("email"):
+                key = "email:" + normalize_email(data["email"])
+                phone_map[key] = {**data, "phone": "", "normalized_phone": ""}
 
         page_token = body.get("nextPageToken")
         if not page_token:
+            next_sync_token = body.get("nextSyncToken")
+            if next_sync_token:
+                phone_map["__meta__"] = {"next_sync_token": next_sync_token, "incremental": bool(sync_token)}
             break
 
     return phone_map
@@ -429,114 +472,390 @@ def lookup_contact_name(company_id: int, phone: str) -> tuple:
 # Sync
 # ---------------------------------------------------------------------------
 
-def sync_contacts(user_id: int, company_id: int) -> dict:
-    """
-    Fetch Google contacts and:
-      1. Update TwilioConversation.contact_name for all conversations in
-         this company where the phone number matches.
-      2. Upsert matching Contact rows so future inbound messages link by name.
+def _blank(value) -> bool:
+    return value is None or (isinstance(value, str) and not value.strip())
 
-    Returns {"synced": int, "matched": int, "error": str|None}
-    """
+
+def _tag_union(*tag_values) -> str:
+    seen = []
+    for tags in tag_values:
+        if isinstance(tags, list):
+            parts = tags
+        else:
+            parts = re.split(r"[,;]", tags or "")
+        for part in parts:
+            tag = str(part).strip()
+            if tag and tag.lower() not in {t.lower() for t in seen}:
+                seen.append(tag)
+    return ",".join(seen)
+
+
+def _google_data(norm_phone: str, value) -> dict:
+    if isinstance(value, dict):
+        data = dict(value)
+    else:
+        data = {"name": value or ""}
+    data.setdefault("phone", norm_phone)
+    data.setdefault("normalized_phone", norm_phone)
+    data.setdefault("resource_name", None)
+    data.setdefault("email", "")
+    data.setdefault("company", "")
+    data.setdefault("avatar_url", "")
+    name = (data.get("name") or "").strip()
+    data.setdefault("first_name", "")
+    data.setdefault("last_name", "")
+    if name and not data.get("first_name") and not data.get("last_name"):
+        parts = name.split(" ", 1)
+        data["first_name"] = parts[0]
+        data["last_name"] = parts[1] if len(parts) > 1 else ""
+    return data
+
+
+def _find_contact_by_google_data(company_id: int, data: dict):
     from extensions import db
-    from models import TwilioConversation, Contact
+    from models import Contact
+    resource = data.get("resource_name")
+    if resource:
+        found = Contact.query.filter_by(company_id=company_id, external_google_contact_id=resource, is_active=True).first()
+        if found:
+            return found
+    phone = data.get("normalized_phone") or normalize_phone(data.get("phone"))
+    if phone:
+        found = _find_contact_by_phone(company_id, phone)
+        if found:
+            return found
+    email = normalize_email(data.get("email"))
+    if email:
+        found = Contact.query.filter(Contact.company_id == company_id, Contact.is_active == True, db.func.lower(Contact.email) == email).first()
+        if found:
+            return found
+    return None
+
+
+
+def _contact_snapshot(contact) -> dict:
+    fields = ["id", "email", "phone", "normalized_phone", "name", "first_name", "last_name",
+              "company", "tags", "source", "source_detail", "source_added_at",
+              "external_google_contact_id", "avatar_url", "created_at", "updated_at",
+              "segment", "sms_consent_status"]
+    snap = {}
+    for field in fields:
+        if hasattr(contact, field):
+            value = getattr(contact, field)
+            snap[field] = value.isoformat() if hasattr(value, "isoformat") else value
+    return snap
+
+
+def _merge_confidence(contact, data: dict) -> dict:
+    resource_match = bool(data.get("resource_name") and getattr(contact, "external_google_contact_id", None) == data.get("resource_name"))
+    phone = data.get("normalized_phone") or normalize_phone(data.get("phone"))
+    contact_phone = getattr(contact, "normalized_phone", None) or normalize_phone(getattr(contact, "phone", None))
+    phone_match = bool(phone and contact_phone and phone == contact_phone)
+    email = normalize_email(data.get("email"))
+    contact_email = normalize_email(getattr(contact, "email", None))
+    email_match = bool(email and contact_email and email == contact_email)
+    if resource_match:
+        score, reason = 100, "google_resource_id"
+    elif phone_match and email_match:
+        score, reason = 95, "phone_email"
+    elif phone_match and getattr(contact, "normalized_phone", None):
+        score, reason = 80, "phone"
+    elif phone_match:
+        score, reason = 70, "phone_normalization"
+    elif email_match:
+        score, reason = 75, "email"
+    else:
+        score, reason = 0, "no_match"
+    return {"confidence": score, "reason": reason, "phone_match": phone_match, "email_match": email_match, "resource_match": resource_match}
+
+
+def _merge_threshold() -> int:
+    try:
+        return int(os.environ.get("GOOGLE_CONTACTS_AUTO_MERGE_THRESHOLD", "95"))
+    except ValueError:
+        return 95
+
+
+def _preview_limit() -> int:
+    try:
+        return int(os.environ.get("GOOGLE_CONTACTS_PREVIEW_LIMIT", "100"))
+    except ValueError:
+        return 100
+
+
+def _append_preview(preview: dict, section: str, item: dict, omitted: dict, limit: int):
+    bucket = preview.setdefault(section, [])
+    if len(bucket) < limit:
+        bucket.append(item)
+    else:
+        omitted[section] = omitted.get(section, 0) + 1
+
+
+def _merge_duplicate_contacts(db, survivor, duplicate, *, data: dict, user_id: int | None,
+                              sync_job_id: int | None, confidence: dict) -> tuple[bool, dict]:
+    if not survivor or not duplicate or survivor.id == duplicate.id or survivor.company_id != duplicate.company_id:
+        return False, {}
+    before_survivor = _contact_snapshot(survivor)
+    before_duplicate = _contact_snapshot(duplicate)
+    reference_mappings = []
+    # Repoint every mapped table with a contact_id column, including Twilio,
+    # SMS/MMS, campaigns, calls, CRM activities, notes, tasks, deals, feedback,
+    # attachments, AI/marketing entities, and future CRM tables.
+    for mapper in db.Model.registry.mappers:
+        model = mapper.class_
+        table_name = getattr(model, "__tablename__", None)
+        if table_name == "contact" or not hasattr(model, "contact_id"):
+            continue
+        query = model.query.filter_by(contact_id=duplicate.id)
+        if hasattr(model, "company_id"):
+            query = query.filter_by(company_id=survivor.company_id)
+        count = query.update({"contact_id": survivor.id}, synchronize_session=False)
+        if count:
+            reference_mappings.append({"table": table_name, "from_contact_id": duplicate.id, "to_contact_id": survivor.id, "rows": count})
+    survivor.tags = _tag_union(survivor.tags, duplicate.tags)
+    updated_fields, preserved_fields, skipped_fields = [], [], []
+    for field in ["email", "phone", "normalized_phone", "name", "first_name", "last_name", "company", "source", "source_detail", "source_added_at", "external_google_contact_id", "avatar_url"]:
+        source_value = getattr(duplicate, field, None) if hasattr(duplicate, field) else None
+        dest_value = getattr(survivor, field, None) if hasattr(survivor, field) else None
+        if hasattr(survivor, field) and _blank(dest_value) and not _blank(source_value):
+            setattr(survivor, field, source_value)
+            updated_fields.append(field)
+        elif not _blank(dest_value):
+            preserved_fields.append(field)
+        else:
+            skipped_fields.append(field)
+    duplicate.is_active = False
+    duplicate.tags = _tag_union(duplicate.tags, "Merged Duplicate")
+    duplicate.source_detail = (duplicate.source_detail or "")[:200]
+    after_survivor = _contact_snapshot(survivor)
+    from models import ContactMergeAudit
+    audit = ContactMergeAudit(
+        company_id=survivor.company_id,
+        source_contact_id=duplicate.id,
+        destination_contact_id=survivor.id,
+        merge_reason=confidence.get("reason"),
+        google_resource_id=data.get("resource_name"),
+        phone_match=bool(confidence.get("phone_match")),
+        email_match=bool(confidence.get("email_match")),
+        match_confidence=int(confidence.get("confidence") or 0),
+        user_id=user_id,
+        sync_job_id=sync_job_id,
+        updated_fields=updated_fields,
+        preserved_fields=preserved_fields,
+        skipped_fields=skipped_fields,
+        fields_before={"survivor": before_survivor, "duplicate": before_duplicate},
+        fields_after={"survivor": after_survivor, "duplicate": _contact_snapshot(duplicate)},
+        reference_mappings=reference_mappings,
+    )
+    db.session.add(audit)
+    return True, {"audit_id": None, "reference_mappings": reference_mappings, "updated_fields": updated_fields,
+                  "preserved_fields": preserved_fields, "skipped_fields": skipped_fields,
+                  "fields_before": audit.fields_before, "fields_after": audit.fields_after}
+
+
+def _apply_google_to_contact(contact, data: dict, *, dry_run: bool = False) -> list[str]:
+    changes = []
+    mapping = {
+        "first_name": data.get("first_name"), "last_name": data.get("last_name"),
+        "name": data.get("name"), "email": normalize_email(data.get("email")) if data.get("email") else "", "phone": data.get("normalized_phone") or data.get("phone"),
+        "normalized_phone": data.get("normalized_phone") or normalize_phone(data.get("phone")),
+        "company": data.get("company"), "avatar_url": data.get("avatar_url"),
+        "external_google_contact_id": data.get("resource_name"),
+    }
+    for field, value in mapping.items():
+        if hasattr(contact, field) and not _blank(value) and _blank(getattr(contact, field, None)):
+            if not dry_run: setattr(contact, field, value)
+            changes.append(field)
+    new_tags = _tag_union(getattr(contact, "tags", None), "Google Contact")
+    if new_tags != (contact.tags or ""):
+        if not dry_run: contact.tags = new_tags
+        changes.append("tags")
+    now = datetime.utcnow()
+    if not dry_run:
+        contact.source = "google_contacts"
+        contact.source_detail = "Google Contacts sync"
+        if not contact.source_added_at:
+            contact.source_added_at = now
+        if hasattr(contact, "updated_at"):
+            contact.updated_at = now
+        contact.is_active = True
+    return changes
+
+
+def preview_sync_contacts(user_id: int, company_id: int) -> dict:
+    return sync_contacts(user_id, company_id, dry_run=True)
+
+
+def _preview_contact(contact) -> dict | None:
+    if not contact:
+        return None
+    return {"id": contact.id, "name": _contact_display_name(contact), "email": getattr(contact, "email", None), "phone": getattr(contact, "phone", None), "tags": getattr(contact, "tags", None)}
+
+
+def _finish_sync_job(db, job, status: str, payload: dict, error: str | None = None):
+    job.status = status
+    job.completed_at = datetime.utcnow()
+    job.duration_ms = int((job.completed_at - job.started_at).total_seconds() * 1000)
+    job.contacts_retrieved = payload.get("synced", 0)
+    job.contacts_created = payload.get("created", 0)
+    job.contacts_updated = payload.get("updated", 0)
+    job.contacts_merged = payload.get("merged", 0)
+    job.contacts_skipped = payload.get("skipped", 0)
+    job.preview_payload = payload.get("preview", {})
+    if error:
+        job.errors = (job.errors or []) + [{"message": error, "at": job.completed_at.isoformat()}]
+    db.session.flush()
+
+
+def sync_contacts(user_id: int, company_id: int, dry_run: bool = False) -> dict:
+    """Fetch Google contacts and enrich/merge Audience contacts. Supports dry-run previews."""
+    from extensions import db
+    from models import TwilioConversation, Contact, GoogleContactsSyncJob
+
+    job = GoogleContactsSyncJob(company_id=company_id, user_id=user_id, dry_run=dry_run, status="running")
+    db.session.add(job)
+    db.session.commit()
+    logger.info("Google Contacts sync job %s started user=%s company=%s dry_run=%s", job.id, user_id, company_id, dry_run)
 
     tok = get_token(user_id)
     if not tok:
-        return {"synced": 0, "matched": 0, "error": "Not connected to Google."}
-
+        payload = {"sync_job_id": job.id, "synced": 0, "matched": 0, "updated": 0, "merged": 0, "created": 0, "skipped": 0, "error": "Not connected to Google.", "dry_run": dry_run}
+        _finish_sync_job(db, job, "failed", payload, payload["error"])
+        db.session.commit()
+        return payload
+    job.google_account_email = getattr(tok, "google_account_email", None)
     try:
         access_token = _refresh_if_needed(tok)
-        phone_map    = _fetch_all_contacts(access_token)
-    except Exception as exc:
-        err_msg = str(exc)
-        reconnect_required = _token_error_requires_reconnect(err_msg)
-        logger.error("Google Contacts fetch error for user %s: %s", user_id, exc)
         try:
-            tok.sync_error = err_msg
-            db.session.commit()
-        except Exception:
-            db.session.rollback()
-        return {"synced": 0, "matched": 0, "error": err_msg, "reconnect_required": reconnect_required}
+            try:
+                phone_map = _fetch_all_contacts(access_token, sync_token=getattr(tok, "google_sync_token", None))
+            except TypeError:
+                # Backward-compatible for tests/extensions monkeypatching the old one-arg fetcher.
+                phone_map = _fetch_all_contacts(access_token)
+        except requests.HTTPError as exc:
+            # Google sync tokens expire. Fall back to a full sync, preserving recoverability in job errors.
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            if status in {400, 410} and getattr(tok, "google_sync_token", None):
+                job.api_failures = (job.api_failures or []) + [{"message": str(exc), "fallback": "full_sync"}]
+                tok.google_sync_token = None
+                try:
+                    phone_map = _fetch_all_contacts(access_token, sync_token=None)
+                except TypeError:
+                    phone_map = _fetch_all_contacts(access_token)
+            else:
+                raise
+    except Exception as exc:
+        err_msg = str(exc); reconnect_required = _token_error_requires_reconnect(err_msg)
+        logger.error("Google Contacts sync job %s failed for user %s: %s", job.id, user_id, exc)
+        if reconnect_required:
+            job.oauth_failures = (job.oauth_failures or []) + [{"message": err_msg}]
+        else:
+            job.api_failures = (job.api_failures or []) + [{"message": err_msg}]
+        tok.sync_error = err_msg
+        payload = {"sync_job_id": job.id, "synced": 0, "matched": 0, "updated": 0, "merged": 0, "created": 0, "skipped": 0, "error": err_msg, "reconnect_required": reconnect_required, "dry_run": dry_run}
+        _finish_sync_job(db, job, "failed", payload, err_msg)
+        db.session.commit()
+        return payload
 
-    # Populate the local Contact cache for every Google phone number, not only
-    # numbers that already have an SMS conversation. This makes PWA contact
-    # search and future inbound-SMS name resolution work immediately after sync.
-    for norm, name in phone_map.items():
-        _upsert_contact_from_google(db, company_id, norm, name, None)
+    meta = phone_map.pop("__meta__", {}) if isinstance(phone_map, dict) else {}
+    updated_ids, created, merged, matched, skipped = set(), 0, 0, 0, 0
+    preview = {"will_create": [], "will_update": [], "will_merge": [], "will_skip": [], "possible_merge_requires_review": []}
+    preview_omitted = {}
+    preview_limit = _preview_limit()
+    samples = []
+    threshold = _merge_threshold()
 
-    convs   = TwilioConversation.query.filter_by(company_id=company_id).all()
-    matched = 0
-
-    for conv in convs:
-        norm = normalize_phone(conv.from_number)
-        name = phone_map.get(norm)
-
-        logger.debug(
-            "sync_contacts: conv_id=%s from=%s norm=%s match=%s",
-            conv.id, conv.from_number, norm, name
-        )
-
-        if name:
-            contact = _upsert_contact_from_google(db, company_id, norm, name, conv)
-            info = {"name": name, "source": "google_contacts", "contact_id": contact.id if contact else None, "normalized_phone": norm}
-            if _apply_contact_to_conversation(conv, info):
+    try:
+        for index, (norm, raw_data) in enumerate(phone_map.items(), start=1):
+            data = _google_data(norm, raw_data)
+            contact = _find_contact_by_google_data(company_id, data)
+            if contact:
                 matched += 1
+                changes = _apply_google_to_contact(contact, data, dry_run=dry_run)
+                if changes:
+                    updated_ids.add(contact.id)
+                    _append_preview(preview, "will_update", {"existing_contact": _preview_contact(contact), "incoming_google_contact": data, "fields_to_update": changes}, preview_omitted, preview_limit)
+                candidates = []
+                phone_key = data.get("normalized_phone") or (norm if not str(norm).startswith("email:") else "")
+                if phone_key:
+                    for form in _all_forms(phone_key):
+                        candidates += Contact.query.filter_by(company_id=company_id, phone=form, is_active=True).all()
+                if data.get("email"):
+                    email = normalize_email(data["email"])
+                    candidates += Contact.query.filter(Contact.company_id == company_id, Contact.is_active == True, db.func.lower(Contact.email) == email).all()
+                for dup in {c.id: c for c in candidates}.values():
+                    if dup.id == contact.id:
+                        continue
+                    confidence = _merge_confidence(dup, data)
+                    merge_item = {"source_contact": _preview_contact(dup), "destination_contact": _preview_contact(contact),
+                                  "match_reason": confidence["reason"], "confidence": confidence["confidence"],
+                                  "fields_changing": changes, "incoming_google_contact": data}
+                    if confidence["confidence"] >= threshold:
+                        _append_preview(preview, "will_merge", merge_item, preview_omitted, preview_limit)
+                        if not dry_run:
+                            did_merge, audit = _merge_duplicate_contacts(db, contact, dup, data=data, user_id=user_id, sync_job_id=job.id, confidence=confidence)
+                            if did_merge:
+                                merged += 1
+                    else:
+                        skipped += 1
+                        _append_preview(preview, "possible_merge_requires_review", {**merge_item, "requires_review": True}, preview_omitted, preview_limit)
+            else:
+                created += 1
+                _append_preview(preview, "will_create", {"contact_name": data.get("name"), "incoming_google_contact": data}, preview_omitted, preview_limit)
+                if not dry_run:
+                    contact = Contact(company_id=company_id, is_subscribed=False)
+                    db.session.add(contact); db.session.flush()
+                    _apply_google_to_contact(contact, data, dry_run=False)
+            if contact and len(samples) < 10:
+                samples.append({"contact_id": contact.id, "name": data.get("name"), "phone": data.get("normalized_phone") or norm})
+            if not dry_run and index % int(os.environ.get("GOOGLE_CONTACTS_BATCH_SIZE", "500")) == 0:
+                db.session.flush()
 
-    tok.last_sync_at    = datetime.utcnow()
-    tok.contacts_synced = len(phone_map)
-    tok.sync_error      = None
-    db.session.commit()
+        if not dry_run:
+            for conv in TwilioConversation.query.filter_by(company_id=company_id).yield_per(500):
+                norm = normalize_phone(conv.from_number)
+                raw_data = phone_map.get(norm)
+                if raw_data:
+                    data = _google_data(norm, raw_data)
+                    contact = _find_contact_by_google_data(company_id, data)
+                    info = {"name": data.get("name"), "source": "google_contacts", "contact_id": contact.id if contact else None, "normalized_phone": norm}
+                    if _apply_contact_to_conversation(conv, info):
+                        matched += 1
 
-    logger.info(
-        "Google Contacts sync: user=%s company=%s total_contacts=%d matched=%d",
-        user_id, company_id, len(phone_map), matched
-    )
-    return {"synced": len(phone_map), "matched": matched, "error": None}
-
-
-def _upsert_contact_from_google(db, company_id: int, norm_phone: str,
-                                 name: str, conv) -> None:
-    """Create or update a Contact row for a Google-synced number."""
-    from models import Contact
-
-    parts      = name.split(" ", 1)
-    first_name = parts[0]
-    last_name  = parts[1] if len(parts) > 1 else ""
-
-    # Try to find existing contact by any normalized form
-    contact = None
-    for form in _all_forms(norm_phone):
-        contact = Contact.query.filter_by(
-            company_id=company_id, phone=form
-        ).first()
-        if contact:
-            break
-
-    if contact:
-        if not contact.first_name and not contact.last_name:
-            contact.first_name = first_name
-            contact.last_name  = last_name
-        contact.name       = getattr(contact, "name", None) or name
-        contact.normalized_phone = norm_phone
-        contact.source     = contact.source or "google_contacts"
-        contact.is_active  = True
-    else:
-        contact = Contact(
-            company_id = company_id,
-            phone      = norm_phone,
-            first_name = first_name,
-            last_name  = last_name,
-            name       = name,
-            normalized_phone = norm_phone,
-            source     = "google_contacts",
-            is_active  = True,
-            is_subscribed = False,
-        )
-        db.session.add(contact)
-        db.session.flush()
-
-    # Link conversation to contact if not already linked
-    if conv and contact.id:
-        conv.contact_id = contact.id
-    return contact
+        if preview_omitted:
+            preview["omitted_counts"] = preview_omitted
+        payload = {"sync_job_id": job.id, "synced": len(phone_map), "matched": matched, "updated": len(updated_ids),
+                   "merged": merged if not dry_run else len(preview["will_merge"]), "created": created, "skipped": skipped,
+                   "error": None, "dry_run": dry_run, "samples": samples, "preview": preview,
+                   "status": "completed", "incremental": bool(meta.get("incremental")),
+                   "review_required": bool(preview["possible_merge_requires_review"] or preview_omitted.get("possible_merge_requires_review"))}
+        if dry_run:
+            job_id = job.id
+            db.session.rollback()
+            job = db.session.get(GoogleContactsSyncJob, job_id)
+            _finish_sync_job(db, job, "completed", payload)
+            db.session.commit()
+        else:
+            tok.last_sync_at = datetime.utcnow(); tok.last_successful_sync_at = tok.last_sync_at
+            tok.contacts_synced = len(phone_map); tok.contacts_created = created; tok.contacts_updated = len(updated_ids)
+            tok.contacts_merged = merged; tok.contacts_skipped = skipped
+            tok.last_sync_status = "completed"; tok.sync_error = None
+            if meta.get("next_sync_token"):
+                tok.google_sync_token = meta["next_sync_token"]
+            _finish_sync_job(db, job, "completed", payload)
+            tok.last_sync_duration_ms = job.duration_ms
+            db.session.commit()
+        logger.info("Google Contacts sync job %s completed: %s", job.id, payload)
+        return payload
+    except Exception as exc:
+        db.session.rollback()
+        # Restore the job failure record after rolling back any partial contact work.
+        job = db.session.get(GoogleContactsSyncJob, job.id) or GoogleContactsSyncJob(id=job.id, company_id=company_id, user_id=user_id, dry_run=dry_run)
+        db.session.add(job)
+        err_msg = str(exc)
+        payload = {"sync_job_id": job.id, "synced": len(phone_map), "matched": matched, "updated": len(updated_ids), "merged": merged,
+                   "created": created, "skipped": skipped, "error": err_msg, "dry_run": dry_run, "status": "failed", "preview": preview}
+        _finish_sync_job(db, job, "failed", payload, err_msg)
+        db.session.commit()
+        logger.exception("Google Contacts sync job %s failed during processing", job.id)
+        return payload

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -958,15 +958,17 @@
         <div style="display:flex;align-items:center;gap:8px;">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
           <div>
-            <span>Google Contacts</span>
+            <span>Sync & Enrich from Google Contacts</span>
             <small id="gcStatusLabel" style="display:block;">Checking…</small>
           </div>
         </div>
         <div style="display:flex;gap:6px;align-items:center;">
-          <button id="gcSyncBtn" class="btn-small" onclick="triggerGoogleSync()" style="display:none;">Sync</button>
+          <button id="gcPreviewBtn" class="btn-small" onclick="triggerGoogleSync(true)" style="display:none;">Preview changes</button>
+          <button id="gcSyncBtn" class="btn-small" onclick="triggerGoogleSync(false)" style="display:none;">Run sync</button>
           <a id="gcConnectBtn" href="/twilio/google-contacts/connect" class="btn-small" style="display:none;text-decoration:none;">Connect</a>
         </div>
       </div>
+      <div id="gcMetrics" style="display:none;width:100%;font-size:.72rem;color:var(--muted);line-height:1.5;"></div>
       <div id="gcErrorBanner" style="display:none;width:100%;padding:6px 8px;border-radius:6px;background:rgba(239,68,68,.1);border:1px solid rgba(239,68,68,.25);color:#f87171;font-size:.75rem;"></div>
     </div>
 
@@ -2008,8 +2010,10 @@ async function moveFavorite(idx, delta) {
 async function loadGoogleContactsStatus() {
   const label     = document.getElementById('gcStatusLabel');
   const syncBtn   = document.getElementById('gcSyncBtn');
+  const previewBtn= document.getElementById('gcPreviewBtn');
   const connectBtn= document.getElementById('gcConnectBtn');
   const errBanner = document.getElementById('gcErrorBanner');
+  const metrics = document.getElementById('gcMetrics');
   if (!label) return;
 
   try {
@@ -2020,6 +2024,8 @@ async function loadGoogleContactsStatus() {
       label.textContent = 'Not connected — names will not show';
       if (connectBtn) { connectBtn.textContent = 'Connect'; connectBtn.style.display = 'inline-flex'; }
       if (syncBtn)    syncBtn.style.display    = 'none';
+      if (previewBtn) previewBtn.style.display = 'none';
+      if (metrics) metrics.style.display = 'none';
       return;
     }
 
@@ -2028,13 +2034,25 @@ async function loadGoogleContactsStatus() {
       label.style.color = '#f59e0b';
       if (connectBtn) { connectBtn.textContent = 'Reconnect Google Contacts'; connectBtn.style.display = 'inline-flex'; }
       if (syncBtn)    syncBtn.style.display    = 'none';
+      if (previewBtn) previewBtn.style.display = 'none';
+      if (metrics) metrics.style.display = 'none';
       return;
     }
 
     const lastSync = d.last_sync_at ? `Last sync: ${d.last_sync_at}` : 'Not synced yet';
-    label.textContent = `Connected · ${d.contacts_synced || 0} contacts · ${lastSync}`;
+    const reviewNote = (d.contacts_skipped || 0) > 0 ? ` · ${d.contacts_skipped} review required` : '';
+    label.textContent = `Connected · ${d.contacts_synced || 0} contacts · ${lastSync}${reviewNote}`;
+    if (metrics) {
+      const duration = d.last_sync_duration_ms ? `${Math.round(d.last_sync_duration_ms / 1000)}s` : '—';
+      const statusLabel = d.reconnect_required ? 'Reconnect required' : (d.sync_error ? 'Failed/partial' : (d.sync_status || '—'));
+      metrics.innerHTML = `Account: ${esc(d.google_account_email || 'Connected Google account')}<br>` +
+        `Last successful: ${esc(d.last_successful_sync_at || '—')} · Status: ${esc(statusLabel)} · Duration: ${duration}<br>` +
+        `Created ${d.contacts_created || 0} · Updated ${d.contacts_updated || 0} · Merged ${d.contacts_merged || 0} · Skipped ${d.contacts_skipped || 0}`;
+      metrics.style.display = 'block';
+    }
     label.style.color = '';
     if (syncBtn)    syncBtn.style.display    = 'inline-flex';
+    if (previewBtn) previewBtn.style.display = 'inline-flex';
     if (connectBtn) { connectBtn.textContent = 'Connect'; connectBtn.style.display = 'none'; }
 
     if (d.sync_error) {
@@ -2050,22 +2068,29 @@ async function loadGoogleContactsStatus() {
   }
 }
 
-async function triggerGoogleSync() {
+async function triggerGoogleSync(previewOnly = false) {
   const syncBtn = document.getElementById('gcSyncBtn');
+  const previewBtn = document.getElementById('gcPreviewBtn');
+  const activeBtn = previewOnly ? previewBtn : syncBtn;
   const label   = document.getElementById('gcStatusLabel');
-  if (syncBtn) { syncBtn.disabled = true; syncBtn.textContent = 'Syncing…'; }
+  if (activeBtn) { activeBtn.disabled = true; activeBtn.textContent = previewOnly ? 'Previewing…' : 'Syncing…'; }
   try {
-    const d = await apiFetch('/api/inbox/google-contacts/sync', 'POST', {});
+    const d = await apiFetch('/api/inbox/google-contacts/sync', 'POST', { dry_run: previewOnly });
     if (d && !d.error) {
-      toast(`Synced ${d.synced || 0} contacts · ${d.matched || 0} names updated`);
-      loadConversations();
+      if (previewOnly) {
+        toast(`${d.updated || 0} contacts will be updated · ${d.merged || 0} duplicates will be merged · ${d.created || 0} contacts will be created · ${d.skipped || 0} skipped/review`);
+      } else {
+        toast(`Sync job ${d.sync_job_id || ''} complete · ${d.updated || 0} updated · ${d.merged || 0} merged · ${d.created || 0} created · ${d.skipped || 0} skipped`);
+        loadConversations();
+      }
     } else {
       toast((d && d.error) || 'Sync failed — check Google connection', true);
     }
   } catch (e) {
     toast('Sync request failed', true);
   } finally {
-    if (syncBtn) { syncBtn.disabled = false; syncBtn.textContent = 'Sync'; }
+    if (syncBtn) { syncBtn.disabled = false; syncBtn.textContent = 'Run sync'; }
+    if (previewBtn) { previewBtn.disabled = false; previewBtn.textContent = 'Preview changes'; }
     loadGoogleContactsStatus();
   loadLineSettings();
   refreshPushDiagnostics();

--- a/tests/test_pwa_communications_completion.py
+++ b/tests/test_pwa_communications_completion.py
@@ -536,3 +536,301 @@ def test_pwa_sound_forwarding_autoreply_static_requirements():
     assert "call_forwarding_enabled" in migration
     assert "business_hours_auto_reply_enabled" in migration
     assert "final_status" in migration
+
+
+def test_google_contacts_enriches_phone_only_contact_and_preserves_existing_tags(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import services.google_contacts as google_contacts
+
+    class DummyToken:
+        last_sync_at = None; contacts_synced = 0; sync_error = None
+
+    with app.app_context():
+        contact = Contact(company_id=ids["company"], phone="4155551212", normalized_phone="+14155551212", tags="MyOrder Customer", is_active=True)
+        db.session.add(contact); db.session.commit(); contact_id = contact.id
+        monkeypatch.setattr(google_contacts, "get_token", lambda user_id: DummyToken())
+        monkeypatch.setattr(google_contacts, "_refresh_if_needed", lambda token: "access")
+        monkeypatch.setattr(google_contacts, "_fetch_all_contacts", lambda access: {
+            "+14155551212": {"resource_name": "people/g1", "name": "Jane Doe", "first_name": "Jane", "last_name": "Doe", "email": "jane@example.com", "phone": "+14155551212", "normalized_phone": "+14155551212", "company": "Acme"}
+        })
+        result = google_contacts.sync_contacts(ids["staff"], ids["company"])
+        enriched = db.session.get(Contact, contact_id)
+        assert result["updated"] == 1
+        assert enriched.first_name == "Jane"
+        assert enriched.last_name == "Doe"
+        assert enriched.email == "jane@example.com"
+        assert enriched.company == "Acme"
+        assert enriched.source == "google_contacts"
+        assert enriched.source_detail == "Google Contacts sync"
+        assert enriched.external_google_contact_id == "people/g1"
+        assert "MyOrder Customer" in enriched.tags and "Google Contact" in enriched.tags
+
+
+def test_google_contacts_enriches_email_only_contact_without_overwriting_existing_name(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import services.google_contacts as google_contacts
+
+    class DummyToken:
+        last_sync_at = None; contacts_synced = 0; sync_error = None
+
+    with app.app_context():
+        contact = Contact(company_id=ids["company"], email="person@example.com", first_name="Existing", name="Existing Name", is_active=True)
+        db.session.add(contact); db.session.commit(); contact_id = contact.id
+        monkeypatch.setattr(google_contacts, "get_token", lambda user_id: DummyToken())
+        monkeypatch.setattr(google_contacts, "_refresh_if_needed", lambda token: "access")
+        monkeypatch.setattr(google_contacts, "_fetch_all_contacts", lambda access: {
+            "+14155550000": {"resource_name": "people/g2", "name": "Google Name", "first_name": "Google", "last_name": "Name", "email": "person@example.com", "phone": "+14155550000", "normalized_phone": "+14155550000"}
+        })
+        google_contacts.sync_contacts(ids["staff"], ids["company"])
+        enriched = db.session.get(Contact, contact_id)
+        assert enriched.first_name == "Existing"
+        assert enriched.name == "Existing Name"
+        assert enriched.last_name == "Name"
+        assert enriched.phone == "+14155550000"
+
+
+def test_google_contacts_duplicate_merge_repoints_twilio_and_unions_tags(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import services.google_contacts as google_contacts
+
+    class DummyToken:
+        last_sync_at = None; contacts_synced = 0; sync_error = None
+
+    with app.app_context():
+        survivor = Contact(company_id=ids["company"], phone="+14155551212", is_active=True, tags="MyOrder Customer")
+        duplicate = Contact(company_id=ids["company"], phone="4155551212", email="jane@example.com", first_name="Jane", tags="VIP", is_active=True)
+        db.session.add_all([survivor, duplicate]); db.session.flush()
+        conv = TwilioConversation(company_id=ids["company"], phone_number_id=ids["line"], contact_id=duplicate.id, from_number="+14155551212", to_number="+15550001000", contact_name="4155551212")
+        db.session.add(conv); db.session.commit(); survivor_id = survivor.id; duplicate_id = duplicate.id; conv_id = conv.id
+        monkeypatch.setattr(google_contacts, "get_token", lambda user_id: DummyToken())
+        monkeypatch.setattr(google_contacts, "_refresh_if_needed", lambda token: "access")
+        monkeypatch.setattr(google_contacts, "_fetch_all_contacts", lambda access: {"+14155551212": {"name": "Jane Doe", "email": "jane@example.com", "phone": "+14155551212", "normalized_phone": "+14155551212"}})
+        result = google_contacts.sync_contacts(ids["staff"], ids["company"])
+        kept = db.session.get(Contact, survivor_id)
+        old = db.session.get(Contact, duplicate_id)
+        refreshed = db.session.get(TwilioConversation, conv_id)
+        assert result["merged"] == 1
+        assert old.is_active is False
+        assert refreshed.contact_id == survivor_id
+        assert kept.name == "Jane Doe"
+        assert "MyOrder Customer" in kept.tags and "VIP" in kept.tags and "Google Contact" in kept.tags
+
+
+def test_google_contacts_cross_company_contacts_do_not_merge_and_preview_counts(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import services.google_contacts as google_contacts
+
+    class DummyToken:
+        last_sync_at = None; contacts_synced = 0; sync_error = None
+
+    with app.app_context():
+        other = Company(name="Other Co", is_active=True); db.session.add(other); db.session.flush()
+        db.session.add(Contact(company_id=other.id, phone="+14155551212", first_name="Other", is_active=True))
+        local = Contact(company_id=ids["company"], phone="+14155551212", is_active=True)
+        db.session.add(local); db.session.commit(); local_id = local.id; other_id = other.id
+        monkeypatch.setattr(google_contacts, "get_token", lambda user_id: DummyToken())
+        monkeypatch.setattr(google_contacts, "_refresh_if_needed", lambda token: "access")
+        monkeypatch.setattr(google_contacts, "_fetch_all_contacts", lambda access: {"+14155551212": "Jane Doe", "+14155559999": "New Person"})
+        preview = google_contacts.sync_contacts(ids["staff"], ids["company"], dry_run=True)
+        assert preview["updated"] == 1
+        assert preview["merged"] == 0
+        assert preview["created"] == 1
+        assert db.session.get(Contact, local_id).name is None
+        assert Contact.query.filter_by(company_id=other_id, is_active=True).count() == 1
+
+
+def test_google_contacts_status_reports_expired_token_reconnect_required(pwa_app):
+    app, client, ids = pwa_app
+    from datetime import datetime, timedelta
+    from models import GoogleOAuthToken
+    with app.app_context():
+        db.session.add(GoogleOAuthToken(user_id=ids["staff"], access_token="old", refresh_token=None, token_expiry=datetime.utcnow() - timedelta(hours=1)))
+        db.session.commit()
+    login(client, ids["staff"])
+    resp = client.get("/api/inbox/google-contacts/status")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["reconnect_required"] is True
+    assert data["oauth_expired"] is True
+
+
+def test_google_contacts_sync_job_and_merge_audit_records_created(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import services.google_contacts as google_contacts
+    from models import ContactMergeAudit, GoogleContactsSyncJob
+
+    class DummyToken:
+        last_sync_at = None; contacts_synced = 0; sync_error = None; google_sync_token = None; google_account_email = "owner@example.com"
+
+    with app.app_context():
+        survivor = Contact(company_id=ids["company"], phone="+14155551212", normalized_phone="+14155551212", tags="MyOrder Customer", is_active=True)
+        duplicate = Contact(company_id=ids["company"], phone="4155551212", email="audit@example.com", tags="VIP", is_active=True)
+        db.session.add_all([survivor, duplicate]); db.session.flush()
+        conv = TwilioConversation(company_id=ids["company"], phone_number_id=ids["line"], contact_id=duplicate.id, from_number="+14155551212", to_number="+15550001000")
+        db.session.add(conv); db.session.commit(); survivor_id = survivor.id; duplicate_id = duplicate.id; conv_id = conv.id
+        monkeypatch.setattr(google_contacts, "get_token", lambda user_id: DummyToken())
+        monkeypatch.setattr(google_contacts, "_refresh_if_needed", lambda token: "access")
+        monkeypatch.setattr(google_contacts, "_fetch_all_contacts", lambda access: {"+14155551212": {"resource_name": "people/audit", "name": "Audit Person", "email": "audit@example.com", "phone": "+14155551212", "normalized_phone": "+14155551212"}})
+        result = google_contacts.sync_contacts(ids["staff"], ids["company"])
+        job = db.session.get(GoogleContactsSyncJob, result["sync_job_id"])
+        audit = ContactMergeAudit.query.filter_by(sync_job_id=job.id, source_contact_id=duplicate_id, destination_contact_id=survivor_id).one()
+        assert job.status == "completed"
+        assert job.google_account_email == "owner@example.com"
+        assert job.contacts_merged == 1
+        assert audit.google_resource_id == "people/audit"
+        assert audit.phone_match is True
+        assert audit.match_confidence >= 95
+        assert audit.reference_mappings[0]["to_contact_id"] == survivor_id
+        assert db.session.get(TwilioConversation, conv_id).contact_id == survivor_id
+
+
+def test_google_contacts_low_confidence_email_merge_requires_review(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import services.google_contacts as google_contacts
+    from models import ContactMergeAudit
+
+    class DummyToken:
+        last_sync_at = None; contacts_synced = 0; sync_error = None; google_sync_token = None
+
+    with app.app_context():
+        survivor = Contact(company_id=ids["company"], phone="+14155551212", normalized_phone="+14155551212", is_active=True)
+        contact = Contact(company_id=ids["company"], email="Case@Test.COM", first_name="Case", is_active=True)
+        db.session.add_all([survivor, contact]); db.session.commit(); contact_id = contact.id
+        monkeypatch.setenv("GOOGLE_CONTACTS_AUTO_MERGE_THRESHOLD", "80")
+        monkeypatch.setattr(google_contacts, "get_token", lambda user_id: DummyToken())
+        monkeypatch.setattr(google_contacts, "_refresh_if_needed", lambda token: "access")
+        monkeypatch.setattr(google_contacts, "_fetch_all_contacts", lambda access: {"+14155551212": {"resource_name": "people/email", "name": "Case Email", "email": " case@test.com ", "phone": "+14155551212", "normalized_phone": "+14155551212"}})
+        result = google_contacts.sync_contacts(ids["staff"], ids["company"], dry_run=True)
+        assert result["preview"]["will_update"]
+        assert result["preview"]["possible_merge_requires_review"]
+        assert result["preview"]["possible_merge_requires_review"][0]["confidence"] == 75
+        assert db.session.get(Contact, contact_id).last_name is None
+        assert ContactMergeAudit.query.count() == 0
+
+
+def test_google_contacts_preview_payload_and_dry_run_do_not_modify_database(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import services.google_contacts as google_contacts
+    from models import GoogleContactsSyncJob
+
+    class DummyToken:
+        last_sync_at = None; contacts_synced = 0; sync_error = None; google_sync_token = None
+
+    with app.app_context():
+        contact = Contact(company_id=ids["company"], phone="(415) 555-1212 x99", is_active=True)
+        db.session.add(contact); db.session.commit(); contact_id = contact.id
+        monkeypatch.setattr(google_contacts, "get_token", lambda user_id: DummyToken())
+        monkeypatch.setattr(google_contacts, "_refresh_if_needed", lambda token: "access")
+        monkeypatch.setattr(google_contacts, "_fetch_all_contacts", lambda access: {"+14155551212": "Dry Run"})
+        result = google_contacts.sync_contacts(ids["staff"], ids["company"], dry_run=True)
+        unchanged = db.session.get(Contact, contact_id)
+        job = db.session.get(GoogleContactsSyncJob, result["sync_job_id"])
+        assert result["preview"]["will_update"][0]["fields_to_update"]
+        assert unchanged.name is None
+        assert unchanged.normalized_phone is None
+        assert job.dry_run is True and job.preview_payload["will_update"]
+
+
+def test_google_contacts_incremental_sync_token_and_avatar_metadata_refresh(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import services.google_contacts as google_contacts
+    from models import GoogleOAuthToken
+
+    with app.app_context():
+        tok = GoogleOAuthToken(user_id=ids["staff"], access_token="tok", refresh_token="ref", google_sync_token="sync-1")
+        db.session.add(tok); db.session.commit(); seen = {}
+        monkeypatch.setattr(google_contacts, "get_token", lambda user_id: tok)
+        monkeypatch.setattr(google_contacts, "_refresh_if_needed", lambda token: "access")
+        def fake_fetch(access, sync_token=None):
+            seen["sync_token"] = sync_token
+            return {"+14155550101": {"resource_name": "people/avatar", "name": "Avatar Person", "phone": "+14155550101", "normalized_phone": "+14155550101", "avatar_url": "https://lh3.googleusercontent.com/a/photo"}, "__meta__": {"next_sync_token": "sync-2", "incremental": bool(sync_token)}}
+        monkeypatch.setattr(google_contacts, "_fetch_all_contacts", fake_fetch)
+        result = google_contacts.sync_contacts(ids["staff"], ids["company"])
+        contact = Contact.query.filter_by(company_id=ids["company"], external_google_contact_id="people/avatar").one()
+        assert seen["sync_token"] == "sync-1"
+        assert result["incremental"] is True
+        assert tok.google_sync_token == "sync-2"
+        assert contact.avatar_url == "https://lh3.googleusercontent.com/a/photo"
+
+
+def test_google_contact_normalization_handles_phone_and_email_variants():
+    from services.google_contacts import normalize_email, normalize_phone
+    assert normalize_phone("001 44 7911 123456 ext. 9") == "+447911123456"
+    assert normalize_phone("(415) 555-1212 x123") == "+14155551212"
+    assert normalize_phone("+1 415-555-1212") == "+14155551212"
+    assert normalize_email("  CASE@Example.COM ") == "case@example.com"
+
+
+def test_google_contacts_default_phone_only_duplicate_requires_review(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import services.google_contacts as google_contacts
+    from models import ContactMergeAudit
+
+    class DummyToken:
+        last_sync_at = None; contacts_synced = 0; sync_error = None; google_sync_token = None
+
+    with app.app_context():
+        survivor = Contact(company_id=ids["company"], phone="+14155551212", normalized_phone="+14155551212", is_active=True)
+        duplicate = Contact(company_id=ids["company"], phone="4155551212", tags="VIP", is_active=True)
+        db.session.add_all([survivor, duplicate]); db.session.commit(); duplicate_id = duplicate.id
+        monkeypatch.delenv("GOOGLE_CONTACTS_AUTO_MERGE_THRESHOLD", raising=False)
+        monkeypatch.setattr(google_contacts, "get_token", lambda user_id: DummyToken())
+        monkeypatch.setattr(google_contacts, "_refresh_if_needed", lambda token: "access")
+        monkeypatch.setattr(google_contacts, "_fetch_all_contacts", lambda access: {"+14155551212": "Phone Only"})
+        result = google_contacts.sync_contacts(ids["staff"], ids["company"])
+        assert result["merged"] == 0
+        assert result["review_required"] is True
+        assert result["preview"]["possible_merge_requires_review"][0]["confidence"] == 70
+        assert db.session.get(Contact, duplicate_id).is_active is True
+        assert ContactMergeAudit.query.count() == 0
+
+
+def test_google_contacts_merge_repointing_is_company_scoped(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import services.google_contacts as google_contacts
+
+    class DummyToken:
+        last_sync_at = None; contacts_synced = 0; sync_error = None; google_sync_token = None
+
+    with app.app_context():
+        other = Company(name="Scoped Other", is_active=True); db.session.add(other); db.session.flush()
+        survivor = Contact(company_id=ids["company"], phone="+14155551212", normalized_phone="+14155551212", is_active=True)
+        duplicate = Contact(company_id=ids["company"], phone="4155551212", email="scope@example.com", is_active=True)
+        db.session.add_all([survivor, duplicate]); db.session.flush()
+        same_company_call = TwilioCallLog(company_id=ids["company"], contact_id=duplicate.id, twilio_sid="CAsame", direction="inbound", from_number="+14155551212", to_number="+15550001000")
+        other_company_call = TwilioCallLog(company_id=other.id, contact_id=duplicate.id, twilio_sid="CAother", direction="inbound", from_number="+14155551212", to_number="+15550001000")
+        db.session.add_all([same_company_call, other_company_call]); db.session.commit()
+        survivor_id = survivor.id; duplicate_id = duplicate.id; same_id = same_company_call.id; other_id = other_company_call.id
+        monkeypatch.setattr(google_contacts, "get_token", lambda user_id: DummyToken())
+        monkeypatch.setattr(google_contacts, "_refresh_if_needed", lambda token: "access")
+        monkeypatch.setattr(google_contacts, "_fetch_all_contacts", lambda access: {"+14155551212": {"name": "Scoped", "email": "scope@example.com", "phone": "+14155551212", "normalized_phone": "+14155551212"}})
+        result = google_contacts.sync_contacts(ids["staff"], ids["company"])
+        assert result["merged"] == 1
+        assert db.session.get(TwilioCallLog, same_id).contact_id == survivor_id
+        assert db.session.get(TwilioCallLog, other_id).contact_id == duplicate_id
+
+
+def test_google_contacts_preview_payload_is_bounded_and_token_metadata_unchanged_on_dry_run(pwa_app, monkeypatch):
+    app, _client, ids = pwa_app
+    import services.google_contacts as google_contacts
+    from models import GoogleContactsSyncJob, GoogleOAuthToken
+
+    with app.app_context():
+        tok = GoogleOAuthToken(user_id=ids["staff"], access_token="secret-access", refresh_token="secret-refresh", contacts_synced=99, google_sync_token="sync-old")
+        db.session.add(tok); db.session.commit()
+        monkeypatch.setenv("GOOGLE_CONTACTS_PREVIEW_LIMIT", "2")
+        monkeypatch.setattr(google_contacts, "get_token", lambda user_id: tok)
+        monkeypatch.setattr(google_contacts, "_refresh_if_needed", lambda token: "access")
+        monkeypatch.setattr(google_contacts, "_fetch_all_contacts", lambda access, sync_token=None: {
+            f"+14155550{i:03d}": {"name": f"Person {i}", "phone": f"+14155550{i:03d}", "normalized_phone": f"+14155550{i:03d}"}
+            for i in range(5)
+        })
+        result = google_contacts.sync_contacts(ids["staff"], ids["company"], dry_run=True)
+        job = db.session.get(GoogleContactsSyncJob, result["sync_job_id"])
+        assert len(result["preview"]["will_create"]) == 2
+        assert result["preview"]["omitted_counts"]["will_create"] == 3
+        assert job.dry_run is True
+        assert tok.contacts_synced == 99
+        assert tok.google_sync_token == "sync-old"
+        serialized = str(result) + str(job.preview_payload) + str(job.errors or [])
+        assert "secret-access" not in serialized and "secret-refresh" not in serialized

--- a/twilio_sms.py
+++ b/twilio_sms.py
@@ -3011,7 +3011,8 @@ def google_contacts_sync():
     from flask_login import current_user
     from services.google_contacts import sync_contacts
     company = _get_company()
-    result  = sync_contacts(current_user.id, company.id)
+    dry_run = request.args.get("dry_run") in {"1", "true", "yes"} or bool((request.get_json(silent=True) or {}).get("dry_run"))
+    result  = sync_contacts(current_user.id, company.id, dry_run=dry_run)
     return jsonify(result)
 
 
@@ -3035,6 +3036,14 @@ def google_contacts_status():
         "oauth_expired":   token_needs_reconnect(tok),
         "last_sync_at":    tok.last_sync_at.strftime("%b %-d %H:%M") if tok.last_sync_at else None,
         "contacts_synced": tok.contacts_synced or 0,
+        "contacts_created": getattr(tok, "contacts_created", 0) or 0,
+        "contacts_updated": getattr(tok, "contacts_updated", 0) or 0,
+        "contacts_merged": getattr(tok, "contacts_merged", 0) or 0,
+        "contacts_skipped": getattr(tok, "contacts_skipped", 0) or 0,
+        "last_successful_sync_at": tok.last_successful_sync_at.strftime("%b %-d %H:%M") if getattr(tok, "last_successful_sync_at", None) else None,
+        "last_sync_duration_ms": getattr(tok, "last_sync_duration_ms", None),
+        "sync_status": getattr(tok, "last_sync_status", None),
+        "google_account_email": getattr(tok, "google_account_email", None),
         "sync_error":      getattr(tok, "sync_error", None),
         "reconnect_required": token_needs_reconnect(tok),
     })


### PR DESCRIPTION
### Motivation

- Add robust Google Contacts sync/enrich workflow that can preview changes before applying them and provide an audit trail for merges.  
- Persist richer metadata about Google syncs and contacts to support metrics, incremental syncs, avatar refreshes, and better name resolution.  
- Surface sync status and controls in the PWA and server APIs, and allow manual dry-run previews from UI and endpoints.  

### Description

- Database/schema updates: added `external_google_contact_id`, `avatar_url`, and `updated_at` to `contact`, added same contact fields to `demo_request`, extended `google_oauth_token` with sync metrics and metadata, and introduced `google_contacts_sync_job` and `contact_merge_audit` tables in models and `app.py` migrations.  
- Core sync logic: rewrote `services/google_contacts.py` to normalize phones/emails more robustly, fetch emails/photos/orgs, support incremental `sync_token`, return richer contact data, support `dry_run` previews, create `GoogleContactsSyncJob` records, and perform safe merges with confidence scoring and `ContactMergeAudit` recording.  
- API & UI: added dry-run support to PWA and server endpoints (`/api/inbox/google-contacts/sync`, `/google-contacts/sync`) and extended status endpoints to include created/updated/merged/skipped counts, last successful sync time, duration, status, and account email; updated the PWA settings sheet to show preview/run buttons and metrics.  
- Misc: added helper functions `_merge_confidence`, `_tag_union`, `_apply_google_to_contact`, preview helpers, and adjustments to contact lookup/merge behavior to be company-scoped and non-destructive on preview.  

### Testing

- Ran the PWA communications test module `tests/test_pwa_communications_completion.py` which includes many new tests for sync preview, enrichment, merging, incremental tokens, normalization, and audit records, and all assertions in that file passed.  
- Executed unit-level tests that exercise `services.google_contacts` flows (normalization, fetch, dry-run preview, merge logic, incremental token handling) and they succeeded.  
- Verified server API surface by exercising `/api/inbox/google-contacts/status` and `/api/inbox/google-contacts/sync` via the new tests, which validated extended status fields and preview behavior.  
- Ensured no OAuth secrets are serialized into preview/job payloads by checking serialized job/preview strings in tests, and that check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4effbf826c83228708993b5b7194b9)