### PR TITLE
Implement user deactivation/archival with active-user enforcement, DB migration, and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -272,7 +272,13 @@ def create_app() -> Flask:
     @app.errorhandler(CSRFError)
     def handle_csrf_error(e):
         from flask import flash as _flash, redirect as _redirect, request as _req, url_for as _url
-        _flash("Your session expired. Please try again.", "error")
+        logging.getLogger(__name__).warning(
+            "CSRF validation failed path=%s request_id=%s reason=%s",
+            _req.path,
+            _req.headers.get("X-Request-ID"),
+            getattr(e, "description", "csrf_error"),
+        )
+        _flash("Security check failed. Please refresh the page and try again.", "error")
         referrer = _req.referrer
         if referrer:
             return _redirect(referrer)
@@ -298,6 +304,9 @@ def create_app() -> Flask:
         _log = _logging.getLogger("auth")
         try:
             u = db.session.get(User, int(user_id))
+            if u and not getattr(u, "is_active", True):
+                _log.info("USER_LOADER: id=%s → inactive user denied", user_id)
+                return None
             _log.info("USER_LOADER: id=%s → user=%s (authenticated=%s)", user_id, u, bool(u))
             return u
         except Exception as _exc:

--- a/auth.py
+++ b/auth.py
@@ -126,6 +126,15 @@ def login():
                 logger.warning("Auth login template missing: %s", exc)
                 return render_template("login.html")
 
+        if not getattr(user, "is_active", True):
+            logger.warning("LOGIN FAIL: inactive user for %r", identifier)
+            flash("This account has been deactivated. Contact an administrator for access.", "error")
+            try:
+                return render_template("auth/login.html")
+            except TemplateNotFound as exc:
+                logger.warning("Auth login template missing: %s", exc)
+                return render_template("login.html")
+
         if not user.password_hash:
             logger.warning("LOGIN FAIL: user has no password hash for %r", identifier)
             flash("This account doesn't have a password set. Use SSO or ask an admin to set a password.", "error")

--- a/docs/company_logo_asset_deployment.md
+++ b/docs/company_logo_asset_deployment.md
@@ -1,0 +1,18 @@
+# Company logo asset deployment note
+
+The production path `/static/company_logos/LC-Logo-Wht_Icon-Blk-Logo-GLOW.png`
+points to an uploaded/company-specific asset and should not be restored by
+committing a binary image in application bug-fix PRs.
+
+For this asset, use one of the source-controlled options below:
+
+1. Update the affected company `logo_path`/`icon_path` value to an existing
+   tracked logo under `static/company_logos/`, such as `LC-Logo-WHT.png`, when
+   that is the intended fallback.
+2. Deploy the original uploaded PNG to the server-side persistent static/upload
+   storage used by production.
+3. If the file was renamed, correct only the configured database path so its
+   casing and filename match the deployed Linux filesystem exactly.
+
+Do not encode, inline, or substitute another binary asset in a user-deletion
+backend fix.

--- a/models.py
+++ b/models.py
@@ -174,6 +174,14 @@ class User(UserMixin, db.Model):
     email = db.Column(db.String(120), unique=True, nullable=False)
     password_hash = db.Column(db.String(256))
     is_admin = db.Column(db.Boolean, default=False)
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    archived_at = db.Column(db.DateTime, nullable=True)
+    archived_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+
+    @property
+    def is_active(self):
+        """Flask-Login gate: archived users cannot authenticate or use remember cookies."""
+        return bool(self.active)
 
     # Replit Auth
     replit_id = db.Column(db.String(64), unique=True, nullable=True)
@@ -707,9 +715,10 @@ class Company(db.Model):
         """
         from sqlalchemy import or_
         via_access = db.session.query(UserCompanyAccess.user_id) \
-            .filter(UserCompanyAccess.company_id == self.id)
+            .join(User, User.id == UserCompanyAccess.user_id) \
+            .filter(UserCompanyAccess.company_id == self.id, User.active.is_(True))
         via_default = db.session.query(User.id) \
-            .filter(User.default_company_id == self.id)
+            .filter(User.default_company_id == self.id, User.active.is_(True))
         ids = {r[0] for r in via_access.all()} | {r[0] for r in via_default.all()}
         return len(ids)
 

--- a/routes.py
+++ b/routes.py
@@ -3,10 +3,12 @@ import io
 import base64
 import logging
 import os
+import uuid
 from datetime import datetime, timedelta
 from flask import Blueprint, render_template, request, flash, redirect, url_for, jsonify, make_response, send_file, current_app, g
 from flask_login import login_required, current_user
 from sqlalchemy import or_, case, text, func
+from sqlalchemy.exc import IntegrityError
 from extensions import db, csrf
 try:
     from models import (
@@ -6425,13 +6427,13 @@ def manage_users():
     try:
         company = current_user.get_default_company()
         if current_user.is_admin:
-            users = User.query.order_by(User.username).all()
+            users = User.query.filter(User.active.is_(True)).order_by(User.username).all()
         else:
             if not company or not can_manage_users(current_user, company.id):
                 flash('Access denied. You need owner or manage-users permission.', 'danger')
                 return redirect(url_for('main.dashboard'))
             user_ids = [a.user_id for a in UserCompanyAccess.query.filter_by(company_id=company.id).all()]
-            users = User.query.filter(User.id.in_(user_ids)).order_by(User.username).all()
+            users = User.query.filter(User.id.in_(user_ids), User.active.is_(True)).order_by(User.username).all()
 
         # Build per-user access map {user_id: access_row} (tenant row first)
         all_access = (UserCompanyAccess.query.filter_by(company_id=company.id).all() if company and not current_user.is_admin else UserCompanyAccess.query.all())
@@ -6486,18 +6488,132 @@ def edit_user(user_id):
 @main_bp.route('/user/delete/<int:user_id>', methods=['POST'])
 @login_required
 def delete_user(user_id):
-    """Delete a user (platform admin only)."""
-    if not current_user.is_admin:
-        flash('Access denied.', 'danger')
+    """Deactivate/archive a user from the tenant-scoped Manage Users page.
+
+    Flask-Login is the canonical authentication layer for this route.  Do not
+    add legacy ``session`` key checks here; a valid ``current_user`` accepted by
+    ``GET /user/manage-users`` must also be accepted for this destructive POST.
+    """
+    from models import User, UserCompanyAccess
+    from services.comms_permissions import can_manage_users, normalize_role
+
+    request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+    actor_company = current_user.get_default_company()
+    actor_role = None
+    if actor_company:
+        actor_role = current_user.get_company_role(actor_company.id)
+
+    def _audit(outcome, **extra):
+        logger.info(
+            "user_delete request_id=%s actor_authenticated=%s actor_user_id=%s "
+            "actor_role=%s actor_tenant_id=%s target_user_id=%s outcome=%s %s",
+            request_id,
+            bool(current_user.is_authenticated),
+            getattr(current_user, "id", None),
+            actor_role,
+            getattr(actor_company, "id", None),
+            user_id,
+            outcome,
+            extra,
+        )
+
+    if not actor_company and not current_user.is_admin:
+        _audit("unauthorized_no_company", authorization_result="denied")
+        flash('You do not have permission to delete users.', 'danger')
         return redirect(url_for('main.dashboard'))
-    from models import User
-    user = User.query.get_or_404(user_id)
-    if user.id == current_user.id:
-        flash('Cannot delete your own account.', 'danger')
+
+    if not current_user.is_admin and not can_manage_users(current_user, actor_company.id):
+        _audit("unauthorized", authorization_result="denied")
+        flash('You do not have permission to delete users.', 'danger')
+        return redirect(url_for('main.dashboard'))
+
+    target = db.session.get(User, user_id)
+    if not target:
+        _audit("not_found", authorization_result="allowed")
+        flash('The selected user no longer exists.', 'warning')
         return redirect(url_for('main.manage_users'))
-    db.session.delete(user)
-    db.session.commit()
-    flash(f'User {user.username} deleted.', 'success')
+    if not getattr(target, "is_active", True):
+        _audit("already_inactive", authorization_result="allowed")
+        flash('The selected user no longer exists.', 'warning')
+        return redirect(url_for('main.manage_users'))
+
+    if target.id == current_user.id:
+        _audit("self_delete_blocked", authorization_result="denied")
+        flash('You cannot delete your own account.', 'danger')
+        return redirect(url_for('main.manage_users'))
+
+    target_access = None
+    if actor_company and not current_user.is_admin:
+        target_access = UserCompanyAccess.query.filter_by(
+            user_id=target.id, company_id=actor_company.id
+        ).first()
+        if not target_access:
+            _audit("cross_tenant_blocked", authorization_result="denied")
+            flash('You do not have permission to delete users.', 'danger')
+            return make_response(redirect(url_for('main.manage_users')), 403)
+    elif actor_company:
+        target_access = UserCompanyAccess.query.filter_by(
+            user_id=target.id, company_id=actor_company.id
+        ).first()
+
+    if target.is_admin and not current_user.is_admin:
+        _audit("protected_global_admin_blocked", authorization_result="denied")
+        flash('You do not have permission to delete protected global administrators.', 'danger')
+        return redirect(url_for('main.manage_users'))
+
+    target_role = normalize_role(getattr(target_access, "role", None)) if target_access else None
+    if target_role == UserCompanyAccess.ROLE_OWNER and actor_company:
+        other_owner_count = UserCompanyAccess.query.join(
+            User, User.id == UserCompanyAccess.user_id
+        ).filter(
+            UserCompanyAccess.company_id == actor_company.id,
+            UserCompanyAccess.user_id != target.id,
+            User.active.is_(True),
+            UserCompanyAccess.role.in_([
+                UserCompanyAccess.ROLE_OWNER,
+                "superadmin",
+                "super_admin",
+                "super-admin",
+            ]),
+        ).count()
+        if other_owner_count == 0:
+            _audit("final_owner_blocked", authorization_result="denied")
+            flash('Another administrator or owner must be assigned before this account can be removed.', 'danger')
+            return redirect(url_for('main.manage_users'))
+
+    try:
+        decision = "deactivation"
+        now = datetime.utcnow()
+        if hasattr(target, "active"):
+            target.active = False
+        if hasattr(target, "archived_at"):
+            target.archived_at = now
+        if hasattr(target, "archived_by_user_id"):
+            target.archived_by_user_id = current_user.id
+        if target_access:
+            target_access.can_access_full_app = False
+            target_access.can_access_mobile_inbox = False
+            target_access.pwa_access_enabled = False
+            target_access.comms_hub_enabled = False
+            target_access.manage_users_enabled = False
+            target_access.updated_at = now
+        else:
+            target.is_admin = False
+        db.session.commit()
+        _audit("success", authorization_result="allowed", csrf_result="passed",
+               deletion_decision=decision, database_result="committed", final_status="302")
+        flash(f'User {target.username} has been deactivated.', 'success')
+    except IntegrityError as exc:
+        db.session.rollback()
+        _audit("dependency_conflict", authorization_result="allowed", csrf_result="passed",
+               deletion_decision="deactivation", database_result="rolled_back", error=exc.__class__.__name__)
+        flash('This user has related records and cannot be fully deleted. Their access was not changed; deactivate or archive related assignments first.', 'danger')
+    except Exception:
+        db.session.rollback()
+        logger.exception("user_delete unexpected failure request_id=%s", request_id)
+        _audit("server_error", authorization_result="allowed", csrf_result="passed",
+               deletion_decision="deactivation", database_result="rolled_back", final_status="302")
+        flash(f'Unable to update this user right now. Reference ID: {request_id}', 'danger')
     return redirect(url_for('main.manage_users'))
 
 @main_bp.route('/api/user/<int:user_id>/access', methods=['POST'])
@@ -6513,7 +6629,7 @@ def update_user_access(user_id):
                 return jsonify({'success': False, 'error': 'Permission denied.'}), 403
 
         target = db.session.get(User, user_id)
-        if not target:
+        if not target or not getattr(target, "is_active", True):
             return jsonify({'success': False, 'error': 'User not found.'}), 404
 
         payload = request.get_json() or {}

--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -79,6 +79,9 @@ MIGRATIONS = [
     ("user", "last_activity",    "DATETIME",      "DEFAULT NULL"),
     ("user", "bio",              "TEXT",          "DEFAULT NULL"),
     ("user", "preferred_hub",    "VARCHAR(20)",   "DEFAULT 'marketing'"),
+    ("user", "active",           "BOOLEAN",       "DEFAULT 1"),
+    ("user", "archived_at",      "DATETIME",      "DEFAULT NULL"),
+    ("user", "archived_by_user_id","INTEGER",     "DEFAULT NULL"),
     ("user", "created_at",       "DATETIME",      "DEFAULT (CURRENT_TIMESTAMP)"),
     ("user", "updated_at",       "DATETIME",      "DEFAULT (CURRENT_TIMESTAMP)"),
 

--- a/services/comms_permissions.py
+++ b/services/comms_permissions.py
@@ -34,6 +34,8 @@ def user_access_for_company(user, company_id: int):
     from models import UserCompanyAccess
     if not user or not company_id:
         return None
+    if not getattr(user, "is_active", True):
+        return None
     return UserCompanyAccess.query.filter_by(user_id=user.id, company_id=company_id).first()
 
 
@@ -57,6 +59,8 @@ def accessible_phone_numbers(user, company_id: int) -> list[str]:
     from models import PhoneNumberUserPermission, TwilioAccount, TwilioPhoneNumber
 
     if not user or not company_id:
+        return []
+    if not getattr(user, "is_active", True):
         return []
     acc = user_access_for_company(user, company_id)
     role = normalize_role(getattr(acc, "role", None)) if acc else "viewer"

--- a/templates/manage_users.html
+++ b/templates/manage_users.html
@@ -92,7 +92,8 @@
                         </a>
                         {% if user.id != current_user.id %}
                         <form method="POST" action="{{ url_for('main.delete_user', user_id=user.id) }}" class="d-inline"
-                              onsubmit="return confirm('Delete {{ user.username }}? This cannot be undone.')">
+                              onsubmit="return confirm('Deactivate {{ user.username }} and revoke access?')">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <button type="submit" class="btn btn-outline-danger">
                                 <i data-feather="trash-2"></i>
                             </button>

--- a/tests/test_user_delete_route.py
+++ b/tests/test_user_delete_route.py
@@ -1,0 +1,293 @@
+import os
+
+import pytest
+from flask import g
+from werkzeug.security import generate_password_hash
+
+from app import create_app
+from extensions import db
+from models import Company, User, UserCompanyAccess
+
+
+@pytest.fixture
+def app():
+    os.environ.setdefault("TWILIO_ACCOUNT_SID", "ACtest")
+    a = create_app()
+    a.config.update(TESTING=True, SERVER_NAME="localhost", WTF_CSRF_ENABLED=False, SECRET_KEY="delete-test-secret")
+    yield a
+
+
+@pytest.fixture
+def client(app):
+    with app.test_client() as c:
+        yield c
+
+
+def login(client, user_id, legacy_keys=True):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user_id)
+        sess["_fresh"] = True
+        if legacy_keys:
+            sess["user_id"] = user_id
+            sess["logged_in"] = True
+
+
+@pytest.fixture
+def delete_world(app):
+    with app.app_context():
+        co = Company(name="Delete Co", is_active=True)
+        other = Company(name="Delete Other Co", is_active=True)
+        db.session.add_all([co, other])
+        db.session.flush()
+        owner = User(username="delete_owner", email="delete_owner@test.com", password_hash=generate_password_hash("pw"), default_company_id=co.id)
+        manager = User(username="delete_manager", email="delete_manager@test.com", password_hash=generate_password_hash("pw"), default_company_id=co.id)
+        staff = User(username="delete_staff", email="delete_staff@test.com", password_hash=generate_password_hash("pw"), default_company_id=co.id)
+        outsider = User(username="delete_out", email="delete_out@test.com", password_hash=generate_password_hash("pw"), default_company_id=other.id)
+        viewer = User(username="delete_viewer", email="delete_viewer@test.com", password_hash=generate_password_hash("pw"), default_company_id=co.id)
+        platform = User(username="delete_platform", email="delete_platform@test.com", password_hash=generate_password_hash("pw"), default_company_id=co.id, is_admin=True)
+        db.session.add_all([owner, manager, staff, outsider, viewer, platform])
+        db.session.flush()
+        db.session.add_all([
+            UserCompanyAccess(user_id=owner.id, company_id=co.id, role="owner", is_default=True),
+            UserCompanyAccess(user_id=manager.id, company_id=co.id, role="manager", is_default=True, manage_users_enabled=True),
+            UserCompanyAccess(user_id=staff.id, company_id=co.id, role="staff", is_default=True, can_access_full_app=True, pwa_access_enabled=True),
+            UserCompanyAccess(user_id=viewer.id, company_id=co.id, role="viewer", is_default=True),
+            UserCompanyAccess(user_id=outsider.id, company_id=other.id, role="staff", is_default=True),
+            UserCompanyAccess(user_id=platform.id, company_id=co.id, role="admin", is_default=True),
+        ])
+        db.session.commit()
+        return {"co": co.id, "owner": owner.id, "manager": manager.id, "staff": staff.id, "outsider": outsider.id, "viewer": viewer.id, "platform": platform.id}
+
+
+def flashed(client):
+    with client.session_transaction() as sess:
+        return [m for _cat, m in sess.get("_flashes", [])]
+
+
+def clear_login_cache():
+    if hasattr(g, "_login_user"):
+        del g._login_user
+
+
+def test_manage_users_and_delete_accept_same_flask_login_auth_without_legacy_session_keys(client, delete_world):
+    login(client, delete_world["manager"], legacy_keys=False)
+    assert client.get("/user/manage-users").status_code == 200
+
+    resp = client.post(f"/user/delete/{delete_world['staff']}")
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/user/manage-users")
+    assert not any("session" in msg.lower() for msg in flashed(client))
+    with client.application.app_context():
+        staff = db.session.get(User, delete_world["staff"])
+        access = UserCompanyAccess.query.filter_by(user_id=staff.id, company_id=delete_world["co"]).first()
+        assert staff.active is False
+        assert staff.archived_at is not None
+        assert access.can_access_full_app is False
+        assert access.pwa_access_enabled is False
+
+
+def test_unauthenticated_delete_is_only_session_expired_like_path(client, delete_world):
+    resp = client.post(f"/user/delete/{delete_world['staff']}")
+    assert resp.status_code == 302
+    assert "/auth/login" in resp.headers["Location"]
+
+
+def test_unauthorized_role_gets_permission_denied_not_session_expired(client, delete_world):
+    login(client, delete_world["viewer"])
+    resp = client.post(f"/user/delete/{delete_world['staff']}")
+    assert resp.status_code == 302
+    messages = flashed(client)
+    assert "You do not have permission to delete users." in messages
+    assert not any("session" in msg.lower() for msg in messages)
+
+
+def test_cross_tenant_delete_is_blocked_with_403(client, delete_world):
+    login(client, delete_world["manager"])
+    resp = client.post(f"/user/delete/{delete_world['outsider']}")
+    assert resp.status_code == 403
+
+
+def test_nonexistent_and_self_and_last_owner_are_controlled(client, delete_world):
+    login(client, delete_world["manager"])
+    assert client.post("/user/delete/999999").status_code == 302
+    assert "The selected user no longer exists." in flashed(client)
+
+    resp = client.post(f"/user/delete/{delete_world['manager']}")
+    assert resp.status_code == 302
+    assert "You cannot delete your own account." in flashed(client)
+
+    resp = client.post(f"/user/delete/{delete_world['owner']}")
+    assert resp.status_code == 302
+    assert "Another administrator or owner must be assigned before this account can be removed." in flashed(client)
+
+
+def test_protected_global_admin_blocked_for_tenant_manager(client, delete_world):
+    login(client, delete_world["manager"])
+    resp = client.post(f"/user/delete/{delete_world['platform']}")
+    assert resp.status_code == 302
+    assert "You do not have permission to delete protected global administrators." in flashed(client)
+
+
+def test_unexpected_exception_rolls_back_and_is_not_session_expired(client, delete_world, monkeypatch):
+    login(client, delete_world["manager"])
+
+    def boom():
+        raise RuntimeError("forced")
+
+    monkeypatch.setattr(db.session, "commit", boom)
+    resp = client.post(f"/user/delete/{delete_world['staff']}")
+    assert resp.status_code == 302
+    messages = flashed(client)
+    assert any("Unable to update this user right now" in msg for msg in messages)
+    assert not any("session" in msg.lower() for msg in messages)
+
+
+def test_integrity_error_dependency_conflict_is_controlled(client, delete_world, monkeypatch):
+    from sqlalchemy.exc import IntegrityError
+
+    login(client, delete_world["manager"])
+
+    def fail_integrity():
+        raise IntegrityError("statement", "params", Exception("fk"))
+
+    monkeypatch.setattr(db.session, "commit", fail_integrity)
+    resp = client.post(f"/user/delete/{delete_world['staff']}")
+    assert resp.status_code == 302
+    messages = flashed(client)
+    assert any("related records" in msg for msg in messages)
+    assert not any("session" in msg.lower() for msg in messages)
+
+def test_deactivated_user_cannot_login_remember_or_access_protected_routes(client, delete_world):
+    login(client, delete_world["manager"])
+    client.post(f"/user/delete/{delete_world['staff']}")
+
+    # Existing protected-route access with the archived user's session is denied by user_loader/is_active.
+    with client.session_transaction() as sess:
+        sess.clear()
+        sess["_user_id"] = str(delete_world["staff"])
+        sess["_fresh"] = True
+    clear_login_cache()
+    protected = client.get("/user/manage-users")
+    assert protected.status_code == 302
+    assert "/auth/login" in protected.headers["Location"]
+
+    with client.session_transaction() as sess:
+        sess.clear()
+    clear_login_cache()
+    login_resp = client.post("/auth/login", data={"username": "delete_staff", "password": "pw"})
+    assert login_resp.status_code == 200
+    assert b"deactivated" in login_resp.data.lower() or any("deactivated" in msg.lower() for msg in flashed(client))
+
+def test_deactivated_user_remember_cookie_cannot_restore_session(app, delete_world):
+    with app.test_client() as staff_client:
+        login_resp = staff_client.post("/auth/login", data={"username": "delete_staff", "password": "pw"})
+        assert login_resp.status_code in (200, 302)
+        with app.app_context():
+            staff = db.session.get(User, delete_world["staff"])
+            staff.active = False
+            staff.archived_at = staff.created_at
+            db.session.commit()
+        with staff_client.session_transaction() as sess:
+            sess.clear()
+        clear_login_cache()
+        protected = staff_client.get("/user/manage-users")
+        assert protected.status_code == 302
+        assert "/auth/login" in protected.headers["Location"]
+
+
+def test_active_user_queries_seats_and_permissions_exclude_deactivated_users(client, delete_world):
+    login(client, delete_world["manager"])
+    client.post(f"/user/delete/{delete_world['staff']}")
+
+    with client.application.app_context():
+        co = db.session.get(Company, delete_world["co"])
+        active_ids = [u.id for u in User.query.filter(User.active.is_(True)).all()]
+        assert delete_world["staff"] not in active_ids
+        assert delete_world["staff"] not in [u.id for u in User.query.filter_by(default_company_id=co.id, active=True).all()]
+        assert delete_world["staff"] not in {row[0] for row in db.session.query(UserCompanyAccess.user_id).join(User, User.id == UserCompanyAccess.user_id).filter(UserCompanyAccess.company_id == co.id, User.active.is_(True)).all()}
+        assert delete_world["staff"] not in {row.user_id for row in UserCompanyAccess.query.filter_by(company_id=co.id).all() if row.user.is_active and row.can_manage_users()}
+        assert co.team_member_count == 4
+        staff = db.session.get(User, delete_world["staff"])
+        assert staff.archived_at is not None
+        assert staff.archived_by_user_id == delete_world["manager"]
+
+
+def test_final_owner_protection_ignores_inactive_owners(client, delete_world):
+    with client.application.app_context():
+        co_id = delete_world["co"]
+        inactive_owner = User(username="inactive_owner", email="inactive_owner@test.com", password_hash=generate_password_hash("pw"), default_company_id=co_id, active=False)
+        db.session.add(inactive_owner)
+        db.session.flush()
+        db.session.add(UserCompanyAccess(user_id=inactive_owner.id, company_id=co_id, role="owner", is_default=True))
+        db.session.commit()
+
+    login(client, delete_world["manager"])
+    resp = client.post(f"/user/delete/{delete_world['owner']}")
+    assert resp.status_code == 302
+    assert "Another administrator or owner must be assigned before this account can be removed." in flashed(client)
+
+
+def _csrf_from_manage_users(client):
+    import re
+    page = client.get("/user/manage-users")
+    assert page.status_code == 200
+    match = re.search(rb'name="csrf_token" value="([^"]+)"', page.data)
+    assert match, page.data[:500]
+    return match.group(1).decode()
+
+
+def test_authenticated_admin_post_with_valid_csrf_succeeds_integration_style(csrf_app):
+    with csrf_app.test_client() as client:
+        with csrf_app.app_context():
+            co = Company(name="CSRF Success Co", is_active=True)
+            db.session.add(co)
+            db.session.flush()
+            owner = User(username="csrf_success_owner", email="csrf_success_owner@test.com", password_hash=generate_password_hash("pw"), default_company_id=co.id)
+            staff = User(username="csrf_success_staff", email="csrf_success_staff@test.com", password_hash=generate_password_hash("pw"), default_company_id=co.id)
+            db.session.add_all([owner, staff])
+            db.session.flush()
+            db.session.add_all([
+                UserCompanyAccess(user_id=owner.id, company_id=co.id, role="owner", is_default=True),
+                UserCompanyAccess(user_id=staff.id, company_id=co.id, role="staff", is_default=True, can_access_full_app=True),
+            ])
+            db.session.commit()
+            owner_id, staff_id = owner.id, staff.id
+        login(client, owner_id)
+        csrf_token = _csrf_from_manage_users(client)
+        resp = client.post(f"/user/delete/{staff_id}", data={"csrf_token": csrf_token})
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/user/manage-users")
+        assert any("has been deactivated" in msg for msg in flashed(client))
+        with csrf_app.app_context():
+            assert db.session.get(User, staff_id).active is False
+
+
+@pytest.fixture
+def csrf_app():
+    os.environ.setdefault("TWILIO_ACCOUNT_SID", "ACtest")
+    a = create_app()
+    a.config.update(TESTING=True, SERVER_NAME="localhost", WTF_CSRF_ENABLED=True, WTF_CSRF_TIME_LIMIT=None, SECRET_KEY="delete-test-secret")
+    yield a
+
+
+def test_delete_requires_csrf_when_enabled(csrf_app):
+    with csrf_app.test_client() as client:
+        with csrf_app.app_context():
+            co = Company(name="CSRF Co", is_active=True)
+            db.session.add(co)
+            db.session.flush()
+            owner = User(username="csrf_owner", email="csrf_owner@test.com", password_hash=generate_password_hash("pw"), default_company_id=co.id)
+            staff = User(username="csrf_staff", email="csrf_staff@test.com", password_hash=generate_password_hash("pw"), default_company_id=co.id)
+            db.session.add_all([owner, staff])
+            db.session.flush()
+            db.session.add_all([
+                UserCompanyAccess(user_id=owner.id, company_id=co.id, role="owner", is_default=True),
+                UserCompanyAccess(user_id=staff.id, company_id=co.id, role="staff", is_default=True),
+            ])
+            db.session.commit()
+            owner_id, staff_id = owner.id, staff.id
+        login(client, owner_id)
+        resp = client.post(f"/user/delete/{staff_id}")
+        assert resp.status_code == 302
+        assert any("Security check failed" in msg for msg in flashed(client))

--- a/user_management.py
+++ b/user_management.py
@@ -57,7 +57,7 @@ def manage_users():
     from services.comms_permissions import can_manage_users
     if not company or not can_manage_users(current_user, company.id):
         return make_response("Forbidden", 403)
-    users = User.query.order_by(User.created_at.desc()).all()
+    users = User.query.filter(User.active.is_(True)).order_by(User.created_at.desc()).all()
     return render_template('manage_users.html', users=users)
 
 @user_bp.route('/add-user', methods=['GET', 'POST'])


### PR DESCRIPTION
### Motivation
- Replace hard-deleting users with a safer deactivate/archive workflow to preserve related records and prevent accidental data loss.
- Ensure archived/inactive users cannot authenticate, be restored by remember cookies, or be counted toward team seats and permissions.
- Add explicit audit/logging and permission checks to make tenant-scoped deletions safer and easier to debug.

### Description
- Added `active`, `archived_at`, and `archived_by_user_id` columns to the `User` model and exposed `is_active` property to let Flask-Login reject inactive users.
- Updated `scripts/migrate_db.py` to include migrations for the new `user` columns.
- Reworked the tenant user removal endpoint to perform a controlled deactivation instead of deletion, with checks for CSRF, tenant scope, final-owner protection, self-deletion prevention, global admin protection, per-tenant access updates, audit logging, and specific handling for `IntegrityError` and other exceptions.  (`/user/delete/<id>`) 
- Enforced active-only queries in user listing and seat/permission computations (e.g. `team_member_count`, `manage_users` views), and prevented API access/permission changes for inactive users. 
- Updated auth handling to log CSRF failures with request ID and to show a safer flash message, and updated the `user_loader` to deny inactive users.
- Updated templates to include the CSRF token on the deactivate form and to change the confirmation copy to reflect deactivation semantics. 
- Added `services/comms_permissions` checks to ignore inactive users for access/phone-number listings.
- Added a documentation note `docs/company_logo_asset_deployment.md` to avoid committing production binary assets accidentally.
- Added integration-style tests in `tests/test_user_delete_route.py` covering authorization, CSRF behavior, deactivation effects, owner protections, IntegrityError and unexpected errors, and that deactivated users cannot authenticate or be restored via remember cookies.

### Testing
- Added `tests/test_user_delete_route.py` and executed the tests via `pytest` against the application test config; the newly added tests passed. 
- Ran `pytest` for the updated delete/deactivate flows and permission checks and observed no failures in the modified areas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a544b0320a48322b634cda1aac8ed40)