### PR TITLE
Add push receipt acknowledgements, improved push diagnostics and idempotent subscription handling

### DIFF
--- a/inbox_pwa.py
+++ b/inbox_pwa.py
@@ -587,7 +587,7 @@ def pwa_index():
         os.environ.get("LUXIT_ASSET_VERSION")
         or os.environ.get("GIT_SHA")
         or os.environ.get("RENDER_GIT_COMMIT")
-        or "20260709-push-subscription-repair-diagnostics"
+        or "20260710-push-receipt-ack"
     )
     return render_template(
         "inbox_pwa/index.html",
@@ -617,7 +617,7 @@ def pwa_calls():
         os.environ.get("LUXIT_ASSET_VERSION")
         or os.environ.get("GIT_SHA")
         or os.environ.get("RENDER_GIT_COMMIT")
-        or "20260709-push-subscription-repair-diagnostics"
+        or "20260710-push-receipt-ack"
     )
     return render_template("inbox_pwa/calls.html", user=user, company=company, pwa_version=pwa_version)
 
@@ -2271,6 +2271,54 @@ def pwa_notifications_read():
     db.session.commit()
     return jsonify({"success": True, "updated": updated})
 
+
+def _redact_push_endpoint(endpoint: str) -> dict:
+    endpoint = endpoint or ""
+    if not endpoint:
+        return {"endpoint_host": "", "endpoint_tail": "", "endpoint_redacted": None}
+    try:
+        parsed = urlparse(endpoint)
+        return {
+            "endpoint_host": parsed.netloc,
+            "endpoint_tail": endpoint[-18:],
+            "endpoint_redacted": f"{parsed.scheme}://{parsed.netloc}/…{endpoint[-18:]}" if parsed.scheme and parsed.netloc else f"…{endpoint[-18:]}",
+        }
+    except Exception:
+        return {"endpoint_host": "", "endpoint_tail": endpoint[-18:], "endpoint_redacted": f"…{endpoint[-18:]}"}
+
+
+def _recent_push_receipts(company_id: int, user_id: int, device_key: str = "", limit: int = 10):
+    from models import MarketingAuditLog
+    rows = MarketingAuditLog.query.filter_by(
+        company_id=company_id,
+        created_by_user_id=user_id,
+        entity_type="pwa_push_receipt",
+    ).order_by(MarketingAuditLog.created_at.desc(), MarketingAuditLog.id.desc()).limit(50).all()
+    receipts = []
+    for row in rows:
+        details = row.details or {}
+        if device_key and details.get("device_key") and details.get("device_key") != device_key:
+            continue
+        receipts.append({
+            "stage": details.get("stage"),
+            "received_at": details.get("received_at"),
+            "server_received_at": row.created_at.isoformat() if row.created_at else None,
+            "sw_version": details.get("sw_version"),
+            "event_type": details.get("event_type"),
+            "tag": details.get("tag"),
+            "silent": details.get("silent"),
+            "renotify": details.get("renotify"),
+            "vibrate": details.get("vibrate"),
+            "requireInteraction": details.get("requireInteraction"),
+            "endpoint_host": details.get("endpoint_host"),
+            "endpoint_tail": details.get("endpoint_tail"),
+            "endpoint_redacted": details.get("endpoint_redacted"),
+            "error": details.get("error"),
+        })
+        if len(receipts) >= limit:
+            break
+    return receipts
+
 def _web_push_missing_settings():
     return [key for key in ("VAPID_PUBLIC_KEY", "VAPID_PRIVATE_KEY", "VAPID_SUBJECT") if not os.environ.get(key)]
 
@@ -2383,7 +2431,7 @@ def send_pwa_push_notification(company_id: int, *, user_ids, title: str, body: s
             "event_type": decision["event_type"], "silent": payload["silent"], "sound": payload["sound"],
             "vibrate": payload["vibrate"], "renotify": payload["renotify"], "tag": payload["tag"],
             "badgeCount": badge_count, "channel": payload["channelId"], "importance": payload["importance"],
-            "sw_version": os.environ.get("LUXIT_ASSET_VERSION") or os.environ.get("GIT_SHA") or os.environ.get("RENDER_GIT_COMMIT") or "20260709-push-subscription-repair-diagnostics",
+            "sw_version": os.environ.get("LUXIT_ASSET_VERSION") or os.environ.get("GIT_SHA") or os.environ.get("RENDER_GIT_COMMIT") or "20260710-push-receipt-ack",
             "push_provider_result": result,
         })
         total += result.get("sent", 0)
@@ -2432,7 +2480,7 @@ def pwa_push_debug():
         "vapid_configured": not missing,
         "vapid_public_key_present": bool(os.environ.get("VAPID_PUBLIC_KEY")),
         "vapid_missing": missing,
-        "service_worker_version": os.environ.get("LUXIT_ASSET_VERSION") or os.environ.get("GIT_SHA") or os.environ.get("RENDER_GIT_COMMIT") or "20260709-push-subscription-repair-diagnostics",
+        "service_worker_version": os.environ.get("LUXIT_ASSET_VERSION") or os.environ.get("GIT_SHA") or os.environ.get("RENDER_GIT_COMMIT") or "20260710-push-receipt-ack",
         "decision": decision,
         "device_instructions": [
             "Android: Chrome/LUXit PWA notification channel cannot be Silent or Low Importance.",
@@ -2440,19 +2488,79 @@ def pwa_push_debug():
             "iPhone: install to Home Screen, then enable Settings > Notifications > LUXit > Sounds.",
             "Disable Focus / Do Not Disturb during notification sound tests.",
         ],
+        "push_receipts": _recent_push_receipts(company.id, user.id, device_key),
+        "latest_push_receipt": (_recent_push_receipts(company.id, user.id, device_key, limit=1) or [None])[0],
         "subscriptions": [{
             "id": sub.id,
             "device_key": sub.device_key,
-            "endpoint_host": (sub.endpoint or "").split("/")[2] if "/" in (sub.endpoint or "") else "",
-            "endpoint_tail": (sub.endpoint or "")[-18:],
+            **_redact_push_endpoint(sub.endpoint),
             "is_active": sub.is_active,
+            "created_at": sub.created_at.isoformat() if sub.created_at else None,
             "updated_at": sub.updated_at.isoformat() if sub.updated_at else None,
+            "last_successful_registration_attempt_at": sub.updated_at.isoformat() if sub.updated_at else None,
         } for sub in subscriptions],
         "user": {"id": user.id, "email": user.email, "username": user.username},
         "company": {"id": company.id, "name": company.name},
         "mobile_inbox_access": True,
     })
 
+
+
+@inbox_pwa_bp.route("/api/pwa/push/receipt", methods=["POST"])
+def pwa_push_receipt():
+    """Service-worker acknowledgement that a push was received/displayed on-device."""
+    user = _require_auth()
+    company = _get_company(user)
+    if not company:
+        return jsonify({"success": False, "error": "No company"}), 400
+    denied = _require_mobile_inbox_api_access(user, company)
+    if denied:
+        return denied
+
+    payload = request.get_json(silent=True) or {}
+    stage = (payload.get("stage") or "received").strip()[:40]
+    subscription = payload.get("subscription") or {}
+    endpoint = subscription.get("endpoint") or payload.get("endpoint") or ""
+    redacted = _redact_push_endpoint(endpoint)
+    # Prefer the already-redacted SW summary when the full endpoint is intentionally omitted.
+    if not endpoint:
+        redacted = {
+            "endpoint_host": subscription.get("endpoint_host", ""),
+            "endpoint_tail": subscription.get("endpoint_tail", ""),
+            "endpoint_redacted": subscription.get("endpoint_redacted"),
+        }
+
+    from models import MarketingAuditLog, PushSubscription
+    device_key = (payload.get("device_key") or request.headers.get("X-PWA-Device-Key") or "").strip()
+    if endpoint:
+        sub = PushSubscription.query.filter_by(company_id=company.id, user_id=user.id, endpoint=endpoint, is_active=True).first()
+        if sub:
+            device_key = device_key or (sub.device_key or "")
+
+    details = {
+        "stage": stage,
+        "received_at": payload.get("received_at"),
+        "sw_version": payload.get("sw_version"),
+        "event_type": payload.get("event_type"),
+        "tag": payload.get("tag"),
+        "silent": payload.get("silent"),
+        "renotify": payload.get("renotify"),
+        "vibrate": payload.get("vibrate"),
+        "requireInteraction": payload.get("requireInteraction"),
+        "error": payload.get("error"),
+        "device_key": device_key,
+        **redacted,
+    }
+    db.session.add(MarketingAuditLog(
+        company_id=company.id,
+        created_by_user_id=user.id,
+        entity_type="pwa_push_receipt",
+        action=stage,
+        details=details,
+    ))
+    db.session.commit()
+    logger.info("PWA push receipt", extra={"user_id": user.id, "company_id": company.id, "stage": stage, **redacted})
+    return jsonify({"success": True, "stage": stage, "device_key": device_key, **redacted})
 
 # ── API: Push notification subscribe ─────────────────────────────────────────
 
@@ -2537,7 +2645,10 @@ def push_subscribe():
     return jsonify({
         "success": True,
         "device_key": device_key,
+        "subscription_id": sub.id,
         "endpoint_saved": True,
+        "database_record_created": True,
+        "last_successful_registration_attempt_at": sub.updated_at.isoformat() if sub.updated_at else None,
         "active_subscription": active_subscriptions > 0,
         "active_subscriptions": active_subscriptions,
         "device_active_subscription": device_active_subscriptions > 0,
@@ -2583,10 +2694,25 @@ def push_test():
     from models import PushSubscription
     subs = PushSubscription.query.filter_by(user_id=user.id, company_id=company.id, is_active=True).all()
     if not subs:
-        return jsonify({"success": False, "error": "No push subscription found. Enable notifications first."})
+        return jsonify({
+            "success": False,
+            "backend_persisted": False,
+            "provider_accepted": False,
+            "service_worker_receipt_confirmed": False,
+            "notification_display_confirmed": False,
+            "error": "No push subscription found. Enable notifications first.",
+        })
 
     if not _web_push_configured():
-        return jsonify({"success": False, "configured": False, "error": "Web push is not configured. Set VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY, and VAPID_SUBJECT."})
+        return jsonify({
+            "success": False,
+            "configured": False,
+            "backend_persisted": True,
+            "provider_accepted": False,
+            "service_worker_receipt_confirmed": False,
+            "notification_display_confirmed": False,
+            "error": "Web push is not configured. Set VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY, and VAPID_SUBJECT.",
+        })
 
     result = _send_web_push_to_subscriptions(subs, {
         "title": "LUXit Inbox",
@@ -2606,8 +2732,24 @@ def push_test():
     errors = result["errors"]
 
     if sent:
-        return jsonify({"success": True, "sent": sent})
-    return jsonify({"success": False, "error": errors[0] if errors else "Unknown error"})
+        return jsonify({
+            "success": True,
+            "sent": sent,
+            "backend_persisted": True,
+            "provider_accepted": True,
+            "service_worker_receipt_confirmed": False,
+            "notification_display_confirmed": False,
+            "delivery_note": "Push provider accepted the test notification. Confirm service-worker receipt via lastPushReceivedAt in client diagnostics.",
+        })
+    return jsonify({
+        "success": False,
+        "sent": sent,
+        "backend_persisted": True,
+        "provider_accepted": False,
+        "service_worker_receipt_confirmed": False,
+        "notification_display_confirmed": False,
+        "error": errors[0] if errors else "Unknown error",
+    })
 
 
 # ── SSE helpers ───────────────────────────────────────────────────────────────

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,5 +1,5 @@
 /* LUXit Inbox — Service Worker */
-const SW_VERSION = new URL(self.location.href).searchParams.get('v') || '20260709-push-subscription-repair-diagnostics';
+const SW_VERSION = new URL(self.location.href).searchParams.get('v') || '20260710-push-receipt-ack';
 const CACHE = `luxit-inbox-${SW_VERSION}`;
 const APP_SHELL = [
   '/app/inbox',
@@ -27,6 +27,47 @@ self.addEventListener('message', e => {
   }
   if (e.data && e.data.type === 'SKIP_WAITING') self.skipWaiting();
 });
+
+
+async function pushSubscriptionSummary() {
+  try {
+    const sub = await self.registration.pushManager.getSubscription();
+    if (!sub || !sub.endpoint) return {};
+    const url = new URL(sub.endpoint);
+    return {
+      endpoint: sub.endpoint,
+      endpoint_host: url.host,
+      endpoint_tail: sub.endpoint.slice(-18),
+      endpoint_redacted: `${url.origin}/…${sub.endpoint.slice(-18)}`,
+    };
+  } catch (e) {
+    return { subscription_error: `${e.name || 'Error'}: ${e.message || e}` };
+  }
+}
+
+async function ackPushReceipt(stage, payload, options, error) {
+  try {
+    const subscription = await pushSubscriptionSummary();
+    await fetch('/api/pwa/push/receipt', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        stage,
+        received_at: new Date().toISOString(),
+        sw_version: SW_VERSION,
+        event_type: payload.eventType || (payload.data && payload.data.event_type) || null,
+        tag: options && options.tag,
+        silent: options && options.silent === true,
+        renotify: options && options.renotify === true,
+        vibrate: options && options.vibrate,
+        requireInteraction: options && options.requireInteraction === true,
+        error: error ? `${error.name || 'Error'}: ${error.message || error}` : null,
+        subscription,
+      }),
+    });
+  } catch (_) {}
+}
 
 async function storePushDebug(payload, options) {
   const debug = {
@@ -100,13 +141,17 @@ self.addEventListener('push', e => {
   if (notificationOptions.renotify && !notificationOptions.tag) {
     notificationOptions.tag = `luxit-${Date.now()}`;
   }
-  e.waitUntil(
-    Promise.all([
-      updateBadge(),
-      storePushDebug(data, notificationOptions),
-      self.registration.showNotification(data.title, notificationOptions)
-    ])
-  );
+  e.waitUntil((async () => {
+    await ackPushReceipt('received', data, notificationOptions);
+    await Promise.all([updateBadge(), storePushDebug(data, notificationOptions)]);
+    try {
+      await self.registration.showNotification(data.title, notificationOptions);
+      await ackPushReceipt('displayed', data, notificationOptions);
+    } catch (err) {
+      await ackPushReceipt('display_failed', data, notificationOptions, err);
+      throw err;
+    }
+  })());
 });
 
 self.addEventListener('notificationclick', e => {

--- a/templates/inbox_pwa/index.html
+++ b/templates/inbox_pwa/index.html
@@ -945,7 +945,7 @@
       <pre id="pushDiagnostics" style="white-space:pre-wrap;font-size:.72rem;background:#05070c;border:1px solid var(--border);border-radius:10px;padding:10px;color:var(--text);max-height:220px;overflow:auto;">Loading…</pre>
       <div style="display:flex;gap:6px;flex-wrap:wrap;">
         <button class="btn-small" onclick="refreshPushDiagnostics()">Refresh diagnostics</button>
-        <button id="repairPushBtn" class="btn-small" onclick="repairPushNotifications()" style="display:none;">Repair Push Notifications</button>
+        <button id="repairPushBtn" class="btn-small" onclick="repairPushNotifications()" style="display:none;">Repair Push Subscription</button>
       </div>
       <small id="pushRepairReason" style="color:var(--muted);"></small>
       <small style="color:var(--muted);">If this shows silent:false, remaining sound issues are OS/browser notification-channel settings.</small>
@@ -1250,11 +1250,65 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 /* ── Service Worker ───────────────────────────────────────────── */
-function registerSW() {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register(`/static/sw.js?v=${encodeURIComponent(PWA_VERSION)}`).then(reg => {
-      reg.update().catch(() => {});
-    }).catch(e => console.warn('SW:', e));
+function pushRegistrationState() {
+  try { return JSON.parse(localStorage.getItem('luxitPushRegistrationState') || '{}'); } catch (_) { return {}; }
+}
+function setPushRegistrationState(stage, patch={}) {
+  const next = Object.assign(pushRegistrationState(), patch, {
+    lastStage: stage,
+    lastStageAt: new Date().toISOString(),
+    installedPwa: isInstalledPwa(),
+    displayMode: pwaDisplayMode(),
+  });
+  localStorage.setItem('luxitPushRegistrationState', JSON.stringify(next));
+  console.info('[push-registration]', stage, next);
+  refreshPushDiagnostics().catch(() => {});
+  return next;
+}
+function setPushRegistrationFailure(stage, error) {
+  const failure = {
+    failureStage: stage,
+    failureAt: new Date().toISOString(),
+    failureName: error?.name || 'Error',
+    failureMessage: error?.message || String(error),
+  };
+  setPushRegistrationState(stage, failure);
+}
+function setPushRegistrationSuccess(stage, patch={}) {
+  return setPushRegistrationState(stage, Object.assign({
+    lastSuccessfulRegistrationAt: new Date().toISOString(),
+    failureStage: null,
+    failureAt: null,
+    failureName: null,
+    failureMessage: null,
+  }, patch));
+}
+function pwaDisplayMode() {
+  if (window.matchMedia?.('(display-mode: standalone)').matches || window.navigator.standalone === true) return 'standalone';
+  if (window.matchMedia?.('(display-mode: fullscreen)').matches) return 'fullscreen';
+  if (window.matchMedia?.('(display-mode: minimal-ui)').matches) return 'minimal-ui';
+  return 'browser-tab';
+}
+function isInstalledPwa() { return pwaDisplayMode() !== 'browser-tab'; }
+function redactEndpoint(endpoint='') {
+  if (!endpoint) return null;
+  try { const u = new URL(endpoint); return `${u.origin}/…${u.pathname.slice(-18)}`; } catch (_) { return `…${endpoint.slice(-24)}`; }
+}
+async function registerSW() {
+  if (!('serviceWorker' in navigator)) {
+    setPushRegistrationFailure('service-worker-unsupported', new Error('This browser does not support service workers.'));
+    return null;
+  }
+  setPushRegistrationState('service-worker-registering');
+  try {
+    const reg = await navigator.serviceWorker.register(`/static/sw.js?v=${encodeURIComponent(PWA_VERSION)}`);
+    setPushRegistrationState('service-worker-registered', { serviceWorkerScope: reg.scope });
+    reg.update().then(() => setPushRegistrationState('service-worker-updated')).catch(e => setPushRegistrationFailure('service-worker-update-failed', e));
+    return reg;
+  } catch (e) {
+    console.warn('SW:', e);
+    setPushRegistrationFailure('service-worker-register-failed', e);
+    return null;
   }
 }
 
@@ -1332,30 +1386,100 @@ function checkNotifPrompt() {
   }
 }
 
-async function requestPush() {
-  let vapidPublic;
-  try {
-    vapidPublic = await currentVapidPublicKey();
-  } catch (e) {
-    toast(e.message, 'error');
-    return;
+async function persistAndVerifyPushSubscription(sub, {sendTest=false}={}) {
+  const subscription = sub.toJSON();
+  subscription.device_key = pwaDeviceKey();
+  subscription.device_label = localStorage.getItem('luxitPwaDeviceName') || `${browserLabel()} ${deviceTypeLabel()}`;
+  setPushRegistrationState('backend-save-subscription', { endpoint: redactEndpoint(subscription.endpoint) });
+  const saved = await apiFetch('/api/push/subscribe', 'POST', subscription);
+  if (!saved?.success) throw new Error(saved?.error || 'Backend did not save the subscription.');
+  setPushRegistrationState('backend-save-complete', { backendPersisted: true, subscriptionId: saved.subscription_id, endpoint: redactEndpoint(subscription.endpoint) });
+  setPushRegistrationState('backend-reread-subscriptions');
+  const verify = await apiFetch(`/api/pwa/push/debug?device_key=${encodeURIComponent(subscription.device_key)}`);
+  if (!verify?.success) throw new Error(verify?.error || 'Backend subscription verification failed.');
+  if (Number(verify.active_subscriptions || 0) < 1 || Number(verify.device_active_subscriptions || 0) < 1) {
+    throw new Error('Backend save succeeded, but verification did not find an active subscription for this device.');
   }
-  const perm = await Notification.requestPermission();
-  if (perm !== 'granted') { toast('Notification permission denied.', 'error'); return; }
-  document.getElementById('notifBanner').classList.remove('show');
+  let test = null;
+  if (sendTest) {
+    setPushRegistrationState('send-test-push');
+    test = await apiFetch('/api/push/test', 'POST', {});
+    setPushRegistrationState('test-push-provider-result', { testPush: test });
+    if (!test?.success) throw new Error(test?.error || 'Test push provider did not accept the notification.');
+  }
+  setPushRegistrationSuccess('registration-verified', {
+    backendPersisted: true,
+    providerAccepted: !!test?.provider_accepted,
+    deliveryConfirmedByServiceWorker: false,
+    serviceWorkerReceiptRequired: !!sendTest,
+    activeSubscriptions: verify.active_subscriptions || 0,
+    deviceActiveSubscriptions: verify.device_active_subscriptions || 0,
+    endpoint: redactEndpoint(subscription.endpoint),
+  });
+  return {saved, verify, test};
+}
+async function ensurePushSubscription({forceFresh=false, sendTest=false}={}) {
+  let stage = 'start';
   try {
-    const reg = await navigator.serviceWorker.ready;
-    const sub = await reg.pushManager.subscribe({
-      userVisibleOnly: true,
-      applicationServerKey: urlBase64ToUint8Array(vapidPublic),
-    });
-    const subscription = sub.toJSON();
-    subscription.device_key = pwaDeviceKey();
-    subscription.device_label = localStorage.getItem('luxitPwaDeviceName') || `${browserLabel()} ${deviceTypeLabel()}`;
-    await apiFetch('/api/push/subscribe', 'POST', subscription);
-    toast('Push notifications enabled!', 'success');
+    setPushRegistrationState('environment-detected', { notificationPermission: ('Notification' in window) ? Notification.permission : 'unsupported' });
+    if (!('Notification' in window)) throw new Error('This browser does not support Notifications.');
+    if (!('serviceWorker' in navigator)) throw new Error('This browser does not support service workers.');
+    if (!('PushManager' in window)) throw new Error('This browser does not support PushManager/Web Push.');
+    stage = 'vapid-key-loaded';
+    const vapidPublic = await currentVapidPublicKey();
+    stage = 'permission-request';
+    const perm = Notification.permission === 'granted' ? 'granted' : await Notification.requestPermission();
+    setPushRegistrationState('permission-result', { notificationPermission: perm });
+    if (perm !== 'granted') throw new Error(`Notification permission ${perm}.`);
+    document.getElementById('notifBanner')?.classList.remove('show');
+    stage = 'service-worker-ready';
+    const reg = (await registerSW()) || await navigator.serviceWorker.ready;
+    await navigator.serviceWorker.ready;
+    setPushRegistrationState('service-worker-ready', { serviceWorkerScope: reg.scope });
+    stage = 'get-subscription';
+    let sub = await reg.pushManager.getSubscription();
+    setPushRegistrationState('get-subscription-complete', { subscriptionExists: !!sub, endpoint: redactEndpoint(sub?.endpoint || '') });
+
+    if (sub) {
+      try {
+        stage = 'reuse-existing-subscription';
+        setPushRegistrationState(stage, { endpoint: redactEndpoint(sub.endpoint), forceFresh });
+        const result = await persistAndVerifyPushSubscription(sub, {sendTest});
+        await registerPwaDevice('heartbeat');
+        await refreshPushDiagnostics();
+        return result;
+      } catch (reuseError) {
+        setPushRegistrationFailure('existing-subscription-reuse-failed', reuseError);
+        if (!forceFresh) throw reuseError;
+        stage = 'replace-rejected-subscription';
+        await sub.unsubscribe();
+        await apiFetch('/api/push/unsubscribe', 'POST', { endpoint: sub.endpoint });
+        setPushRegistrationState('stale-subscription-unsubscribed', { endpoint: redactEndpoint(sub.endpoint), reason: reuseError.message });
+        sub = null;
+      }
+    }
+
+    if (!sub) {
+      stage = 'push-manager-subscribe';
+      sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlBase64ToUint8Array(vapidPublic) });
+      setPushRegistrationState('push-manager-subscribe-complete', { endpoint: redactEndpoint(sub.endpoint) });
+    }
+    const result = await persistAndVerifyPushSubscription(sub, {sendTest});
+    await registerPwaDevice('heartbeat');
+    await refreshPushDiagnostics();
+    return result;
   } catch (e) {
-    toast('Could not enable notifications: ' + e.message, 'error');
+    setPushRegistrationFailure(stage, e);
+    throw e;
+  }
+}
+
+async function requestPush() {
+  try {
+    await ensurePushSubscription();
+    toast('Push notifications enabled and verified!', 'success');
+  } catch (e) {
+    toast(`Could not enable notifications at ${pushRegistrationState().failureStage || 'unknown stage'}: ${e.name || 'Error'} ${e.message}`, 'error');
   }
 }
 
@@ -2197,6 +2321,19 @@ async function refreshPushDiagnostics() {
       vapidPublicKeyPresent: !!api.vapid_public_key_present,
       vapidMissing: api.vapid_missing || [],
       subscriptions: api.subscriptions || [],
+      browserPushRegistration: pushRegistrationState(),
+      installedPwa: isInstalledPwa(),
+      displayMode: pwaDisplayMode(),
+      currentBrowserSubscription: await (async () => {
+        try {
+          const reg = await navigator.serviceWorker?.getRegistration?.();
+          const sub = await reg?.pushManager?.getSubscription?.();
+          return sub ? { exists: true, endpoint: redactEndpoint(sub.endpoint), expirationTime: sub.expirationTime || null } : { exists: false };
+        } catch (e) { return { error: `${e.name || 'Error'}: ${e.message}` }; }
+      })(),
+      lastSuccessfulRegistrationAt: pushRegistrationState().lastSuccessfulRegistrationAt || null,
+      lastRegistrationFailureStage: pushRegistrationState().failureStage || null,
+      lastRegistrationFailure: pushRegistrationState().failureMessage || null,
       deviceInstructions: api.device_instructions,
     }, null, 2);
     updatePushRepairUi(api);
@@ -2220,7 +2357,7 @@ function updatePushRepairUi(api={}) {
   const permission = ('Notification' in window) ? Notification.permission : 'unsupported';
   const shouldRepair = permission === 'granted' && Number(api.active_subscriptions || 0) === 0;
   const iosReason = iosPushBlockReason();
-  btn.style.display = shouldRepair ? 'inline-flex' : 'none';
+  btn.style.display = (shouldRepair || iosReason) ? 'inline-flex' : 'none';
   if (reason) reason.textContent = iosReason || (shouldRepair ? 'Permission is granted, but no active backend subscription is linked to this user/device.' : '');
 }
 
@@ -2228,38 +2365,17 @@ async function repairPushNotifications() {
   const btn = document.getElementById('repairPushBtn');
   const reason = document.getElementById('pushRepairReason');
   try {
-    const vapidPublic = await currentVapidPublicKey();
-    if (!('Notification' in window)) throw new Error('This browser does not support Notifications.');
-    if (Notification.permission !== 'granted') throw new Error(`Notification permission is ${Notification.permission}; allow notifications before repair.`);
+    if (btn) { btn.disabled = true; btn.textContent = 'Repairing…'; }
     const iosReason = iosPushBlockReason();
     if (iosReason) throw new Error(iosReason);
-    if (!('serviceWorker' in navigator)) throw new Error('This browser does not support service workers.');
-    if (!('PushManager' in window)) throw new Error('This browser does not support PushManager/Web Push.');
-    if (btn) { btn.disabled = true; btn.textContent = 'Repairing…'; }
-    let reg = await navigator.serviceWorker.getRegistration();
-    if (!reg) reg = await navigator.serviceWorker.register(`/static/sw.js?v=${encodeURIComponent(PWA_VERSION)}`);
-    await reg.update().catch(() => {});
-    await navigator.serviceWorker.ready;
-    let sub = await reg.pushManager.getSubscription();
-    if (!sub) {
-      sub = await reg.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: urlBase64ToUint8Array(vapidPublic) });
-    }
-    const subscription = sub.toJSON();
-    subscription.device_key = pwaDeviceKey();
-    subscription.device_label = localStorage.getItem('luxitPwaDeviceName') || `${browserLabel()} ${deviceTypeLabel()}`;
-    const saved = await apiFetch('/api/push/subscribe', 'POST', subscription);
-    if (!saved?.success) throw new Error(saved?.error || 'Backend did not save the subscription.');
-    if (Number(saved.device_active_subscriptions || saved.active_subscriptions || 0) < 1) {
-      throw new Error('Backend accepted the subscription but diagnostics still reports zero active subscriptions for this device.');
-    }
-    await registerPwaDevice('heartbeat');
-    toast('Push notifications repaired', 'success');
-    await refreshPushDiagnostics();
+    await ensurePushSubscription({forceFresh:true, sendTest:true});
+    if (reason) reason.textContent = 'Fresh subscription saved, backend verified, and test push sent.';
+    toast('Push notifications repaired and test push sent', 'success');
   } catch (e) {
-    if (reason) reason.textContent = e.message;
+    if (reason) reason.textContent = `${pushRegistrationState().failureStage || 'repair'}: ${e.name || 'Error'} ${e.message}`;
     toast('Push repair failed: ' + e.message, 'error');
   } finally {
-    if (btn) { btn.disabled = false; btn.textContent = 'Repair Push Notifications'; }
+    if (btn) { btn.disabled = false; btn.textContent = 'Repair Push Subscription'; }
   }
 }
 function installPwaNavPerformanceHandlers() {

--- a/tests/test_comms_permissions_architecture.py
+++ b/tests/test_comms_permissions_architecture.py
@@ -249,7 +249,7 @@ def test_pwa_shell_and_service_worker_bump_sms_send_version():
     assert "/api/inbox/conversations/${state.activeConvId}/messages" in page
     assert "/twilio/send" not in page
     assert "Server error (${res.status}). Please try again." not in page
-    assert "20260702-pwa-sms-send-fix" in worker
+    assert "20260710-push-receipt-ack" in worker
 
 def test_pwa_notifications_and_push_subscription_are_scoped_by_number(client, comms_world):
     login(client, comms_world["staff"])

--- a/tests/test_pwa_communications_completion.py
+++ b/tests/test_pwa_communications_completion.py
@@ -520,7 +520,7 @@ def test_pwa_sound_forwarding_autoreply_static_requirements():
     html = open("templates/inbox_pwa/index.html", encoding="utf-8").read()
     nav = open("templates/inbox_pwa/_bottom_nav.html", encoding="utf-8").read()
     migration = open("migrations/20260705_pwa_sound_forwarding_autoreply.sql", encoding="utf-8").read()
-    assert "20260709-push-subscription-repair-diagnostics" in sw
+    assert "20260710-push-receipt-ack" in sw
     assert "silent:  false" in sw
     assert "renotify: data.renotify !== false" in sw
     assert "[200, 100, 200]" in sw
@@ -834,3 +834,166 @@ def test_google_contacts_preview_payload_is_bounded_and_token_metadata_unchanged
         assert tok.google_sync_token == "sync-old"
         serialized = str(result) + str(job.preview_payload) + str(job.errors or [])
         assert "secret-access" not in serialized and "secret-refresh" not in serialized
+
+
+def test_push_subscribe_is_idempotent_per_endpoint_and_device(pwa_app):
+    app, client, ids = pwa_app
+    login(client, ids["staff"])
+    payload = {
+        "endpoint": "https://push.example/sub/idempotent",
+        "keys": {"p256dh": "first-key", "auth": "first-auth"},
+        "device_key": "same-device",
+        "device_label": "Same Device",
+    }
+    first = client.post("/api/pwa/push/subscribe", json=payload)
+    second_payload = dict(payload)
+    second_payload["keys"] = {"p256dh": "rotated-key", "auth": "rotated-auth"}
+    second = client.post("/api/pwa/push/subscribe", json=second_payload)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json["subscription_id"] == second.json["subscription_id"]
+    assert second.json["active_subscriptions"] == 1
+    assert second.json["device_active_subscriptions"] == 1
+    with app.app_context():
+        rows = PushSubscription.query.filter_by(endpoint="https://push.example/sub/idempotent", is_active=True).all()
+        assert len(rows) == 1
+        assert rows[0].user_id == ids["staff"]
+        assert rows[0].company_id == ids["company"]
+        assert rows[0].device_key == "same-device"
+        assert rows[0].p256dh == "rotated-key"
+
+
+def test_push_subscriptions_are_per_authenticated_user_not_shared_line(pwa_app, monkeypatch):
+    app, client, ids = pwa_app
+    with app.app_context():
+        other = User(username="pwa_staff_2", email="pwa_staff_2@example.com", password_hash=generate_password_hash("pw"), default_company_id=ids["company"])
+        db.session.add(other)
+        db.session.flush()
+        db.session.add(UserCompanyAccess(user_id=other.id, company_id=ids["company"], role="staff", is_default=True, can_access_mobile_inbox=True))
+        db.session.add(PhoneNumberUserPermission(company_id=ids["company"], user_id=other.id, phone_number_id=ids["line"], can_access_pwa=True, can_view_sms=True, can_view_calls=True, can_view_voicemail=True))
+        db.session.commit()
+        other_id = other.id
+
+    import inbox_pwa
+    current_user_id = {"id": ids["staff"]}
+    monkeypatch.setattr(inbox_pwa, "_current_user", lambda: db.session.get(User, current_user_id["id"]))
+    staff_resp = client.post("/api/pwa/push/subscribe", json={
+        "endpoint": "https://push.example/sub/shared-line-staff",
+        "keys": {"p256dh": "staff-key", "auth": "staff-auth"},
+        "device_key": "staff-device",
+    })
+    assert staff_resp.status_code == 200
+
+    current_user_id["id"] = other_id
+    other_resp = client.post("/api/pwa/push/subscribe", json={
+        "endpoint": "https://push.example/sub/shared-line-other",
+        "keys": {"p256dh": "other-key", "auth": "other-auth"},
+        "device_key": "other-device",
+    })
+    assert other_resp.status_code == 200
+    assert other_resp.json["success"] is True
+    assert other_resp.json["device_active_subscriptions"] == 1
+
+    with app.app_context():
+        staff_sub = PushSubscription.query.filter_by(user_id=ids["staff"], device_key="staff-device", is_active=True).one()
+        other_sub = PushSubscription.query.filter_by(user_id=other_id, device_key="other-device", is_active=True).one()
+        assert staff_sub.company_id == other_sub.company_id == ids["company"]
+        assert staff_sub.endpoint != other_sub.endpoint
+        assert PushSubscription.query.filter_by(company_id=ids["company"], is_active=True).count() == 2
+
+
+def test_push_test_separates_provider_acceptance_from_delivery_confirmation(pwa_app, monkeypatch):
+    app, client, ids = pwa_app
+    monkeypatch.setenv("VAPID_PUBLIC_KEY", "public")
+    monkeypatch.setenv("VAPID_PRIVATE_KEY", "private")
+    monkeypatch.setenv("VAPID_SUBJECT", "mailto:test@example.com")
+    login(client, ids["staff"])
+    client.post("/api/pwa/push/subscribe", json={
+        "endpoint": "https://push.example/sub/test-state",
+        "keys": {"p256dh": "key", "auth": "auth"},
+        "device_key": "test-device",
+    })
+    import inbox_pwa
+    monkeypatch.setattr(inbox_pwa, "_send_web_push_to_subscriptions", lambda subs, payload: {"sent": len(subs), "errors": []})
+
+    resp = client.post("/api/pwa/push/test")
+    assert resp.status_code == 200
+    assert resp.json["success"] is True
+    assert resp.json["backend_persisted"] is True
+    assert resp.json["provider_accepted"] is True
+    assert resp.json["service_worker_receipt_confirmed"] is False
+    assert resp.json["notification_display_confirmed"] is False
+    assert "lastPushReceivedAt" in resp.json["delivery_note"]
+
+
+def test_push_provider_expiration_deactivates_only_affected_subscription(pwa_app, monkeypatch):
+    app, client, ids = pwa_app
+    monkeypatch.setenv("VAPID_PUBLIC_KEY", "public")
+    monkeypatch.setenv("VAPID_PRIVATE_KEY", "private")
+    monkeypatch.setenv("VAPID_SUBJECT", "mailto:test@example.com")
+    with app.app_context():
+        expired = PushSubscription(user_id=ids["staff"], company_id=ids["company"], endpoint="https://push.example/sub/expired", p256dh="p", auth_key="a", is_active=True)
+        healthy = PushSubscription(user_id=ids["denied"], company_id=ids["company"], endpoint="https://push.example/sub/healthy", p256dh="p", auth_key="a", is_active=True)
+        db.session.add_all([expired, healthy])
+        db.session.commit()
+        expired_id = expired.id
+        healthy_id = healthy.id
+
+    import inbox_pwa
+    calls = []
+    def fake_webpush(subscription_info, data, vapid_private_key, vapid_claims):
+        calls.append(subscription_info["endpoint"])
+        if subscription_info["endpoint"].endswith("/expired"):
+            raise Exception("410 Gone")
+    monkeypatch.setattr("pywebpush.webpush", fake_webpush)
+
+    with app.app_context():
+        result = inbox_pwa._send_web_push_to_subscriptions(PushSubscription.query.order_by(PushSubscription.id).all(), {"title": "test"})
+        assert result["sent"] == 1
+        assert any("410" in error for error in result["errors"])
+        assert db.session.get(PushSubscription, expired_id).is_active is False
+        assert db.session.get(PushSubscription, healthy_id).is_active is True
+        assert calls == ["https://push.example/sub/expired", "https://push.example/sub/healthy"]
+
+
+def test_push_receipt_endpoint_records_redacted_service_worker_delivery_state(pwa_app):
+    app, client, ids = pwa_app
+    login(client, ids["staff"])
+    client.post("/api/pwa/push/subscribe", json={
+        "endpoint": "https://push.example/sub/receipt-device",
+        "keys": {"p256dh": "key", "auth": "auth"},
+        "device_key": "receipt-device",
+    })
+
+    receipt = client.post("/api/pwa/push/receipt", json={
+        "stage": "displayed",
+        "received_at": "2026-07-10T13:30:00.000Z",
+        "sw_version": "20260710-push-receipt-ack",
+        "event_type": "push_test",
+        "tag": "push-test",
+        "silent": False,
+        "renotify": True,
+        "vibrate": [200, 100, 200],
+        "requireInteraction": False,
+        "subscription": {
+            "endpoint": "https://push.example/sub/receipt-device",
+        },
+    })
+    assert receipt.status_code == 200
+    assert receipt.json["success"] is True
+    assert receipt.json["device_key"] == "receipt-device"
+    assert receipt.json["endpoint_redacted"].startswith("https://push.example/")
+    assert "receipt-device" in receipt.json["endpoint_redacted"]
+
+    debug = client.get("/api/pwa/push/debug", headers={"X-PWA-Device-Key": "receipt-device"})
+    assert debug.status_code == 200
+    payload = debug.get_json()
+    assert payload["latest_push_receipt"]["stage"] == "displayed"
+    assert payload["latest_push_receipt"]["sw_version"] == "20260710-push-receipt-ack"
+    assert payload["latest_push_receipt"]["silent"] is False
+    assert payload["latest_push_receipt"]["renotify"] is True
+    assert payload["latest_push_receipt"]["vibrate"] == [200, 100, 200]
+    assert payload["latest_push_receipt"]["endpoint_redacted"].startswith("https://push.example/")
+    serialized = str(payload["push_receipts"])
+    assert "key" not in serialized and "auth" not in serialized


### PR DESCRIPTION
### Motivation

- Improve server-side visibility of service-worker delivery events so the app can confirm when a push was received and displayed on-device.
- Harden subscription lifecycle and diagnostics so subscriptions are idempotent, scoped per user/device, and easier to debug and repair from the PWA client. 
- Surface richer push test and registration state to the client for clearer repair flows.

### Description

- Introduce a new endpoint `POST /api/pwa/push/receipt` that records service-worker acknowledgements into `MarketingAuditLog` and returns redacted endpoint metadata. 
- Add helper functions `_redact_push_endpoint` and `_recent_push_receipts` to redact endpoints and read recent receipt records for diagnostics. 
- Include `push_receipts` and `latest_push_receipt` in the `/api/pwa/push/debug` response and redact subscription endpoints returned by the same API. 
- Extend `push_subscribe` response to return `subscription_id`, timing metadata and `last_successful_registration_attempt_at`. 
- Make `push_test` return richer state flags (`backend_persisted`, `provider_accepted`, `service_worker_receipt_confirmed`, `notification_display_confirmed`) and include a `delivery_note` when provider accepted the notification. 
- Update server-side logging to use a new default `pwa_version`/`sw_version` tag (`20260710-push-receipt-ack`).
- Service Worker (`static/sw.js`) now sends receipts back to the server at stages `received`, `displayed`, and `display_failed`, and includes a `pushSubscriptionSummary()` helper to redact endpoint details before posting. 
- Client JS in `templates/inbox_pwa/index.html` implements structured push registration state tracking (`setPushRegistrationState`, `setPushRegistrationFailure`, `setPushRegistrationSuccess`), `ensurePushSubscription`/`persistAndVerifyPushSubscription` flows to persist and verify subscriptions, improved repair logic, subscription redaction helpers, and UI tweaks (button text change). 
- Add server-side logic to prefer matching `device_key` when receipts arrive and to associate a receipt with an active `PushSubscription` where possible. 
- Update tests to reflect the new `SW_VERSION` string and add several new tests for idempotent subscribe behavior, per-user subscription isolation, separation of provider acceptance vs delivery confirmation, provider-expiration handling, and push receipt recording.

### Testing

- Ran the test suite with `pytest tests/` including updated and new tests in `tests/test_pwa_communications_completion.py` and `tests/test_comms_permissions_architecture.py`, and all tests passed. 
- Exercised the new flows via unit tests that simulate `POST /api/pwa/push/subscribe`, `POST /api/pwa/push/test`, and `POST /api/pwa/push/receipt`, and assertions validate database records and API responses succeeded. 
- Verified the service worker string bump and that diagnostics endpoints include `push_receipts` and registration state as expected in automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50906dd3a08322a392ba5f2fadfaa9)