### PR TITLE
Surface canonical after-hours SMS copy in Auto Replies UI and webhook

### DIFF
--- a/templates/twilio/comms_hub.html
+++ b/templates/twilio/comms_hub.html
@@ -132,6 +132,13 @@
 
   {% elif tab == 'auto' %}
   <div class="d-flex mb-3"><h6 class="fw-semibold">Auto Replies{% if selected_number %} — {{ selected_number.friendly_name or selected_number.phone_number }}{% endif %}</h6></div>
+  {% if after_hours_effective %}
+  <div class="alert mb-3" style="background:#101827;border:1px solid #334155;color:#e5e7eb;">
+    <div class="small text-muted text-uppercase">Current effective message</div>
+    <div class="mt-1">{{ after_hours_effective.message }}</div>
+    <div class="small mt-2">Source: <strong>{{ after_hours_effective.source }}</strong> · <code>{{ after_hours_effective.row }}.{{ after_hours_effective.field }}</code></div>
+  </div>
+  {% endif %}
   {% if selected_number %}
   <form method="POST" action="{{ url_for('twilio.create_rule') }}" class="card p-3 mb-3" style="background:#0f1117;border:1px solid #1e2535;">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -160,7 +167,7 @@
           <div class="col-md-2"><label class="form-label small text-muted">Keyword(s)</label><input class="form-control" name="keywords" value="{{ (rule.keywords or [])|join(', ') }}"></div>
           <div class="col-md-1"><label class="form-label small text-muted">Priority</label><input class="form-control" type="number" name="priority" value="{{ rule.priority or 0 }}"></div>
           <div class="col-md-2"><label class="form-label small text-muted">Reply text</label><textarea class="form-control" name="response" rows="1">{{ rule.response or '' }}</textarea></div>
-          <div class="col-md-1"><span class="badge {% if rule.phone_number_id %}bg-primary{% else %}bg-secondary{% endif %}">{% if rule.phone_number_id %}Number-specific{% else %}Global{% endif %}</span><div class="small text-muted mt-1">{{ (rule.trigger_type or 'No match type') | replace('_', ' ') | title }}</div></div>
+          <div class="col-md-1"><span class="badge {% if rule.phone_number_id %}bg-primary{% else %}bg-secondary{% endif %}">{% if rule.phone_number_id %}Number-specific{% else %}Company-wide{% endif %}</span><div class="small text-muted mt-1">{{ (rule.trigger_type or 'No match type') | replace('_', ' ') | title }}</div></div>
           <div class="col-md-1"><label class="form-check small"><input class="form-check-input" type="checkbox" name="is_active" value="1" {% if rule.is_active %}checked{% endif %}> Active</label></div>
           <div class="col-md-1 d-flex gap-1"><button class="btn btn-sm btn-primary" type="submit">Save</button><button class="btn btn-sm btn-outline-danger" type="submit" form="delete-rule-{{ rule.id }}">Delete</button></div>
         </div>

--- a/tests/test_pwa_phone_system.py
+++ b/tests/test_pwa_phone_system.py
@@ -1258,3 +1258,74 @@ def test_twilio_message_media_url_is_proxied_in_conversation_payload(client, app
     payload = resp.get_json()
     assert payload["messages"][0]["media_urls"] == [f"/api/inbox/messages/{payload['messages'][0]['id']}/media/0"]
     assert "api.twilio.com" not in payload["messages"][0]["media_urls"][0]
+
+
+def test_auto_replies_editor_surfaces_canonical_after_hours_message_used_by_inbound_sms(app, client, world, monkeypatch):
+    desired = "Thanks for reaching out. Our business hours are daily from 2 PM to 2 AM. We’ll respond as soon as we’re back online."
+    updated = "Thanks for reaching out. Our business hours are daily from 2 PM to 2 AM. We’ll respond as soon as we’re back online."
+    sent = []
+    monkeypatch.setattr("twilio_sms.sendConversationSms", lambda conv_id, message, **kw: sent.append(message) or {"success": True})
+
+    with app.app_context():
+        save_settings(world["co_a"], business_hours={str(i): {"is_open": False} for i in range(7)})
+        pn = add_phone_number(world["co_a"], "+15550001000", after_hours_text=desired)
+        db.session.commit()
+        number_id = pn.id
+
+    login(client, world["alice"])
+    page = client.get(f"/twilio/comms?tab=auto&number_id={number_id}")
+    assert page.status_code == 200
+    assert desired.encode() in page.data
+    assert b"Current effective message" in page.data
+    assert b"migrated number setting" in page.data or b"number-specific AutoReplyRule" in page.data
+    assert b"Number-specific" in page.data
+
+    with app.app_context():
+        rule = AutoReplyRule.query.filter_by(company_id=world["co_a"], phone_number_id=number_id, trigger_type="after_hours").one()
+        assert rule.response == desired
+        rule_id = rule.id
+
+    resp = client.post(
+        f"/twilio/rules/{rule_id}/edit",
+        data={
+            "name": "After Hours",
+            "phone_number_id": str(number_id),
+            "return_number_id": str(number_id),
+            "trigger_type": "after_hours",
+            "keywords": "",
+            "priority": "50",
+            "response": updated,
+            "action": "reply",
+            "is_active": "1",
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert updated.encode() in resp.data
+
+    sms = client.post("/twilio/sms/inbound", data={"From": "+15551117777", "To": "+15550001000", "Body": "hello", "MessageSid": "SMAUTOUI"})
+    assert sms.status_code == 200
+    assert sent == [updated]
+
+
+def test_company_wide_after_hours_rule_is_labeled_and_used_for_selected_number(app, client, world, monkeypatch):
+    sent = []
+    monkeypatch.setattr("twilio_sms.sendConversationSms", lambda conv_id, message, **kw: sent.append(message) or {"success": True})
+    with app.app_context():
+        save_settings(world["co_a"], business_hours={str(i): {"is_open": False} for i in range(7)})
+        pn = add_phone_number(world["co_a"], "+15550001000")
+        rule = AutoReplyRule(company_id=world["co_a"], name="After Hours Company", trigger_type="after_hours", action="reply", response="Company-wide closed", is_active=True, priority=50)
+        db.session.add(rule)
+        db.session.commit()
+        number_id = pn.id
+
+    login(client, world["alice"])
+    page = client.get(f"/twilio/comms?tab=auto&number_id={number_id}")
+    assert page.status_code == 200
+    assert b"Company-wide" in page.data
+    assert b"company-wide AutoReplyRule" in page.data
+    assert b"Company-wide closed" in page.data
+
+    sms = client.post("/twilio/sms/inbound", data={"From": "+15551118888", "To": "+15550001000", "Body": "hello", "MessageSid": "SMCOMPANYWIDE"})
+    assert sms.status_code == 200
+    assert sent == ["Company-wide closed"]

--- a/twilio_sms.py
+++ b/twilio_sms.py
@@ -787,27 +787,93 @@ def _update_contact_sms_consent(company_id, phone_number, opted_in, source):
     return contact
 
 
-def _after_hours_rule_response(company_id: int, phone_number_id: int | None = None) -> str | None:
-    from models import AutoReplyRule, TwilioPhoneNumber
+
+def _clean_after_hours_text(value) -> str | None:
+    text = (value or "").strip()
+    return text or None
+
+
+def _after_hours_legacy_candidates(company_id: int, phone_number_id: int | None = None):
+    from models import PhoneSettings, TwilioAccount, TwilioPhoneNumber
     if phone_number_id is not None:
         pn = db.session.get(TwilioPhoneNumber, phone_number_id)
-        if pn and pn.company_id == company_id and getattr(pn, "after_hours_text", None):
-            return (pn.after_hours_text or "").strip()
-    rule_query = AutoReplyRule.query.filter_by(
+        if pn and pn.company_id == company_id:
+            text = _clean_after_hours_text(getattr(pn, "after_hours_text", None))
+            if text:
+                yield "migrated number setting", text, pn
+    ps = PhoneSettings.query.filter_by(company_id=company_id).first()
+    text = _clean_after_hours_text(getattr(ps, "after_hours_sms_body", None)) if ps else None
+    if text:
+        yield "migrated phone settings", text, ps
+    ta = TwilioAccount.query.filter_by(company_id=company_id).first()
+    text = _clean_after_hours_text(getattr(ta, "after_hours_text", None)) if ta else None
+    if text:
+        yield "migrated account setting", text, ta
+    yield "fallback", REQUIRED_AFTER_HOURS_SMS_COPY, None
+
+
+def _after_hours_auto_reply_query(company_id: int, phone_number_id: int | None = None):
+    from models import AutoReplyRule
+    q = AutoReplyRule.query.filter_by(
         company_id=company_id,
         trigger_type="after_hours",
         action="reply",
         is_active=True,
     )
     if phone_number_id is not None:
-        rule_query = rule_query.filter(db.or_(
+        q = q.filter(db.or_(
             AutoReplyRule.phone_number_id == phone_number_id,
             AutoReplyRule.phone_number_id.is_(None),
         ))
     else:
-        rule_query = rule_query.filter(AutoReplyRule.phone_number_id.is_(None))
-    rule = rule_query.order_by(AutoReplyRule.phone_number_id.desc().nullslast(), AutoReplyRule.priority.desc()).first()
-    return (rule.response or "").strip() if rule and rule.response else None
+        q = q.filter(AutoReplyRule.phone_number_id.is_(None))
+    return q.order_by(AutoReplyRule.phone_number_id.desc().nullslast(), AutoReplyRule.priority.desc(), AutoReplyRule.id.asc())
+
+
+def _current_after_hours_effective_message(company_id: int, phone_number_id: int | None = None) -> dict:
+    rule = _after_hours_auto_reply_query(company_id, phone_number_id).first()
+    if rule and _clean_after_hours_text(rule.response):
+        return {
+            "message": rule.response.strip(),
+            "source": "number-specific AutoReplyRule" if rule.phone_number_id else "company-wide AutoReplyRule",
+            "row": f"auto_reply_rule.id={rule.id}",
+            "field": "response",
+            "rule": rule,
+        }
+    source, text, obj = next(_after_hours_legacy_candidates(company_id, phone_number_id))
+    table = getattr(obj, "__tablename__", None) if obj is not None else None
+    row = f"{table}.id={getattr(obj, 'id', None)}" if table and getattr(obj, "id", None) is not None else "constant.REQUIRED_AFTER_HOURS_SMS_COPY"
+    field = "after_hours_text" if table in {"twilio_phone_number", "twilio_account"} else ("after_hours_sms_body" if table == "phone_settings" else "REQUIRED_AFTER_HOURS_SMS_COPY")
+    return {"message": text, "source": source if source == "fallback" else source, "row": row, "field": field, "rule": None}
+
+
+def _ensure_visible_after_hours_rule(company_id: int, phone_number_id: int | None = None):
+    """Surface legacy after-hours copy as an editable AutoReplyRule for the UI/webhook."""
+    from models import AutoReplyRule
+    existing = _after_hours_auto_reply_query(company_id, phone_number_id).first()
+    if existing:
+        return existing
+    source, text, obj = next(_after_hours_legacy_candidates(company_id, phone_number_id))
+    if not text:
+        return None
+    rule = AutoReplyRule(
+        company_id=company_id,
+        phone_number_id=phone_number_id,
+        name="After Hours" if phone_number_id else "After Hours (Company-wide)",
+        trigger_type="after_hours",
+        keywords=[],
+        response=text,
+        action="reply",
+        priority=50,
+        is_active=True,
+    )
+    db.session.add(rule)
+    db.session.flush()
+    logger.info("Migrated visible after-hours AutoReplyRule id=%s from %s", rule.id, source)
+    return rule
+
+def _after_hours_rule_response(company_id: int, phone_number_id: int | None = None) -> str | None:
+    return _current_after_hours_effective_message(company_id, phone_number_id).get("message")
 
 
 def _send_number_configured_auto_reply(conv, ta, *, in_business=None) -> bool:
@@ -2254,9 +2320,13 @@ def comms_hub():
                 users_with_access.append({"user": u, "access": acc, "permission": perm})
     except Exception:
         pass
+    after_hours_effective = None
     rules = []
     try:
         selected_rule_number_id = selected_number.id if selected_number else None
+        _ensure_visible_after_hours_rule(company.id, selected_rule_number_id)
+        db.session.commit()
+        after_hours_effective = _current_after_hours_effective_message(company.id, selected_rule_number_id)
         rules_query = AutoReplyRule.query.filter_by(company_id=company.id)
         if selected_rule_number_id is not None:
             rules_query = rules_query.filter(db.or_(
@@ -2314,6 +2384,7 @@ def comms_hub():
         selected_number=selected_number,
         users_with_access=users_with_access,
         rules=rules,
+        after_hours_effective=after_hours_effective,
         voicemails=voicemails,
         activity=activity,
         devices=devices,


### PR DESCRIPTION
### Motivation
- Make the after-hours SMS message canonical and editable from Communications → Auto Replies so the UI reflects and controls the exact message the inbound webhook sends.
- Surface legacy values (per-number, tenant, account, and hard-coded fallback) instead of silently overriding what the user sees, and provide clear visibility of the source row/field.

### Description
- Added canonical resolution helpers in `twilio_sms.py` (`_clean_after_hours_text`, `_after_hours_legacy_candidates`, `_after_hours_auto_reply_query`, `_current_after_hours_effective_message`) that prefer an active number-specific `AutoReplyRule`, then a company-wide `AutoReplyRule`, then legacy `TwilioPhoneNumber.after_hours_text`, `PhoneSettings.after_hours_sms_body`, `TwilioAccount.after_hours_text`, and finally `REQUIRED_AFTER_HOURS_SMS_COPY` as fallback. 
- Added `_ensure_visible_after_hours_rule(company_id, phone_number_id)` which materializes legacy after-hours copy as an editable `AutoReplyRule` so the Auto Replies editor is always showing the canonical editable rule used by the webhook. 
- Updated `_after_hours_rule_response` to read from the canonical resolver so inbound SMS uses the same effective message as the UI. 
- Updated `comms_hub()` (Communications → Auto Replies) to call `_ensure_visible_after_hours_rule()`, compute `after_hours_effective`, and pass that metadata to the template so the UI can show a preview and exact source (`<table>.id=<n>.<field>`). 
- Templating changes in `templates/twilio/comms_hub.html` add a “Current effective message” preview block and relabel global rules as `Company-wide` to make scope explicit. 
- Added regression tests in `tests/test_pwa_phone_system.py` that assert the Auto Replies editor surfaces the canonical after-hours message and that an actual inbound after-hours SMS sends the same message, and that company-wide After Hours rules are labeled and used for a selected number. 

### Testing
- Ran the new regression coverage: `pytest tests/test_pwa_phone_system.py::test_auto_replies_editor_surfaces_canonical_after_hours_message_used_by_inbound_sms tests/test_pwa_phone_system.py::test_company_wide_after_hours_rule_is_labeled_and_used_for_selected_number -q`, and both tests passed. 
- Verified `twilio_sms.py` compiles with `python -m compileall twilio_sms.py` successfully. 
- Attempted a production data audit to report the exact DB row/field currently supplying the message, but this environment has no provisioned database connection so the audit query could not run (runtime raised `No database connection could be established`); the UI will now show the exact supplier as `auto_reply_rule.id=<n>.response`, `twilio_phone_number.id=<n>.after_hours_text`, `phone_settings.id=<n>.after_hours_sms_body`, `twilio_account.id=<n>.after_hours_text`, or `constant.REQUIRED_AFTER_HOURS_SMS_COPY` when displayed in production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a515168cd988322a7a4d9606cc91ec6)