### PR TITLE
Add Contact Intelligence CRM, safe SQL migration runner, and user archive/restore flows

### DIFF
--- a/.github/workflows/push-to-production.yml
+++ b/.github/workflows/push-to-production.yml
@@ -68,14 +68,8 @@ jobs:
             test -n "${DATABASE_URL:-}"
 
             echo "== Forward-only migrations =="
-            if command -v psql >/dev/null 2>&1 && [ -d migrations ]; then
-              find migrations -maxdepth 1 -type f -name "*.sql" ! -iname "*rollback*" | sort | while read -r f; do
-                echo "Running migration: $f"
-                psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"
-              done
-            else
-              echo "No migrations directory or psql unavailable; skipping SQL migrations."
-            fi
+            test -x scripts/apply_migrations.sh
+            scripts/apply_migrations.sh "$DATABASE_URL" migrations
 
             echo "== Python syntax check =="
             if [ -x ".venv/bin/python" ]; then

--- a/app.py
+++ b/app.py
@@ -17,8 +17,8 @@ try:
 except ImportError:
     pass
 
-from flask import Flask, g, has_request_context, jsonify, redirect, request
-from flask_login import LoginManager
+from flask import Flask, g, has_request_context, jsonify, redirect, request, session
+from flask_login import LoginManager, current_user, logout_user
 from werkzeug.middleware.proxy_fix import ProxyFix
 from extensions import db, csrf  # csrf used below to exempt Stripe routes
 
@@ -298,6 +298,9 @@ def create_app() -> Flask:
         _log = _logging.getLogger("auth")
         try:
             u = db.session.get(User, int(user_id))
+            if u is not None and not getattr(u, "active", True):
+                _log.info("USER_LOADER: id=%s is archived/inactive; refusing session", user_id)
+                return None
             _log.info("USER_LOADER: id=%s → user=%s (authenticated=%s)", user_id, u, bool(u))
             return u
         except Exception as _exc:
@@ -311,6 +314,14 @@ def create_app() -> Flask:
     def assign_request_id():
         g.request_id = request.headers.get("X-Request-ID") or str(uuid4())
         g.request_started_at = time.time()
+        if current_user.is_authenticated:
+            revoked = getattr(current_user, "session_revoked_at", None)
+            session_revoked = session.get("user_session_revoked_at")
+            revoked_marker = revoked.isoformat() if revoked else None
+            if not getattr(current_user, "active", True) or (revoked_marker and session_revoked != revoked_marker):
+                logout_user()
+                session.clear()
+                return redirect("/auth/login")
         # Replit's proxy delivers HTTPS externally but passes HTTP internally.
         # Force WSGI to treat requests as HTTPS so Secure cookies are accepted.
         if is_replit and request.environ.get("wsgi.url_scheme") != "https":

--- a/auth.py
+++ b/auth.py
@@ -126,6 +126,15 @@ def login():
                 logger.warning("Auth login template missing: %s", exc)
                 return render_template("login.html")
 
+        if not getattr(user, "active", True):
+            logger.warning("LOGIN FAIL: user is archived/inactive for %r", identifier)
+            flash("This account has been archived. Ask an administrator to restore access.", "error")
+            try:
+                return render_template("auth/login.html")
+            except TemplateNotFound as exc:
+                logger.warning("Auth login template missing: %s", exc)
+                return render_template("login.html")
+
         if not user.password_hash:
             logger.warning("LOGIN FAIL: user has no password hash for %r", identifier)
             flash("This account doesn't have a password set. Use SSO or ask an admin to set a password.", "error")
@@ -149,6 +158,8 @@ def login():
         from flask import session as _session
         _session.permanent = True
         login_user(user, remember=True)
+        revoked = getattr(user, "session_revoked_at", None)
+        _session["user_session_revoked_at"] = revoked.isoformat() if revoked else None
         logger.info("LOGIN: after login_user — session keys=%s, _user_id=%s, is_authenticated=%s, user.id=%s, is_secure=%s, scheme=%s",
                     list(_session.keys()), _session.get('_user_id'), current_user.is_authenticated, user.id,
                     request.is_secure, request.environ.get('wsgi.url_scheme'))

--- a/docs/migration_transaction_audit.md
+++ b/docs/migration_transaction_audit.md
@@ -1,0 +1,36 @@
+# Migration transaction audit
+
+Static audit date: 2026-07-18.
+
+The runner defaults migrations to `psql --single-transaction -v ON_ERROR_STOP=1` unless a file is already explicitly wrapped in `BEGIN;`/`COMMIT;`. Files containing transaction-incompatible statements such as `CREATE INDEX CONCURRENTLY`, `VACUUM`, `REINDEX`, `CLUSTER`, `CREATE DATABASE`, `DROP DATABASE`, or `ALTER TYPE ... ADD VALUE` are rejected unless they carry explicit nontransactional metadata and are allowlisted at runtime.
+
+## Classification
+
+| Migration | Classification | Notes |
+|---|---|---|
+| `20260613_sms_campaign_compliance.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `20260615_pwa_phone_system.sql` | Already transaction wrapped | Contains explicit `BEGIN;` and `COMMIT;`; runner does not add `--single-transaction`. |
+| `20260616_agent_company_scope.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `20260616_sms_campaign_segment.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `20260617_comms_phone_number_permissions.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `20260617_sms_campaign_audit_fix.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `20260618_segment_management_suppression.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `20260619_sms_phone_line_campaign_completion.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `20260620_voice_notification_calllog_compat.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `20260621_contact_name_backfill_fields.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `20260621_license_billing_feature_management.sql` | Safe with `--single-transaction` | Includes idempotent seed/upsert statements; no transaction-incompatible statements found. |
+| `20260621_pwa_alerts_greetings.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `20260622_after_hours_sms_canonical.sql` | Safe with `--single-transaction` | Includes data backfill `UPDATE`; no transaction-incompatible statements found. |
+| `20260623_paylink_documenso_production_fix.sql` | Already transaction wrapped | Contains explicit `BEGIN;` and `COMMIT;`; runner does not add `--single-transaction`. |
+| `20260630_contact_source_dedupe.sql` | Safe with `--single-transaction` | Includes data normalization `UPDATE`; no transaction-incompatible statements found. |
+| `20260702_pwa_device_approval.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `20260705_pwa_sound_forwarding_autoreply.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `20260714_contact_intelligence_crm.sql` | Safe with `--single-transaction` | Additive contact-intelligence migration; no transaction-incompatible statements found. |
+| `20260718_user_archive_restore.sql` | Safe with `--single-transaction` | Additive user/archive columns and idempotent active backfill; no transaction-incompatible statements found. |
+| `analytics_v3_7_2.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+| `marketing_hub_sms_20260615.sql` | Safe with `--single-transaction` | Contains PL/pgSQL `END;` block terminators but no top-level `COMMIT;` or transaction-incompatible statements. |
+| `phase_2_6_schema.sql` | Safe with `--single-transaction` | Static scan found no transaction-incompatible statements. |
+
+## Rollback consequences
+
+No migration currently requires nontransactional execution. If a future migration is marked `-- luxit-migration: transaction=off`, the operator must allowlist its basename with `--allow-nontransactional` and document why PostgreSQL cannot roll it back atomically before deployment.

--- a/docs/patch_transfer_validation.md
+++ b/docs/patch_transfer_validation.md
@@ -1,0 +1,65 @@
+# Patch transfer validation
+
+Validation date: 2026-07-18.
+
+## Verified base
+
+`46101128e01c2ddc316718a581814d802cc403d4` (`Merge pull request #210 from ldshawver/codex/instrument-client-push-registration-lifecycle`).
+
+## Transfer artifacts
+
+Patch artifacts are intentionally not committed to the application branch. They were generated under `/tmp` for transfer:
+
+| Artifact | Size | SHA-256 | Base | Applies independently |
+|---|---:|---|---|---|
+| `/tmp/luxit-user-archive-fix.patch` | 39733 bytes | `ce6499b4cff678a414b1339204914edaf07b6be51e4043f9f05cadfa5ccd6221` | `46101128e01c2ddc316718a581814d802cc403d4` | Yes |
+| `/tmp/luxit-contact-intelligence.patch` | regenerated after removing user-archive references | `da0f38aaa899ad9726f90601e4f1dfe9bc13e30a5e1dd291d57811e9b5c63754` | `46101128e01c2ddc316718a581814d802cc403d4` | Yes |
+
+## User archive-only patch file list
+
+`git apply --stat /tmp/luxit-user-archive-fix.patch` produced 11 files:
+
+- `app.py`
+- `auth.py`
+- `docs/user_archive_access_audit.md`
+- `migrations/20260718_user_archive_restore.sql`
+- `models.py`
+- `routes.py`
+- `services/comms_permissions.py`
+- `services/user_lifecycle.py`
+- `templates/manage_users.html`
+- `tests/test_user_archive_migration_workflow.py`
+- `tests/test_user_archive_restore.py`
+
+`git apply --numstat /tmp/luxit-user-archive-fix.patch` produced:
+
+```text
+13	2	app.py
+11	0	auth.py
+16	0	docs/user_archive_access_audit.md
+17	0	migrations/20260718_user_archive_restore.sql
+26	7	models.py
+53	13	routes.py
+4	4	services/comms_permissions.py
+129	0	services/user_lifecycle.py
+37	6	templates/manage_users.html
+28	0	tests/test_user_archive_migration_workflow.py
+154	0	tests/test_user_archive_restore.py
+```
+
+No binary records were present, and the clean user-archive patch did not contain these Contact Intelligence identifiers: `contact_intelligence`, `google_contact`, `contact_dedupe`, `phone_normalization`, `marketing_api`, `twilio_service`, `contact_duplicate_review`, or `20260714_contact_intelligence_crm`.
+
+## Independent patch application
+
+Disposable worktrees were created at the verified base and tested with:
+
+- User archive only: `git apply --check /tmp/luxit-user-archive-fix.patch`, `git apply /tmp/luxit-user-archive-fix.patch`, `git diff --check`.
+- Contact Intelligence only: `git apply --check /tmp/luxit-contact-intelligence.patch`, `git apply /tmp/luxit-contact-intelligence.patch`, `git diff --check`.
+- User archive then Contact Intelligence: both patches applied and `git diff --check` passed.
+- Contact Intelligence then user archive: both patches applied and `git diff --check` passed.
+
+No required order is currently needed; both application orders succeeded in disposable worktrees.
+
+## Staging status
+
+Staging validation has not been performed. Production approval remains blocked until the user archive-only patch is applied and validated on staging.

--- a/docs/user_archive_access_audit.md
+++ b/docs/user_archive_access_audit.md
@@ -1,0 +1,16 @@
+# User archive access audit
+
+Standard user deletion is now archival. Historical records keep their user foreign keys; access-bearing records are deactivated or ignored for inactive users.
+
+| Access-bearing path | Archive action | Runtime guard |
+|---|---|---|
+| Password login | `User.active` is set false; login rejects inactive users. | `auth.login` checks `user.active`. |
+| Existing Flask session / remember cookie | `User.session_revoked_at` is updated; old session markers no longer match. | `app.before_request` logs out inactive/revoked sessions. |
+| Company membership via `default_company_id` | Archive clears `default_company_id` when archiving from that company. | `User.get_default_company` cannot resolve inactive archived users because loader denies them. |
+| `UserCompanyAccess` | Tenant row is set `is_active=false`, previous role is preserved. | `get_company_access` and comms permission helpers require active access. |
+| Manage Users | Access row toggles are blocked for archived users. | `/api/user/<id>/access` returns 409 for inactive users. |
+| PWA/mobile inbox | PWA and mobile flags are disabled on the tenant access row. | `user_access_for_company` rejects inactive users/access rows. |
+| Phone-number permissions | Per-number booleans are set false for the archived tenant. | Phone-number filters require explicit true permissions. |
+| Push/device access | Active push subscriptions for the tenant are disabled. | Push APIs filter `PushSubscription.is_active=true`. |
+| Provider/API credentials | Historical credential rows are preserved; user sessions are invalidated. | User-bound operational routes must still pass active-session checks. |
+| Audit/history rows | Preserved. | Archive/restore write `IntegrationAuditLog` events. |

--- a/docs_contact_intelligence.md
+++ b/docs_contact_intelligence.md
@@ -1,0 +1,98 @@
+# Contact Intelligence / CRM Rollout
+
+## Audit findings
+LUXit is a Flask + Flask-SQLAlchemy application. The canonical tenant is `Company` and the canonical contact model/table is `Contact` / `contact`. Existing contact-related tables include campaign recipients, SMS recipients, segment members, Twilio conversations/messages/call logs, contact activities, Google OAuth/sync jobs, integration audit logs, CRM deals/tasks, and conversion/analytics records.
+
+Known creation/update paths found in the audit:
+- `/contacts/add`, `/contacts/import`, import preview/template, and `/api/contacts/add-subscriber` in `routes.py`.
+- Marketing API duplicate review/merge and SMS audience workflows in `marketing_api.py`.
+- CSV/XLSX import and Twilio/marketing upsert through `services/contact_audience.py`.
+- Twilio inbound/outbound SMS/calls in `twilio_sms.py`, `inbox_pwa.py`, and `services/integrations/twilio_service.py`.
+- Existing Google Contacts OAuth/sync in `google_contacts.py` with `contacts.readonly` behavior and sync job auditing.
+- Existing merge helpers in `services/contact_dedupe.py` and source helpers in `services/contact_source.py`.
+
+Existing risks: duplicate logic previously included name+company as an automatic merge key; phone normalization was duplicated and regex-based; source fields were mutable single fields without append-only event history; Google token storage exists in a legacy table and should be migrated to the encrypted/ref based connection table for new work.
+
+## Schema changes
+Apply `migrations/20260714_contact_intelligence_crm.sql`. It adds nullable/backward-compatible Contact intelligence fields and creates `contact_phone_number`, `contact_email_address`, `contact_source_event`, `google_contact_connection`, `opportunity`, and `contact_task`.
+
+## Migration command
+Back up production first, then run the project’s normal SQL migration mechanism, for example:
+
+```bash
+psql "$DATABASE_URL" -f migrations/20260714_contact_intelligence_crm.sql
+```
+
+## Rollback procedure
+Because the migration is additive, preferred rollback is application rollback without dropping data. If required after backup, drop the added tables and columns in reverse order. Do not drop audit/source tables until exported.
+
+## Google Cloud Console
+Enable People API. Configure OAuth consent and redirect URI matching the existing `/twilio/google-contacts/callback`. Use only `https://www.googleapis.com/auth/contacts.readonly` until write/export is explicitly required.
+
+## Administrator cleanup order
+1. Audit only with `cleanup_audit(company_id)`.
+2. Back up `contact`, Twilio, campaign, segment, order/contract/invoice, and activity tables.
+3. Run idempotent phone normalization/backfill in batches.
+4. Backfill source attribution only from provable records; otherwise mark legacy/unknown.
+5. Generate duplicate candidates.
+6. Preview high-confidence merges.
+7. Merge only after administrator confirmation.
+8. Review ambiguous duplicates.
+9. Connect Google Contacts.
+10. Match unnamed contacts.
+11. Review ambiguous Google matches.
+12. Enable automatic enrichment.
+13. Monitor sync jobs/errors and retry failed batches.
+
+## Privacy and secrets
+Do not place OAuth/Twilio credentials in source, browser storage, logs, or diagnostics. Google matching defaults to company/user ownership and read-only contacts. Disable Google enrichment by disconnecting the connection or disabling the matching job; Twilio/contact creation continues.
+
+## Supported admin/API workflows
+All commands below are development/staging examples and must be run by an authenticated company admin through the existing Flask app; do not run production cleanup from a shell without a backup and approval.
+
+### Admin APIs
+- Audit / create a resumable job: `POST /api/marketing/contacts/intelligence/jobs` with JSON `{ "job_type": "duplicate_scan", "dry_run": true, "batch_size": 100 }`.
+- Normalize/backfill phones: same endpoint with `job_type=phone_backfill`; dry-run defaults to true; set `dry_run=false` only after backup.
+- Backfill provable attribution: `job_type=attribution_backfill`.
+- Generate duplicate candidates: `job_type=duplicate_scan`.
+- Match unnamed contacts from local Google cache: `job_type=unnamed_match` or `POST /api/marketing/contacts/google/match-unnamed`.
+- Run/resume a job: `POST /api/marketing/contacts/intelligence/jobs/<job_id>/run` with optional `{ "max_batches": 1 }`.
+- View job progress: `GET /api/marketing/contacts/intelligence/jobs/<job_id>`.
+- Google status: `GET /api/marketing/contacts/google/status`.
+- Google connect URL: `GET /api/marketing/contacts/google/connect`.
+- Google sync: `POST /api/marketing/contacts/google/sync`.
+- Disconnect Google: `POST /api/marketing/contacts/google/disconnect`.
+- Recheck one contact: `POST /api/marketing/contacts/<contact_id>/google/recheck`.
+- Review ambiguous Google matches: `GET /api/marketing/contacts/google/ambiguous`.
+- Accept/reject Google suggestion: `POST /api/marketing/contacts/<contact_id>/google/suggestion`.
+- Duplicate review UI: `GET /contacts/duplicates/review`.
+- Mark not duplicate: `POST /api/marketing/contacts/duplicates/not-duplicate`.
+
+### Job semantics
+Jobs are company scoped, admin controlled, batched by `batch_size`, resumed from `checkpoint.last_contact_id`, and safe to retry. Each job persists status, cursor/checkpoint, totals, processed, updated, skipped, ambiguous, failed, timestamps, initiating user, and sanitized error details in `contact_intelligence_job`. Logs remain in normal application logs; per-record failures are retained in the job row. Rollback is limited to restoring the pre-run database backup or manually reversing reviewed changes; merged contacts are archived rather than hard-deleted.
+
+## Contact path integration checklist
+| Contact path | Source value | Canonical resolver used | Exact-match behavior | Test added |
+|---|---|---|---|---|
+| `/contacts/add` | `manual_entry` | `resolve_contact` | Reuses same-company exact normalized phone/email | `test_contacts_add_route_uses_canonical_resolution` |
+| `/contacts/import` CSV | `csv_import` | `import_contacts` → `upsert_contact_from_source` → canonical normalizer/source events | Reuses same-company exact normalized phone/email | existing import tests + route coverage |
+| `/api/contacts/add-subscriber` | `manual_entry` | `resolve_contact` | Reuses same-company exact email | route covered indirectly through resolver tests |
+| Public newsletter form | `website_form` | `resolve_contact` with fallback company | Reuses exact email within fallback company | not yet route-tested |
+| Twilio inbound SMS conversation/capture | `twilio_inbound_sms` | `upsert_contact_from_source` | Reuses exact normalized phone within company | existing Twilio/contact tests |
+| Twilio integration unknown lead | `twilio_inbound_sms` | `resolve_contact` | Reuses exact normalized phone within company | syntax/target tests |
+| Google Contacts sync-created contacts | `google_contacts` | `resolve_contact` | Reuses exact normalized phone/email within company | Google matching tests |
+| Duplicate review mark-not-duplicate | n/a | persistent exclusion | Pair excluded from future candidates | `test_not_duplicate_pair_is_persisted_and_excluded` |
+| Contact intelligence jobs | `legacy` / job type | `sync_contact_points`, `apply_source_attribution`, Google local cache | Resumable by contact id cursor | `test_contact_intelligence_job_api_requires_admin_and_resumes` |
+
+## Current PR review of `f29fbb1`
+- Branch: `work`.
+- PR URL: unavailable in this container because no git remote/hosting metadata is configured.
+- Diff summary: 9 files, 690 insertions and 21 deletions in contact schema, migration, normalizer, intelligence service, dedupe hardening, import/upsert wiring, docs, and tests.
+- Production DB compatibility: LUXit production docs point to PostgreSQL. The migration uses PostgreSQL-compatible `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, `SERIAL`, partial indexes, and quoted `"user"`; it is not a SQLite migration and was not run against production.
+- Foreign keys: new FKs reference `company(id)`, `contact(id)`, and `"user"(id)`, matching the existing integer primary-key models.
+- Model/migration names: model columns match the migration for the deployed fields; `ContactSourceEvent.event_metadata` maps to SQL column `metadata` intentionally to avoid SQLAlchemy's reserved `metadata` attribute name.
+- Idempotency: migration uses `IF NOT EXISTS` for columns/tables/indexes and is designed to be re-runnable on PostgreSQL.
+- Model registration: new models import through `models.py`; circular import checks pass via `py_compile`.
+- Dependency conflicts: `phonenumbers==8.13.52` is a leaf dependency and no installed package in this repo pins an incompatible version.
+- Test caveat: most existing tests use SQLite/in-memory `db.create_all()`, which can conceal PostgreSQL-specific SQL migration errors; migration validation is therefore a separate staging step.
+- Scope: `f29fbb1` contained only LUXit contact/CRM work.

--- a/marketing_api.py
+++ b/marketing_api.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import os
 from datetime import datetime
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, current_app
 from flask_login import current_user, login_required
 from sqlalchemy import or_
 
@@ -1112,3 +1112,231 @@ def api_email_campaign_send(campaign_id):
         db.session.add(CampaignRecipient(campaign_id=c.id, contact_id=contact.id)); sent += 1
     c.status = "sent"; c.sent_at = datetime.utcnow(); db.session.commit()
     return jsonify({"success": True, "sent": sent, "skipped": skipped})
+
+# ---------------------------------------------------------------------------
+# Contact Intelligence / CRM admin APIs
+# ---------------------------------------------------------------------------
+
+def _require_contact_admin():
+    if not getattr(current_user, "is_admin", False):
+        return False
+    return True
+
+
+def _contact_job_json(job):
+    return {
+        "id": job.id, "company_id": job.company_id, "job_type": job.job_type, "status": job.status,
+        "cursor": job.cursor, "batch_size": job.batch_size, "total_found": job.total_found,
+        "processed": job.processed, "updated": job.updated, "skipped": job.skipped,
+        "ambiguous": job.ambiguous, "failed": job.failed, "dry_run": job.dry_run,
+        "sanitized_last_error": job.sanitized_last_error,
+        "started_at": job.started_at.isoformat() if job.started_at else None,
+        "completed_at": job.completed_at.isoformat() if job.completed_at else None,
+    }
+
+
+@marketing_api_bp.post("/contacts/intelligence/jobs")
+@login_required
+def api_contact_intelligence_create_job():
+    if not _require_contact_admin():
+        return _json_error("admin required", 403)
+    cid = tenant_id()
+    data = request.get_json(silent=True) or {}
+    from services.contact_intelligence_jobs import create_job
+    try:
+        job = create_job(cid, data.get("job_type"), user_id=current_user.id, batch_size=int(data.get("batch_size") or 100), dry_run=data.get("dry_run", True))
+    except Exception as exc:
+        return _json_error(str(exc), 400)
+    return jsonify({"success": True, "job": _contact_job_json(job)})
+
+
+@marketing_api_bp.post("/contacts/intelligence/jobs/<int:job_id>/run")
+@login_required
+def api_contact_intelligence_run_job(job_id):
+    if not _require_contact_admin():
+        return _json_error("admin required", 403)
+    cid = tenant_id()
+    from models import ContactIntelligenceJob
+    from services.contact_intelligence_jobs import run_job
+    job = ContactIntelligenceJob.query.filter_by(id=job_id, company_id=cid).first()
+    if not job:
+        return _json_error("job not found", 404)
+    job = run_job(job.id, max_batches=int((request.get_json(silent=True) or {}).get("max_batches") or 1))
+    return jsonify({"success": True, "job": _contact_job_json(job)})
+
+
+@marketing_api_bp.get("/contacts/intelligence/jobs/<int:job_id>")
+@login_required
+def api_contact_intelligence_job_status(job_id):
+    cid = tenant_id()
+    from models import ContactIntelligenceJob
+    job = ContactIntelligenceJob.query.filter_by(id=job_id, company_id=cid).first()
+    if not job:
+        return _json_error("job not found", 404)
+    return jsonify({"success": True, "job": _contact_job_json(job)})
+
+
+@marketing_api_bp.get("/contacts/google/status")
+@login_required
+def api_google_contacts_status():
+    cid = tenant_id()
+    from services.google_contacts import get_token, token_needs_reconnect, upsert_connection_from_token, SCOPES
+    tok = get_token(current_user.id)
+    conn = upsert_connection_from_token(current_user.id, cid) if tok else None
+    db.session.commit()
+    return jsonify({
+        "success": True, "connected": bool(tok), "scope": SCOPES,
+        "oauth_expired": bool(token_needs_reconnect(tok)) if tok else False,
+        "google_account_email": getattr(tok, "google_account_email", None) if tok else None,
+        "connection_id": conn.id if conn else None,
+        "sync_status": getattr(conn, "sync_status", "disconnected") if conn else "disconnected",
+        "last_successful_sync_at": conn.last_successful_sync_at.isoformat() if conn and conn.last_successful_sync_at else None,
+    })
+
+
+@marketing_api_bp.post("/contacts/google/disconnect")
+@login_required
+def api_google_contacts_disconnect():
+    cid = tenant_id()
+    from services.google_contacts import disconnect
+    from models import GoogleContactConnection
+    disconnect(current_user.id)
+    conn = GoogleContactConnection.query.filter_by(company_id=cid, user_id=current_user.id).first()
+    if conn:
+        conn.sync_status = "disconnected"; conn.disconnected_at = datetime.utcnow()
+    db.session.commit()
+    return jsonify({"success": True, "connected": False})
+
+
+@marketing_api_bp.post("/contacts/google/sync")
+@login_required
+def api_google_contacts_sync():
+    if not _require_contact_admin():
+        return _json_error("admin required", 403)
+    cid = tenant_id(); data = request.get_json(silent=True) or {}
+    from services.google_contacts import sync_contacts, upsert_connection_from_token
+    result = sync_contacts(current_user.id, cid, dry_run=bool(data.get("dry_run", False)))
+    conn = upsert_connection_from_token(current_user.id, cid)
+    conn.sync_status = "failed" if result.get("error") else "synced"
+    conn.last_error = result.get("error")
+    if not result.get("error"):
+        conn.last_successful_sync_at = datetime.utcnow()
+    db.session.commit()
+    result.pop("access_token", None); result.pop("refresh_token", None)
+    return jsonify({"success": not bool(result.get("error")), "result": result})
+
+
+@marketing_api_bp.post("/contacts/google/match-unnamed")
+@login_required
+def api_google_match_unnamed():
+    if not _require_contact_admin():
+        return _json_error("admin required", 403)
+    cid = tenant_id(); data = request.get_json(silent=True) or {}
+    from services.contact_intelligence_jobs import create_job, run_job
+    job = create_job(cid, "unnamed_match", user_id=current_user.id, batch_size=int(data.get("batch_size") or 100), dry_run=bool(data.get("dry_run", False)))
+    job = run_job(job.id, max_batches=int(data.get("max_batches") or 1))
+    return jsonify({"success": True, "job": _contact_job_json(job)})
+
+
+@marketing_api_bp.post("/contacts/<int:contact_id>/google/recheck")
+@login_required
+def api_google_recheck_contact(contact_id):
+    cid = tenant_id()
+    from models import Contact, GoogleContactLookup
+    from services.contact_intelligence import apply_google_name_match
+    contact = Contact.query.filter_by(id=contact_id, company_id=cid, is_active=True).first()
+    if not contact:
+        return _json_error("contact not found", 404)
+    lookups = GoogleContactLookup.query.filter_by(company_id=cid, normalized_phone=contact.normalized_phone).all() if contact.normalized_phone else []
+    candidates = []
+    for l in lookups:
+        candidates.extend(l.candidates or [{"normalized_phone": l.normalized_phone, "name": l.display_name, "resource_id": l.resource_id, "etag": l.etag}])
+    status = apply_google_name_match(contact, candidates) if candidates else "not_found"
+    db.session.commit()
+    return jsonify({"success": True, "status": status, "contact_id": contact.id})
+
+
+@marketing_api_bp.get("/contacts/google/ambiguous")
+@login_required
+def api_google_ambiguous_matches():
+    cid = tenant_id()
+    from models import GoogleContactLookup
+    rows = GoogleContactLookup.query.filter_by(company_id=cid, is_ambiguous=True).limit(200).all()
+    return jsonify({"success": True, "matches": [{"id": r.id, "normalized_phone": r.normalized_phone, "candidate_count": r.candidate_count, "candidates": r.candidates} for r in rows]})
+
+
+@marketing_api_bp.post("/contacts/<int:contact_id>/google/suggestion")
+@login_required
+def api_google_suggestion_action(contact_id):
+    cid = tenant_id(); data = request.get_json(silent=True) or {}; action = data.get("action")
+    from models import Contact
+    from services.contact_intelligence import meaningful_name
+    contact = Contact.query.filter_by(id=contact_id, company_id=cid, is_active=True).first()
+    if not contact:
+        return _json_error("contact not found", 404)
+    if action == "accept":
+        name = (data.get("name") or "").strip()
+        if not name:
+            return _json_error("name is required", 400)
+        if not meaningful_name(contact):
+            contact.name = name; contact.display_name = name; contact.name_source = "google_contacts"; contact.google_match_status = "accepted"
+        else:
+            return _json_error("reliable contact name will not be overwritten", 409)
+    elif action == "reject":
+        contact.google_match_status = "rejected"
+    else:
+        return _json_error("action must be accept or reject", 400)
+    db.session.commit()
+    return jsonify({"success": True, "contact_id": contact.id, "google_match_status": contact.google_match_status})
+
+
+@marketing_api_bp.post("/contacts/duplicates/not-duplicate")
+@login_required
+def api_contact_not_duplicate():
+    if not _require_contact_admin():
+        return _json_error("admin required", 403)
+    cid = tenant_id(); data = request.get_json(silent=True) or {}
+    a, b = sorted([int(data.get("contact_id_a") or 0), int(data.get("contact_id_b") or 0)])
+    if not a or not b or a == b:
+        return _json_error("two distinct contact ids are required", 400)
+    from models import Contact, ContactDuplicateExclusion
+    if Contact.query.filter(Contact.company_id == cid, Contact.id.in_([a,b])).count() != 2:
+        return _json_error("contacts must belong to your company", 400)
+    row = ContactDuplicateExclusion.query.filter_by(company_id=cid, contact_id_a=a, contact_id_b=b).first()
+    if not row:
+        row = ContactDuplicateExclusion(company_id=cid, contact_id_a=a, contact_id_b=b, reason=data.get("reason"), created_by_user_id=current_user.id)
+        db.session.add(row)
+    db.session.commit()
+    return jsonify({"success": True, "excluded_pair": [a, b]})
+
+
+@marketing_api_bp.get("/contacts/reports/attribution")
+@login_required
+def api_contact_attribution_report():
+    cid = tenant_id()
+    from sqlalchemy import func
+    from models import Opportunity, ContactTask
+    by_original = db.session.query(Contact.original_source, func.count(Contact.id)).filter(Contact.company_id == cid).group_by(Contact.original_source).all()
+    by_latest = db.session.query(Contact.latest_source, func.count(Contact.id)).filter(Contact.company_id == cid).group_by(Contact.latest_source).all()
+    open_pipeline = db.session.query(Opportunity.stage, Opportunity.owner_user_id, func.coalesce(func.sum(Opportunity.estimated_value), 0)).filter(Opportunity.company_id == cid, Opportunity.status == "open").group_by(Opportunity.stage, Opportunity.owner_user_id).all()
+    won_by_source = db.session.query(Contact.original_source, func.coalesce(func.sum(Opportunity.estimated_value), 0)).join(Contact, Contact.id == Opportunity.contact_id).filter(Opportunity.company_id == cid, Opportunity.status == "won").group_by(Contact.original_source).all()
+    overdue = ContactTask.query.filter(ContactTask.company_id == cid, ContactTask.status == "open", ContactTask.due_at < datetime.utcnow()).count()
+    unnamed = Contact.query.filter(Contact.company_id == cid, Contact.is_active.is_(True), (Contact.name.is_(None)) | (Contact.name == "")).count()
+    return jsonify({"success": True, "labels": {"won_value": "won opportunity value, not collected revenue"}, "contacts_by_original_source": dict(by_original), "contacts_by_latest_source": dict(by_latest), "open_pipeline_value_by_stage_owner": [{"stage": s, "owner_user_id": o, "value": float(v or 0)} for s,o,v in open_pipeline], "won_opportunity_value_by_original_source": {k or "unknown": float(v or 0) for k,v in won_by_source}, "unnamed_contacts": unnamed, "followups_overdue": overdue})
+
+@marketing_api_bp.get("/contacts/google/connect")
+@login_required
+def api_google_contacts_connect():
+    from services.google_contacts import get_auth_url, SCOPES
+    if not os.environ.get("GOOGLE_CLIENT_ID"):
+        return _json_error("GOOGLE_CLIENT_ID is not configured", 400, scope=SCOPES)
+    return jsonify({"success": True, "auth_url": get_auth_url(state=str(current_user.id)), "scope": SCOPES, "callback": "/twilio/google-contacts/callback"})
+
+
+@marketing_api_bp.get("/contacts/google/callback")
+@login_required
+def api_google_contacts_callback_compat():
+    # Preserve existing Twilio callback and expose a CRM-scoped compatibility endpoint.
+    from flask import redirect, url_for
+    qs = request.query_string.decode()
+    return redirect((url_for("twilio.google_contacts_callback") if "twilio.google_contacts_callback" in current_app.view_functions else "/twilio/google-contacts/callback") + (f"?{qs}" if qs else ""))

--- a/migrations/20260714_contact_intelligence_crm.sql
+++ b/migrations/20260714_contact_intelligence_crm.sql
@@ -1,0 +1,137 @@
+-- Contact Intelligence, Deduplication, Google Contacts, Source Attribution, and Sales CRM
+-- Additive migration only. Cleanup/backfill jobs are deliberately not run by this migration.
+
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS display_name VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS business_name VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS primary_phone VARCHAR(50);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS phone_extension VARCHAR(30);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS primary_email VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS normalized_email VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS contact_type VARCHAR(50);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS lifecycle_stage VARCHAR(80) DEFAULT 'new_lead';
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS owner_user_id INTEGER REFERENCES "user"(id);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS status VARCHAR(40) DEFAULT 'active';
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS archived_at TIMESTAMP;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS original_source VARCHAR(80);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS latest_source VARCHAR(80);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS original_source_detail VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS latest_source_detail VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS original_source_campaign VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS latest_source_campaign VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS original_source_url VARCHAR(500);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS latest_source_url VARCHAR(500);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS original_referrer VARCHAR(500);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS latest_referrer VARCHAR(500);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS first_touch_at TIMESTAMP;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS last_touch_at TIMESTAMP;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER REFERENCES "user"(id);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS name_source VARCHAR(80) DEFAULT 'user';
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS google_contact_resource_id VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS google_contact_etag VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS google_match_status VARCHAR(50) DEFAULT 'not_checked';
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS google_match_confidence INTEGER;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS google_matched_at TIMESTAMP;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS google_sync_status VARCHAR(50);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS google_sync_error TEXT;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS google_name_last_checked_at TIMESTAMP;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS duplicate_status VARCHAR(50) DEFAULT 'unknown';
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS possible_duplicate_of_id INTEGER REFERENCES contact(id);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS duplicate_confidence INTEGER;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS duplicate_reason VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS merged_into_contact_id INTEGER REFERENCES contact(id);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS merged_at TIMESTAMP;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS merged_by_user_id INTEGER REFERENCES "user"(id);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS lead_status VARCHAR(80) DEFAULT 'new';
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS lead_score INTEGER DEFAULT 0;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS estimated_value NUMERIC(12,2);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS last_contacted_at TIMESTAMP;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS next_follow_up_at TIMESTAMP;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS last_activity_at TIMESTAMP;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS won_revenue NUMERIC(12,2);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS lost_reason VARCHAR(255);
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS do_not_contact BOOLEAN DEFAULT FALSE NOT NULL;
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS email_consent_status VARCHAR(30) DEFAULT 'unknown';
+
+CREATE INDEX IF NOT EXISTS ix_contact_company_normalized_phone ON contact(company_id, normalized_phone) WHERE normalized_phone IS NOT NULL;
+CREATE INDEX IF NOT EXISTS ix_contact_company_normalized_email ON contact(company_id, normalized_email) WHERE normalized_email IS NOT NULL;
+CREATE INDEX IF NOT EXISTS ix_contact_company_lifecycle ON contact(company_id, lifecycle_stage);
+CREATE INDEX IF NOT EXISTS ix_contact_company_owner ON contact(company_id, owner_user_id);
+CREATE INDEX IF NOT EXISTS ix_contact_company_followup ON contact(company_id, next_follow_up_at);
+
+CREATE TABLE IF NOT EXISTS contact_phone_number (
+  id SERIAL PRIMARY KEY, company_id INTEGER NOT NULL REFERENCES company(id), contact_id INTEGER NOT NULL REFERENCES contact(id),
+  original_value VARCHAR(80), normalized_value VARCHAR(32), extension VARCHAR(30), phone_type VARCHAR(40) DEFAULT 'mobile',
+  is_primary BOOLEAN DEFAULT FALSE NOT NULL, verification_status VARCHAR(40) DEFAULT 'unverified' NOT NULL, source VARCHAR(80),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS ix_contact_phone_company_norm ON contact_phone_number(company_id, normalized_value) WHERE normalized_value IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_contact_phone_primary ON contact_phone_number(contact_id) WHERE is_primary = TRUE;
+
+CREATE TABLE IF NOT EXISTS contact_email_address (
+  id SERIAL PRIMARY KEY, company_id INTEGER NOT NULL REFERENCES company(id), contact_id INTEGER NOT NULL REFERENCES contact(id),
+  original_value VARCHAR(255), normalized_value VARCHAR(255), email_type VARCHAR(40) DEFAULT 'work', is_primary BOOLEAN DEFAULT FALSE NOT NULL,
+  verification_status VARCHAR(40) DEFAULT 'unverified' NOT NULL, source VARCHAR(80), created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS ix_contact_email_company_norm ON contact_email_address(company_id, normalized_value) WHERE normalized_value IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS contact_source_event (
+  id SERIAL PRIMARY KEY, company_id INTEGER NOT NULL REFERENCES company(id), contact_id INTEGER NOT NULL REFERENCES contact(id), source VARCHAR(80) NOT NULL,
+  source_detail VARCHAR(255), campaign VARCHAR(255), source_url VARCHAR(500), referrer VARCHAR(500), event_type VARCHAR(80) DEFAULT 'touch' NOT NULL,
+  event_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL, metadata JSON, created_by_user_id INTEGER REFERENCES "user"(id)
+);
+CREATE INDEX IF NOT EXISTS ix_contact_source_event_company_contact ON contact_source_event(company_id, contact_id, event_at);
+CREATE INDEX IF NOT EXISTS ix_contact_source_event_source ON contact_source_event(company_id, source);
+
+CREATE TABLE IF NOT EXISTS google_contact_connection (
+  id SERIAL PRIMARY KEY, company_id INTEGER NOT NULL REFERENCES company(id), user_id INTEGER NOT NULL REFERENCES "user"(id),
+  google_account_email VARCHAR(255), encrypted_refresh_token_ref TEXT, scopes JSON, sync_status VARCHAR(50) DEFAULT 'disconnected' NOT NULL,
+  last_successful_sync_at TIMESTAMP, last_failure_at TIMESTAMP, last_error TEXT, disconnected_at TIMESTAMP,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_google_contact_connection_owner ON google_contact_connection(company_id, user_id);
+
+CREATE TABLE IF NOT EXISTS opportunity (
+  id SERIAL PRIMARY KEY, company_id INTEGER NOT NULL REFERENCES company(id), contact_id INTEGER NOT NULL REFERENCES contact(id), owner_user_id INTEGER REFERENCES "user"(id),
+  name VARCHAR(255) NOT NULL, pipeline VARCHAR(80) DEFAULT 'sales' NOT NULL, stage VARCHAR(80) DEFAULT 'new_lead' NOT NULL,
+  estimated_value NUMERIC(12,2), probability INTEGER DEFAULT 0 NOT NULL, expected_close_date DATE, status VARCHAR(40) DEFAULT 'open' NOT NULL,
+  won_lost_reason VARCHAR(255), next_action VARCHAR(255), follow_up_at TIMESTAMP, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS ix_opportunity_company_stage ON opportunity(company_id, stage, status);
+CREATE INDEX IF NOT EXISTS ix_opportunity_contact ON opportunity(contact_id);
+
+CREATE TABLE IF NOT EXISTS contact_task (
+  id SERIAL PRIMARY KEY, company_id INTEGER NOT NULL REFERENCES company(id), contact_id INTEGER NOT NULL REFERENCES contact(id), assigned_user_id INTEGER REFERENCES "user"(id),
+  title VARCHAR(255) NOT NULL, due_at TIMESTAMP, priority VARCHAR(30) DEFAULT 'normal' NOT NULL, status VARCHAR(40) DEFAULT 'open' NOT NULL,
+  reminder_at TIMESTAMP, completed_at TIMESTAMP, completed_by_user_id INTEGER REFERENCES "user"(id), created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS ix_contact_task_company_due ON contact_task(company_id, due_at, status);
+
+CREATE TABLE IF NOT EXISTS contact_intelligence_job (
+  id SERIAL PRIMARY KEY, company_id INTEGER NOT NULL REFERENCES company(id), user_id INTEGER REFERENCES "user"(id), job_type VARCHAR(80) NOT NULL,
+  status VARCHAR(40) DEFAULT 'queued' NOT NULL, cursor VARCHAR(255), batch_size INTEGER DEFAULT 100 NOT NULL,
+  total_found INTEGER DEFAULT 0 NOT NULL, processed INTEGER DEFAULT 0 NOT NULL, updated INTEGER DEFAULT 0 NOT NULL, skipped INTEGER DEFAULT 0 NOT NULL,
+  ambiguous INTEGER DEFAULT 0 NOT NULL, failed INTEGER DEFAULT 0 NOT NULL, dry_run BOOLEAN DEFAULT TRUE NOT NULL, checkpoint JSON, failures JSON,
+  sanitized_last_error TEXT, started_at TIMESTAMP, completed_at TIMESTAMP, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS ix_contact_intel_job_company_type ON contact_intelligence_job(company_id, job_type, status);
+
+CREATE TABLE IF NOT EXISTS google_contact_lookup (
+  id SERIAL PRIMARY KEY, company_id INTEGER NOT NULL REFERENCES company(id), user_id INTEGER NOT NULL REFERENCES "user"(id),
+  connection_id INTEGER REFERENCES google_contact_connection(id), normalized_phone VARCHAR(32) NOT NULL, display_name VARCHAR(255),
+  resource_id VARCHAR(255), etag VARCHAR(255), is_ambiguous BOOLEAN DEFAULT FALSE NOT NULL, candidate_count INTEGER DEFAULT 1 NOT NULL,
+  candidates JSON, last_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS ix_google_lookup_company_phone ON google_contact_lookup(company_id, normalized_phone);
+CREATE INDEX IF NOT EXISTS ix_google_lookup_user_phone ON google_contact_lookup(user_id, normalized_phone);
+
+CREATE TABLE IF NOT EXISTS contact_duplicate_exclusion (
+  id SERIAL PRIMARY KEY, company_id INTEGER NOT NULL REFERENCES company(id), contact_id_a INTEGER NOT NULL REFERENCES contact(id),
+  contact_id_b INTEGER NOT NULL REFERENCES contact(id), reason VARCHAR(255), created_by_user_id INTEGER REFERENCES "user"(id),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_contact_duplicate_exclusion_pair ON contact_duplicate_exclusion(company_id, contact_id_a, contact_id_b);

--- a/migrations/20260718_user_archive_restore.sql
+++ b/migrations/20260718_user_archive_restore.sql
@@ -1,0 +1,17 @@
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS active BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS archived_at TIMESTAMP NULL;
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS archived_by_user_id INTEGER NULL REFERENCES "user"(id) ON DELETE SET NULL;
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS archived_company_id INTEGER NULL REFERENCES company(id) ON DELETE SET NULL;
+
+ALTER TABLE user_company_access ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE user_company_access ADD COLUMN IF NOT EXISTS archived_at TIMESTAMP NULL;
+ALTER TABLE user_company_access ADD COLUMN IF NOT EXISTS archived_by_user_id INTEGER NULL REFERENCES "user"(id) ON DELETE SET NULL;
+ALTER TABLE user_company_access ADD COLUMN IF NOT EXISTS previous_role VARCHAR(20) NULL;
+
+CREATE INDEX IF NOT EXISTS ix_user_active_archived ON "user"(active, archived_at);
+CREATE INDEX IF NOT EXISTS ix_user_archived_company ON "user"(archived_company_id, archived_at);
+CREATE INDEX IF NOT EXISTS ix_user_company_access_active_company ON user_company_access(company_id, is_active, user_id);
+
+UPDATE "user" SET active = TRUE WHERE active IS NULL;
+UPDATE user_company_access SET is_active = TRUE WHERE is_active IS NULL;
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS session_revoked_at TIMESTAMP NULL;

--- a/models.py
+++ b/models.py
@@ -55,6 +55,10 @@ class UserCompanyAccess(db.Model):
     updated_at = db.Column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
     )
+    is_active = db.Column(db.Boolean, default=True, nullable=False)
+    archived_at = db.Column(db.DateTime, nullable=True)
+    archived_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    previous_role = db.Column(db.String(20), nullable=True)
 
     __table_args__ = (
         db.UniqueConstraint("user_id", "company_id", name="uq_user_company_access"),
@@ -92,7 +96,7 @@ class UserCompanyAccess(db.Model):
         ROLE_INBOX_ONLY: 0,
     }
 
-    user = db.relationship("User", backref=db.backref("company_access", lazy="dynamic"))
+    user = db.relationship("User", foreign_keys=[user_id], backref=db.backref("company_access", lazy="dynamic"))
     company = db.relationship(
         "Company", backref=db.backref("user_access", lazy="dynamic")
     )
@@ -217,6 +221,11 @@ class User(UserMixin, db.Model):
     updated_at = db.Column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
     )
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    archived_at = db.Column(db.DateTime, nullable=True)
+    archived_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    archived_company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=True)
+    session_revoked_at = db.Column(db.DateTime, nullable=True)
 
     # -------------------------
     # Relationships
@@ -245,6 +254,11 @@ class User(UserMixin, db.Model):
     # -------------------------
     def __repr__(self):
         return f"<User {self.username}>"
+
+    @property
+    def is_active(self):
+        """Flask-Login active flag: archived users cannot keep using sessions."""
+        return bool(self.active)
 
     def set_password(self, password: str):
         """Set password_hash for legacy tests and admin-created users."""
@@ -433,6 +447,7 @@ class User(UserMixin, db.Model):
                 .join(UserCompanyAccess, UserCompanyAccess.company_id == Company.id)
                 .filter(
                     UserCompanyAccess.user_id == self.id,
+                    UserCompanyAccess.is_active == True,
                     Company.is_active == True,
                 )
                 .all()
@@ -473,7 +488,7 @@ class User(UserMixin, db.Model):
     
     def get_company_access(self, company_id):
         return UserCompanyAccess.query.filter_by(
-            user_id=self.id, company_id=company_id
+            user_id=self.id, company_id=company_id, is_active=True
         ).first()
 
     def get_company_role(self, company_id):
@@ -705,11 +720,15 @@ class Company(db.Model):
         Counts a union of: users with ``default_company_id == self.id`` and
         users joined via the ``UserCompanyAccess`` table.
         """
-        from sqlalchemy import or_
-        via_access = db.session.query(UserCompanyAccess.user_id) \
-            .filter(UserCompanyAccess.company_id == self.id)
-        via_default = db.session.query(User.id) \
-            .filter(User.default_company_id == self.id)
+        via_access = (
+            db.session.query(UserCompanyAccess.user_id)
+            .join(User, User.id == UserCompanyAccess.user_id)
+            .filter(UserCompanyAccess.company_id == self.id, UserCompanyAccess.is_active == True, User.active == True)
+        )
+        via_default = (
+            db.session.query(User.id)
+            .filter(User.default_company_id == self.id, User.active == True)
+        )
         ids = {r[0] for r in via_access.all()} | {r[0] for r in via_default.all()}
         return len(ids)
 
@@ -846,7 +865,218 @@ class Contact(db.Model):
     marketing_preferences_updated_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
     marketing_preferences_updated_at = db.Column(db.DateTime)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    # Contact Intelligence / CRM extension fields (additive and nullable where possible).
+    display_name = db.Column(db.String(255), nullable=True)
+    business_name = db.Column(db.String(255), nullable=True)
+    primary_phone = db.Column(db.String(50), nullable=True)
+    phone_extension = db.Column(db.String(30), nullable=True)
+    primary_email = db.Column(db.String(255), nullable=True)
+    normalized_email = db.Column(db.String(255), nullable=True, index=True)
+    contact_type = db.Column(db.String(50), nullable=True)
+    lifecycle_stage = db.Column(db.String(80), default="new_lead", nullable=True, index=True)
+    owner_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True, index=True)
+    status = db.Column(db.String(40), default="active", nullable=True, index=True)
+    archived_at = db.Column(db.DateTime, nullable=True)
+    original_source = db.Column(db.String(80), nullable=True, index=True)
+    latest_source = db.Column(db.String(80), nullable=True, index=True)
+    original_source_detail = db.Column(db.String(255), nullable=True)
+    latest_source_detail = db.Column(db.String(255), nullable=True)
+    original_source_campaign = db.Column(db.String(255), nullable=True)
+    latest_source_campaign = db.Column(db.String(255), nullable=True)
+    original_source_url = db.Column(db.String(500), nullable=True)
+    latest_source_url = db.Column(db.String(500), nullable=True)
+    original_referrer = db.Column(db.String(500), nullable=True)
+    latest_referrer = db.Column(db.String(500), nullable=True)
+    first_touch_at = db.Column(db.DateTime, nullable=True)
+    last_touch_at = db.Column(db.DateTime, nullable=True)
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    name_source = db.Column(db.String(80), default="user", nullable=True)
+    google_contact_resource_id = db.Column(db.String(255), nullable=True, index=True)
+    google_contact_etag = db.Column(db.String(255), nullable=True)
+    google_match_status = db.Column(db.String(50), default="not_checked", nullable=True, index=True)
+    google_match_confidence = db.Column(db.Integer, nullable=True)
+    google_matched_at = db.Column(db.DateTime, nullable=True)
+    google_sync_status = db.Column(db.String(50), nullable=True)
+    google_sync_error = db.Column(db.Text, nullable=True)
+    google_name_last_checked_at = db.Column(db.DateTime, nullable=True)
+    duplicate_status = db.Column(db.String(50), default="unknown", nullable=True, index=True)
+    possible_duplicate_of_id = db.Column(db.Integer, db.ForeignKey("contact.id"), nullable=True, index=True)
+    duplicate_confidence = db.Column(db.Integer, nullable=True)
+    duplicate_reason = db.Column(db.String(255), nullable=True)
+    merged_into_contact_id = db.Column(db.Integer, db.ForeignKey("contact.id"), nullable=True, index=True)
+    merged_at = db.Column(db.DateTime, nullable=True)
+    merged_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    lead_status = db.Column(db.String(80), default="new", nullable=True, index=True)
+    lead_score = db.Column(db.Integer, default=0, nullable=True)
+    estimated_value = db.Column(db.Numeric(12, 2), nullable=True)
+    last_contacted_at = db.Column(db.DateTime, nullable=True, index=True)
+    next_follow_up_at = db.Column(db.DateTime, nullable=True, index=True)
+    last_activity_at = db.Column(db.DateTime, nullable=True, index=True)
+    won_revenue = db.Column(db.Numeric(12, 2), nullable=True)
+    lost_reason = db.Column(db.String(255), nullable=True)
+    do_not_contact = db.Column(db.Boolean, default=False, nullable=False)
+    email_consent_status = db.Column(db.String(30), default="unknown", nullable=True)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class ContactPhoneNumber(db.Model):
+    __tablename__ = "contact_phone_number"
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    contact_id = db.Column(db.Integer, db.ForeignKey("contact.id"), nullable=False, index=True)
+    original_value = db.Column(db.String(80), nullable=True)
+    normalized_value = db.Column(db.String(32), nullable=True, index=True)
+    extension = db.Column(db.String(30), nullable=True)
+    phone_type = db.Column(db.String(40), default="mobile", nullable=True)
+    is_primary = db.Column(db.Boolean, default=False, nullable=False)
+    verification_status = db.Column(db.String(40), default="unverified", nullable=False)
+    source = db.Column(db.String(80), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    contact = db.relationship("Contact", backref=db.backref("phone_numbers", lazy="dynamic"))
+
+
+class ContactEmailAddress(db.Model):
+    __tablename__ = "contact_email_address"
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    contact_id = db.Column(db.Integer, db.ForeignKey("contact.id"), nullable=False, index=True)
+    original_value = db.Column(db.String(255), nullable=True)
+    normalized_value = db.Column(db.String(255), nullable=True, index=True)
+    email_type = db.Column(db.String(40), default="work", nullable=True)
+    is_primary = db.Column(db.Boolean, default=False, nullable=False)
+    verification_status = db.Column(db.String(40), default="unverified", nullable=False)
+    source = db.Column(db.String(80), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    contact = db.relationship("Contact", backref=db.backref("email_addresses", lazy="dynamic"))
+
+
+class ContactSourceEvent(db.Model):
+    __tablename__ = "contact_source_event"
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    contact_id = db.Column(db.Integer, db.ForeignKey("contact.id"), nullable=False, index=True)
+    source = db.Column(db.String(80), nullable=False, index=True)
+    source_detail = db.Column(db.String(255), nullable=True)
+    campaign = db.Column(db.String(255), nullable=True)
+    source_url = db.Column(db.String(500), nullable=True)
+    referrer = db.Column(db.String(500), nullable=True)
+    event_type = db.Column(db.String(80), default="touch", nullable=False)
+    event_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False, index=True)
+    event_metadata = db.Column("metadata", JSON, default=dict)
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    contact = db.relationship("Contact", backref=db.backref("source_events", lazy="dynamic"))
+
+
+class GoogleContactConnection(db.Model):
+    __tablename__ = "google_contact_connection"
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False, index=True)
+    google_account_email = db.Column(db.String(255), nullable=True)
+    encrypted_refresh_token_ref = db.Column(db.Text, nullable=True)
+    scopes = db.Column(JSON, default=list)
+    sync_status = db.Column(db.String(50), default="disconnected", nullable=False)
+    last_successful_sync_at = db.Column(db.DateTime, nullable=True)
+    last_failure_at = db.Column(db.DateTime, nullable=True)
+    last_error = db.Column(db.Text, nullable=True)
+    disconnected_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class Opportunity(db.Model):
+    __tablename__ = "opportunity"
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    contact_id = db.Column(db.Integer, db.ForeignKey("contact.id"), nullable=False, index=True)
+    owner_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True, index=True)
+    name = db.Column(db.String(255), nullable=False)
+    pipeline = db.Column(db.String(80), default="sales", nullable=False)
+    stage = db.Column(db.String(80), default="new_lead", nullable=False, index=True)
+    estimated_value = db.Column(db.Numeric(12, 2), nullable=True)
+    probability = db.Column(db.Integer, default=0, nullable=False)
+    expected_close_date = db.Column(db.Date, nullable=True)
+    status = db.Column(db.String(40), default="open", nullable=False, index=True)
+    won_lost_reason = db.Column(db.String(255), nullable=True)
+    next_action = db.Column(db.String(255), nullable=True)
+    follow_up_at = db.Column(db.DateTime, nullable=True, index=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    contact = db.relationship("Contact", backref=db.backref("opportunities", lazy="dynamic"))
+
+
+class ContactTask(db.Model):
+    __tablename__ = "contact_task"
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    contact_id = db.Column(db.Integer, db.ForeignKey("contact.id"), nullable=False, index=True)
+    assigned_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True, index=True)
+    title = db.Column(db.String(255), nullable=False)
+    due_at = db.Column(db.DateTime, nullable=True, index=True)
+    priority = db.Column(db.String(30), default="normal", nullable=False)
+    status = db.Column(db.String(40), default="open", nullable=False, index=True)
+    reminder_at = db.Column(db.DateTime, nullable=True)
+    completed_at = db.Column(db.DateTime, nullable=True)
+    completed_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    contact = db.relationship("Contact", backref=db.backref("contact_tasks", lazy="dynamic"))
+
+
+class ContactIntelligenceJob(db.Model):
+    __tablename__ = "contact_intelligence_job"
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True, index=True)
+    job_type = db.Column(db.String(80), nullable=False, index=True)
+    status = db.Column(db.String(40), default="queued", nullable=False, index=True)
+    cursor = db.Column(db.String(255), nullable=True)
+    batch_size = db.Column(db.Integer, default=100, nullable=False)
+    total_found = db.Column(db.Integer, default=0, nullable=False)
+    processed = db.Column(db.Integer, default=0, nullable=False)
+    updated = db.Column(db.Integer, default=0, nullable=False)
+    skipped = db.Column(db.Integer, default=0, nullable=False)
+    ambiguous = db.Column(db.Integer, default=0, nullable=False)
+    failed = db.Column(db.Integer, default=0, nullable=False)
+    dry_run = db.Column(db.Boolean, default=True, nullable=False)
+    checkpoint = db.Column(JSON, default=dict)
+    failures = db.Column(JSON, default=list)
+    sanitized_last_error = db.Column(db.Text, nullable=True)
+    started_at = db.Column(db.DateTime, nullable=True)
+    completed_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class GoogleContactLookup(db.Model):
+    __tablename__ = "google_contact_lookup"
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False, index=True)
+    connection_id = db.Column(db.Integer, db.ForeignKey("google_contact_connection.id"), nullable=True, index=True)
+    normalized_phone = db.Column(db.String(32), nullable=False, index=True)
+    display_name = db.Column(db.String(255), nullable=True)
+    resource_id = db.Column(db.String(255), nullable=True, index=True)
+    etag = db.Column(db.String(255), nullable=True)
+    is_ambiguous = db.Column(db.Boolean, default=False, nullable=False)
+    candidate_count = db.Column(db.Integer, default=1, nullable=False)
+    candidates = db.Column(JSON, default=list)
+    last_seen_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class ContactDuplicateExclusion(db.Model):
+    __tablename__ = "contact_duplicate_exclusion"
+    id = db.Column(db.Integer, primary_key=True)
+    company_id = db.Column(db.Integer, db.ForeignKey("company.id"), nullable=False, index=True)
+    contact_id_a = db.Column(db.Integer, db.ForeignKey("contact.id"), nullable=False, index=True)
+    contact_id_b = db.Column(db.Integer, db.ForeignKey("contact.id"), nullable=False, index=True)
+    reason = db.Column(db.String(255), nullable=True)
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
 class ContactImportBatch(db.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -104,3 +104,4 @@ flask
 flask-sqlalchemy
 gunicorn
 psycopg2-binary
+phonenumbers==8.13.52

--- a/routes.py
+++ b/routes.py
@@ -21,7 +21,7 @@ try:
         AutomationTest, AutomationTriggerLibrary, AutomationABTest, Company, user_company,
         Deal, LeadScore, PersonalizationRule, KeywordResearch,
         Notification, InboxMessage, CampaignCost, CRMTask, Meeting, SalesStage,
-        TouchpointEvent, MarketingAuditLog, User,
+        TouchpointEvent, MarketingAuditLog, IntegrationAuditLog, User,
     )
     MODELS_AVAILABLE = True
 except ImportError as exc:
@@ -40,7 +40,7 @@ except ImportError as exc:
     Deal = LeadScore = PersonalizationRule = KeywordResearch = None
     Notification = InboxMessage = CampaignCost = None
     CRMTask = Meeting = SalesStage = TouchpointEvent = None
-    MarketingAuditLog = User = None
+    MarketingAuditLog = IntegrationAuditLog = User = None
 try:
     from email_service import EmailService
 except ImportError as exc:
@@ -2022,21 +2022,86 @@ def contacts():
     page = request.args.get('page', 1, type=int)
     search = request.args.get('search', '')
     
-    query = Contact.query.filter_by(is_active=True)
-    
+    company_id = getattr(current_user, 'default_company_id', None)
+    query = Contact.query.filter(Contact.company_id == company_id) if company_id else Contact.query.filter(Contact.id == -1)
+    show_archived = request.args.get('archived') in {'1', 'true', 'yes'}
+    if not show_archived:
+        query = query.filter(Contact.is_active.is_(True), Contact.archived_at.is_(None))
+    source = request.args.get('source')
+    if source:
+        query = query.filter(db.or_(Contact.original_source == source, Contact.latest_source == source, Contact.source == source))
+    if request.args.get('missing_name') in {'1', 'true'}:
+        query = query.filter(db.or_(Contact.name.is_(None), Contact.name == ''))
+    if request.args.get('google_status'):
+        query = query.filter(Contact.google_match_status == request.args['google_status'])
+    if request.args.get('duplicate_status'):
+        query = query.filter(Contact.duplicate_status == request.args['duplicate_status'])
+    if request.args.get('owner_user_id', type=int):
+        query = query.filter(Contact.owner_user_id == request.args.get('owner_user_id', type=int))
+    if request.args.get('stage'):
+        query = query.filter(Contact.lifecycle_stage == request.args['stage'])
+    if request.args.get('tag'):
+        query = query.filter(Contact.tags.ilike(f"%{request.args['tag']}%"))
+    if request.args.get('followup_overdue') in {'1', 'true'}:
+        query = query.filter(Contact.next_follow_up_at < datetime.utcnow())
+    if request.args.get('do_not_contact') in {'1', 'true'}:
+        query = query.filter(db.or_(Contact.do_not_contact.is_(True), Contact.do_not_sms.is_(True), Contact.do_not_email.is_(True)))
     if search:
         query = query.filter(or_(
             Contact.email.contains(search),
             Contact.first_name.contains(search),
             Contact.last_name.contains(search),
-            Contact.company.contains(search)
+            Contact.company.contains(search),
+            Contact.phone.contains(search)
         ))
-    
     contacts = query.order_by(Contact.created_at.desc()).paginate(
         page=page, per_page=20, error_out=False
     )
-    
-    return render_template('contacts.html', contacts=contacts, search=search)
+    from models import Opportunity
+    opp_values = dict(db.session.query(Opportunity.contact_id, db.func.coalesce(db.func.sum(Opportunity.estimated_value), 0)).filter(Opportunity.company_id == company_id, Opportunity.status == 'open').group_by(Opportunity.contact_id).all()) if company_id else {}
+    return render_template('contacts.html', contacts=contacts, search=search, show_archived=show_archived, opp_values=opp_values)
+
+
+def _trusted_public_company_id():
+    """Resolve public submissions without assigning arbitrary fallback companies."""
+    explicit = request.values.get("company_id") or request.headers.get("X-LUXIT-Company-ID") or os.environ.get("PUBLIC_NEWSLETTER_COMPANY_ID")
+    if explicit and str(explicit).isdigit():
+        company = Company.query.filter_by(id=int(explicit), is_active=True).first()
+        if company:
+            return company.id
+    host = (request.host or "").split(":", 1)[0].lower()
+    if host:
+        company = Company.query.filter(db.or_(db.func.lower(Company.custom_domain) == host, db.func.lower(Company.domain) == host) if hasattr(Company, "custom_domain") and hasattr(Company, "domain") else Company.id == -1).first()
+        if company:
+            return company.id
+    return None
+
+
+def _resolve_contact_from_route(company_id, *, email=None, phone=None, first_name=None, last_name=None,
+                                proposed_name=None, source='api', detail=None, segment=None, tags=None,
+                                user_id=None, metadata=None):
+    """Route-level wrapper so legacy import/webhook paths share canonical resolution."""
+    from services.contact_intelligence import resolve_contact
+    contact = resolve_contact(
+        company_id,
+        email=email,
+        phone=phone,
+        first_name=first_name or None,
+        last_name=last_name or None,
+        proposed_name=proposed_name or None,
+        source=source,
+        detail=detail,
+        user_id=user_id,
+        metadata=metadata,
+    )
+    if segment:
+        contact.segment = segment
+    if tags:
+        existing = {t.strip() for t in (contact.tags or '').split(',') if t.strip()}
+        for tag in [t.strip() for t in str(tags).split(',') if t.strip()]:
+            existing.add(tag)
+        contact.tags = ','.join(sorted(existing))
+    return contact
 
 
 def _scheduler_status():
@@ -3579,7 +3644,7 @@ def update_phone_line(number_id):
     company_id = _current_company_id()
     from models import TwilioPhoneNumber, IntegrationAuditLog
     line = TwilioPhoneNumber.query.filter_by(id=number_id, company_id=company_id).first_or_404()
-    for field in ['sms_webhook_url','voice_webhook_url','status_callback_webhook_url','timezone','sms_forward_to','call_forward_to','number_auto_reply_text','missed_call_text','voicemail_greeting_text','voicemail_greeting_audio_url']:
+    for field in ['sms_webhook_url','voice_webhook_url','status_callback_webhook_url','timezone','sms_forward_to','call_forward_to','number_auto_reply_text','missed_call_text','voicemail_greeting_text','voicemail_greeting_audio_url','after_hours_text']:
         setattr(line, field, request.form.get(field) or None)
     line.auto_reply_enabled = bool(request.form.get('auto_reply_enabled'))
     line.after_hours_sms_enabled = bool(request.form.get('after_hours_sms_enabled'))
@@ -4405,29 +4470,16 @@ def newsletter_subscribe():
     if not email or not validate_email(email):
         return jsonify({'success': False, 'message': 'Please enter a valid email address'}), 400
     
-    # Check if contact already exists
-    contact = Contact.query.filter_by(email=email).first()
-    
-    if contact:
-        if 'newsletter' not in (contact.tags or ''):
-            existing_tags = contact.tags.split(',') if contact.tags else []
-            if 'newsletter' not in existing_tags:
-                existing_tags.append('newsletter')
-                contact.tags = ','.join(existing_tags)
-                contact.updated_at = datetime.utcnow()
-                db.session.commit()
-                return jsonify({'success': True, 'message': 'You have been subscribed to our newsletter!'}), 200
-        return jsonify({'success': True, 'message': 'You are already subscribed to our newsletter!'}), 200
-    
-    # Create new contact
-    contact = Contact(
-        email=email,
-        source='newsletter_archive',
-        tags='newsletter',
-        is_active=True
-    )
-    
-    db.session.add(contact)
+    from services.contact_intelligence import resolve_contact
+    from services.contact_audience import add_contact_tag
+    company_id = _trusted_public_company_id()
+    if not company_id:
+        return jsonify({'success': False, 'message': 'Company could not be verified for this public form'}), 400
+    contact = resolve_contact(company_id, email=email, source='website_form', detail='Newsletter archive subscription')
+    add_contact_tag(contact, 'newsletter')
+    contact.is_active = True
+    contact.email_opt_in = True
+    contact.email_consent_status = 'opted_in'
     db.session.commit()
     
     return jsonify({'success': True, 'message': 'Thank you for subscribing to our newsletter!'}), 200
@@ -6422,27 +6474,37 @@ def manage_users():
     """Manage users page — owner/admin/manage-users scoped by tenant."""
     from models import User, UserCompanyAccess
     from services.comms_permissions import can_manage_users
+    from services.user_lifecycle import restoration_eligible
     try:
         company = current_user.get_default_company()
+        show_archived = request.args.get('archived') in {'1', 'true', 'yes'}
         if current_user.is_admin:
-            users = User.query.order_by(User.username).all()
+            q = User.query
+            users = q.filter(User.active.is_(False) if show_archived else User.active.is_(True)).order_by(User.username).all()
         else:
             if not company or not can_manage_users(current_user, company.id):
                 flash('Access denied. You need owner or manage-users permission.', 'danger')
                 return redirect(url_for('main.dashboard'))
-            user_ids = [a.user_id for a in UserCompanyAccess.query.filter_by(company_id=company.id).all()]
-            users = User.query.filter(User.id.in_(user_ids)).order_by(User.username).all()
+            access_ids = [a.user_id for a in UserCompanyAccess.query.filter_by(company_id=company.id, is_active=not show_archived).all()]
+            direct_ids = [u.id for u in User.query.filter_by(default_company_id=company.id, active=not show_archived).all()]
+            users = User.query.filter(User.id.in_(set(access_ids) | set(direct_ids))).order_by(User.username).all()
 
         # Build per-user access map {user_id: access_row} (tenant row first)
         all_access = (UserCompanyAccess.query.filter_by(company_id=company.id).all() if company and not current_user.is_admin else UserCompanyAccess.query.all())
         access_by_user = {}
         for acc in all_access:
             access_by_user.setdefault(acc.user_id, acc)
+        restoration_by_user = {}
+        if company:
+            for user in users:
+                restoration_by_user[user.id] = restoration_eligible(user, company.id)
 
         return render_template(
             'manage_users.html',
             users=users,
             access_by_user=access_by_user,
+            show_archived=show_archived,
+            restoration_by_user=restoration_by_user,
         )
     except Exception as e:
         logger.error("manage_users error: %s", e)
@@ -6486,19 +6548,47 @@ def edit_user(user_id):
 @main_bp.route('/user/delete/<int:user_id>', methods=['POST'])
 @login_required
 def delete_user(user_id):
-    """Delete a user (platform admin only)."""
-    if not current_user.is_admin:
+    """Archive a tenant user without deleting historical attribution."""
+    from models import User
+    from services.comms_permissions import can_manage_users
+    from services.user_lifecycle import archive_user_for_company
+    company = current_user.get_default_company()
+    if not current_user.is_admin and (not company or not can_manage_users(current_user, company.id)):
         flash('Access denied.', 'danger')
         return redirect(url_for('main.dashboard'))
-    from models import User
     user = User.query.get_or_404(user_id)
-    if user.id == current_user.id:
-        flash('Cannot delete your own account.', 'danger')
-        return redirect(url_for('main.manage_users'))
-    db.session.delete(user)
-    db.session.commit()
-    flash(f'User {user.username} deleted.', 'success')
+    try:
+        with db.session.begin_nested():
+            archive_user_for_company(user, company.id, current_user)
+        db.session.commit()
+        flash(f'User {user.username} archived.', 'success')
+    except Exception as exc:
+        db.session.rollback()
+        flash(str(exc), 'danger')
     return redirect(url_for('main.manage_users'))
+
+
+@main_bp.route('/user/restore/<int:user_id>', methods=['POST'])
+@login_required
+def restore_user(user_id):
+    """Restore a user only for the current tenant after validation."""
+    from models import User
+    from services.comms_permissions import can_manage_users
+    from services.user_lifecycle import restore_user_for_company
+    company = current_user.get_default_company()
+    if not current_user.is_admin and (not company or not can_manage_users(current_user, company.id)):
+        flash('Access denied.', 'danger')
+        return redirect(url_for('main.dashboard'))
+    user = User.query.get_or_404(user_id)
+    try:
+        with db.session.begin_nested():
+            restore_user_for_company(user, company.id, current_user)
+        db.session.commit()
+        flash(f'User {user.username} restored.', 'success')
+    except Exception as exc:
+        db.session.rollback()
+        flash(str(exc), 'danger')
+    return redirect(url_for('main.manage_users', archived='1'))
 
 @main_bp.route('/api/user/<int:user_id>/access', methods=['POST'])
 @login_required
@@ -6515,12 +6605,14 @@ def update_user_access(user_id):
         target = db.session.get(User, user_id)
         if not target:
             return jsonify({'success': False, 'error': 'User not found.'}), 404
+        if not getattr(target, "active", True):
+            return jsonify({'success': False, 'error': 'Archived users must be restored before access can be changed.'}), 409
 
         payload = request.get_json() or {}
 
         if not company:
             return jsonify({'success': False, 'error': 'No company context.'}), 400
-        acc = UserCompanyAccess.query.filter_by(user_id=target.id, company_id=company.id).first()
+        acc = UserCompanyAccess.query.filter_by(user_id=target.id, company_id=company.id, is_active=True).first()
         if not acc:
             if not current_user.is_admin:
                 return jsonify({'success': False, 'error': 'Target user is not in this tenant.'}), 403
@@ -8297,31 +8389,17 @@ def import_forminator_newsletter():
                 last_name = submission.get('last_name', '')
                 
                 if email:
-                    # Check if contact already exists
-                    contact = Contact.query.filter_by(email=email).first()
-                    
-                    if contact:
-                        # Update existing contact with Newsletter segment
-                        contact.segment = 'newsletter'
-                        if first_name:
-                            contact.first_name = first_name
-                        if last_name:
-                            contact.last_name = last_name
-                        contact.tags = 'newsletter_signup'
-                        contact.source = 'forminator'
-                    else:
-                        # Create new contact with Newsletter segment
-                        contact = Contact(
-                            email=email,
-                            first_name=first_name,
-                            last_name=last_name,
-                            segment='newsletter',
-                            tags='newsletter_signup',
-                            source='forminator',
-                            is_active=True
-                        )
-                        db.session.add(contact)
-                    
+                    _resolve_contact_from_route(
+                        current_user.get_default_company().id,
+                        email=email,
+                        first_name=first_name,
+                        last_name=last_name,
+                        source='website_form',
+                        detail='Forminator newsletter import form 3482',
+                        segment='newsletter',
+                        tags='newsletter_signup,forminator',
+                        user_id=current_user.id,
+                    )
                     import_count += 1
             
             db.session.commit()
@@ -8354,28 +8432,20 @@ def forminator_webhook():
         last_name = data.get('last_name') or data.get('fields', {}).get('last_name', {}).get('value', '')
         
         if email:
-            contact = Contact.query.filter_by(email=email).first()
-            
-            if contact:
-                contact.segment = 'newsletter'
-                contact.tags = 'newsletter_signup'
-                contact.source = 'forminator'
-                if first_name:
-                    contact.first_name = first_name
-                if last_name:
-                    contact.last_name = last_name
-            else:
-                contact = Contact(
-                    email=email,
-                    first_name=first_name,
-                    last_name=last_name,
-                    segment='newsletter',
-                    tags='newsletter_signup',
-                    source='forminator',
-                    is_active=True
-                )
-                db.session.add(contact)
-            
+            company_id = _trusted_public_company_id()
+            if not company_id:
+                return jsonify({'status': 'error', 'message': 'Unable to verify company for submission'}), 400
+            _resolve_contact_from_route(
+                company_id,
+                email=email,
+                first_name=first_name,
+                last_name=last_name,
+                source='website_form',
+                detail='Forminator newsletter webhook form 3482',
+                segment='newsletter',
+                tags='newsletter_signup,forminator',
+                metadata={'form_id': form_id},
+            )
             db.session.commit()
             return jsonify({'status': 'success', 'email': email}), 200
         
@@ -8434,26 +8504,17 @@ def import_wordpress_users():
                     # For now, we'll mark users with specific roles as members
                     has_membership = wp_role in ['member', 'premium', 'vip', 'administrator']
                     
-                    contact = Contact.query.filter_by(email=email).first()
-                    
-                    if contact:
-                        contact.segment = 'member' if has_membership else 'Website Users'
-                        contact.tags = f"{wp_role},wordpress_import,{username}"
-                        contact.first_name = first_name or contact.first_name
-                        contact.last_name = last_name or contact.last_name
-                        contact.source = 'wordpress'
-                    else:
-                        contact = Contact(
-                            email=email,
-                            first_name=first_name,
-                            last_name=last_name,
-                            segment='member' if has_membership else 'Website Users',
-                            tags=f"{wp_role},wordpress_import,{username}",
-                            source='wordpress',
-                            is_active=True
-                        )
-                        db.session.add(contact)
-                    
+                    _resolve_contact_from_route(
+                        current_user.get_default_company().id,
+                        email=email,
+                        first_name=first_name,
+                        last_name=last_name,
+                        source='website_form',
+                        detail=f'WordPress user import from {wordpress_url}',
+                        segment='member' if has_membership else 'Website Users',
+                        tags=f"{wp_role},wordpress_import,{username}",
+                        user_id=current_user.id,
+                    )
                     import_count += 1
             
             db.session.commit()
@@ -8482,30 +8543,21 @@ def wordpress_webhook():
         wp_role = data.get('role', 'subscriber')
         
         if email:
+            company_id = _trusted_public_company_id()
+            if not company_id:
+                return jsonify({'status': 'error', 'message': 'Unable to verify company for submission'}), 400
             has_membership = wp_role in ['member', 'premium', 'vip', 'administrator']
-            
-            contact = Contact.query.filter_by(email=email).first()
-            
-            if contact:
-                contact.segment = 'member' if has_membership else 'Website Users'
-                contact.tags = f"{wp_role},wordpress_user,{username}"
-                if first_name:
-                    contact.first_name = first_name
-                if last_name:
-                    contact.last_name = last_name
-                contact.source = 'wordpress'
-            else:
-                contact = Contact(
-                    email=email,
-                    first_name=first_name,
-                    last_name=last_name,
-                    segment='member' if has_membership else 'Website Users',
-                    tags=f"{wp_role},wordpress_user,{username}",
-                    source='wordpress',
-                    is_active=True
-                )
-                db.session.add(contact)
-            
+            _resolve_contact_from_route(
+                company_id,
+                email=email,
+                first_name=first_name,
+                last_name=last_name,
+                source='website_form',
+                detail='WordPress registration webhook',
+                segment='member' if has_membership else 'Website Users',
+                tags=f"{wp_role},wordpress_user,{username}",
+                metadata={'role': wp_role, 'username': username},
+            )
             db.session.commit()
             return jsonify({'status': 'success', 'email': email}), 200
         
@@ -8588,26 +8640,17 @@ def test_wordpress_import():
             
             has_membership = wp_role in ['member', 'premium', 'vip', 'administrator']
             
-            contact = Contact.query.filter_by(email=email).first()
-            
-            if contact:
-                contact.segment = 'member' if has_membership else 'Website Users'
-                contact.tags = f"{wp_role},wordpress_import,{username}"
-                contact.first_name = first_name or contact.first_name
-                contact.last_name = last_name or contact.last_name
-                contact.source = 'wordpress'
-            else:
-                contact = Contact(
-                    email=email,
-                    first_name=first_name,
-                    last_name=last_name,
-                    segment='member' if has_membership else 'Website Users',
-                    tags=f"{wp_role},wordpress_import,{username}",
-                    source='wordpress',
-                    is_active=True
-                )
-                db.session.add(contact)
-            
+            _resolve_contact_from_route(
+                current_user.get_default_company().id,
+                email=email,
+                first_name=first_name,
+                last_name=last_name,
+                source='website_form',
+                detail='Test WordPress import',
+                segment='member' if has_membership else 'Website Users',
+                tags=f"{wp_role},wordpress_import,{username}",
+                user_id=current_user.id,
+            )
             import_count += 1
         
         db.session.commit()
@@ -8696,6 +8739,13 @@ def zapier_contact_webhook():
         if not source:
             source = 'Zapier'
         
+        company_id = _trusted_public_company_id()
+        if not company_id:
+            return jsonify({
+                'success': False,
+                'error': 'Unable to verify company for submission'
+            }), 400
+
         # Parse name into first and last
         first_name = ''
         last_name = ''
@@ -8703,72 +8753,34 @@ def zapier_contact_webhook():
             name_parts = name.split(' ', 1)
             first_name = name_parts[0] if len(name_parts) > 0 else ''
             last_name = name_parts[1] if len(name_parts) > 1 else ''
-        
-        # Check for duplicate
-        existing_contact = Contact.query.filter_by(email=email).first()
-        
-        if existing_contact:
-            # Update existing contact
-            if first_name:
-                existing_contact.first_name = first_name
-            if last_name:
-                existing_contact.last_name = last_name
-            if phone:
-                existing_contact.phone = phone
-            
-            # Add zapier tag if not present
-            current_tags = existing_contact.tags or ''
-            if 'zapier' not in current_tags.lower():
-                existing_contact.tags = f"{current_tags},zapier".strip(',')
-            
-            # Set/update source to track where it came from
-            if not existing_contact.source:
-                existing_contact.source = source
-            
-            # Ensure Newsletter segment for signup sources
-            if 'newsletter' in source.lower() or 'signup' in source.lower():
-                existing_contact.segment = 'Newsletter'
-            elif not existing_contact.segment:
-                existing_contact.segment = 'lead'
-            
-            existing_contact.updated_at = datetime.utcnow()
-            db.session.commit()
-            
-            return jsonify({
-                'success': True,
-                'message': 'Contact updated successfully',
-                'action': 'updated',
-                'contact_id': existing_contact.id,
-                'email': existing_contact.email,
-                'segment': existing_contact.segment,
-                'source': existing_contact.source
-            }), 200
-        
-        else:
-            # Create new contact
-            new_contact = Contact()
-            new_contact.email = email
-            new_contact.first_name = first_name
-            new_contact.last_name = last_name
-            new_contact.phone = phone
-            new_contact.segment = 'Newsletter' if 'newsletter' in source.lower() or 'signup' in source.lower() else 'lead'
-            new_contact.tags = 'zapier'
-            new_contact.source = source
-            new_contact.is_active = True
-            
-            db.session.add(new_contact)
-            db.session.commit()
-            
-            return jsonify({
-                'success': True,
-                'message': 'Contact created successfully',
-                'action': 'created',
-                'contact_id': new_contact.id,
-                'email': new_contact.email,
-                'segment': new_contact.segment,
-                'source': new_contact.source
-            }), 201
-    
+
+        segment = 'Newsletter' if 'newsletter' in source.lower() or 'signup' in source.lower() else 'lead'
+        contact = _resolve_contact_from_route(
+            company_id,
+            email=email,
+            phone=phone,
+            first_name=first_name,
+            last_name=last_name,
+            proposed_name=name,
+            source='api',
+            detail=f'Zapier contact webhook: {source}',
+            segment=segment,
+            tags='zapier',
+            metadata={'source': source},
+        )
+        was_created = contact.created_at == contact.updated_at if getattr(contact, 'updated_at', None) else False
+        db.session.commit()
+
+        return jsonify({
+            'success': True,
+            'message': 'Contact resolved successfully',
+            'action': 'created_or_updated' if not was_created else 'created',
+            'contact_id': contact.id,
+            'email': contact.email,
+            'segment': contact.segment,
+            'source': contact.source or contact.latest_source
+        }), 200
+
     except Exception as e:
         logger.error(f'Deal creation error: {e}')
         return jsonify({'success': False, 'error': str(e)}), 400
@@ -10260,38 +10272,14 @@ def add_subscriber():
         if not email:
             return jsonify({'success': False, 'error': 'Email is required'}), 400
         
-        existing = Contact.query.filter_by(email=email).first()
-        if existing:
-            if 'newsletter' not in (existing.tags or ''):
-                existing_tags = existing.tags.split(',') if existing.tags else []
-                existing_tags.append('newsletter')
-                existing.tags = ','.join(existing_tags)
-                existing.subscribed_at = datetime.utcnow()
-                existing.subscription_source = 'manual'
-                if existing.segment == 'lead':
-                    existing.segment = 'newsletter'
-                db.session.commit()
-                return jsonify({
-                    'success': True,
-                    'message': f'{email} has been subscribed to the newsletter'
-                })
-            return jsonify({
-                'success': False,
-                'error': 'This email is already subscribed'
-            }), 400
-        
-        contact = Contact(
-            email=email,
-            first_name=first_name or None,
-            last_name=last_name or None,
-            segment='newsletter',
-            source='manual',
-            subscribed_at=datetime.utcnow(),
-            subscription_source='manual',
-            is_active=True,
-            tags='newsletter'
-        )
-        db.session.add(contact)
+        company_id = getattr(current_user, 'default_company_id', None)
+        from services.contact_intelligence import resolve_contact
+        from services.contact_audience import add_contact_tag
+        contact = resolve_contact(company_id, email=email, first_name=first_name or None, last_name=last_name or None, source='manual_entry', detail=f'Created manually by {getattr(current_user, "email", current_user.id)}', user_id=current_user.id)
+        add_contact_tag(contact, 'newsletter')
+        contact.segment = 'newsletter'
+        contact.email_opt_in = True
+        contact.email_consent_status = 'opted_in'
         db.session.commit()
         
         return jsonify({
@@ -10841,13 +10829,18 @@ def send_campaign(campaign_id):
 def add_contact():
     try:
         company_id = getattr(current_user, 'default_company_id', None)
-        contact = Contact(
-            email=request.form.get('email', ''),
-            first_name=request.form.get('first_name', ''),
-            last_name=request.form.get('last_name', ''),
-            company_id=company_id
+        from services.contact_intelligence import resolve_contact
+        contact = resolve_contact(
+            company_id,
+            phone=request.form.get('phone') or None,
+            email=request.form.get('email') or None,
+            first_name=request.form.get('first_name') or None,
+            last_name=request.form.get('last_name') or None,
+            business_name=request.form.get('company') or None,
+            source='manual_entry',
+            detail=f'Created manually by {getattr(current_user, "email", current_user.id)}',
+            user_id=current_user.id,
         )
-        db.session.add(contact)
         db.session.commit()
         log_activity(current_user.id, 'Added contact', f'{contact.first_name} {contact.last_name}'.strip() or contact.email, 'user-plus', company_id)
         if company_id:
@@ -10880,18 +10873,46 @@ def add_contact():
 @login_required
 def delete_contact(contact_id):
     try:
-        if Contact is not None:
-            contact = db.session.get(Contact, contact_id)
-            if contact:
-                db.session.delete(contact)
-                db.session.commit()
-                flash('Contact deleted successfully!', 'success')
-            else:
-                flash('Contact not found.', 'danger')
+        company_id = getattr(current_user, 'default_company_id', None)
+        contact = Contact.query.filter_by(id=contact_id, company_id=company_id).first()
+        if not contact:
+            flash('Contact not found.', 'danger')
+        elif Contact.query.filter_by(company_id=company_id, merged_into_contact_id=contact.id).first():
+            flash('This contact is a merge master; review merge history before archiving it.', 'warning')
+        elif getattr(contact, 'merged_into_contact_id', None) is None and getattr(contact, 'status', None) == 'merged':
+            flash('Merged contacts are retained for audit history.', 'warning')
+        else:
+            contact.archived_at = datetime.utcnow()
+            contact.status = 'archived'
+            contact.is_active = False
+            db.session.add(IntegrationAuditLog(company_id=company_id, service_slug='contacts', action='archive', user_id=current_user.id, changes={'contact_id': contact.id}))
+            db.session.commit()
+            flash('Contact archived successfully.', 'success')
     except Exception as e:
         db.session.rollback()
-        flash(f'Error deleting contact: {str(e)}', 'danger')
+        flash(f'Error archiving contact: {str(e)}', 'danger')
     return redirect(url_for('main.contacts'))
+
+
+@main_bp.route('/contacts/<int:contact_id>/restore', methods=['POST'])
+@login_required
+def restore_contact(contact_id):
+    try:
+        company_id = getattr(current_user, 'default_company_id', None)
+        contact = Contact.query.filter_by(id=contact_id, company_id=company_id).first()
+        if not contact:
+            flash('Contact not found.', 'danger')
+        else:
+            contact.archived_at = None
+            contact.status = 'active'
+            contact.is_active = True
+            db.session.add(IntegrationAuditLog(company_id=company_id, service_slug='contacts', action='restore', user_id=current_user.id, changes={'contact_id': contact.id}))
+            db.session.commit()
+            flash('Contact restored successfully.', 'success')
+    except Exception as e:
+        db.session.rollback()
+        flash(f'Error restoring contact: {str(e)}', 'danger')
+    return redirect(url_for('main.contacts', archived='1'))
 
 
 @main_bp.route('/contacts/export')
@@ -10932,18 +10953,9 @@ def import_contacts():
             file = request.files.get('file')
             if file and file.filename.endswith('.csv'):
                 company_id = getattr(current_user, 'default_company_id', None)
-                stream = io.StringIO(file.stream.read().decode('utf-8'))
-                reader = csv.DictReader(stream)
-                count = 0
-                for row in reader:
-                    contact = Contact(
-                        email=row.get('Email', row.get('email', '')),
-                        first_name=row.get('First Name', row.get('first_name', '')),
-                        last_name=row.get('Last Name', row.get('last_name', '')),
-                        company_id=company_id
-                    )
-                    db.session.add(contact)
-                    count += 1
+                from services.contact_audience import import_contacts as import_contact_file
+                result = import_contact_file(company_id, file.stream.read(), file.filename, source_provider='csv_import', tenant_id=company_id)
+                count = result.get('success_count', 0)
                 db.session.commit()
                 flash(f'Successfully imported {count} contacts!', 'success')
             else:
@@ -12620,3 +12632,56 @@ def admin_diagnostics_legacy():
         'recent_errors': read_logs('error', limit=20),
     }
     return render_template('admin_diagnostics.html', diagnostics=diagnostics)
+
+
+@main_bp.route('/contacts/duplicates/review')
+@login_required
+def contact_duplicate_review():
+    company_id = getattr(current_user, 'default_company_id', None)
+    from services.contact_dedupe import find_duplicate_contacts, related_record_counts
+    groups = find_duplicate_contacts(company_id) if company_id else []
+    counts = {}
+    for group in groups:
+        for c in group.get('contacts', []):
+            counts[c.id] = related_record_counts(c.id)
+    return render_template('contact_duplicate_review.html', groups=groups, related_counts=counts)
+
+
+@main_bp.route('/contacts/duplicates/review/scan', methods=['POST'])
+@login_required
+def contact_duplicate_review_scan():
+    company_id = getattr(current_user, 'default_company_id', None)
+    from services.contact_intelligence_jobs import create_job, run_job
+    job = create_job(company_id, 'duplicate_scan', user_id=current_user.id, dry_run=True)
+    run_job(job.id)
+    flash(f'Duplicate audit completed: {job.total_found} groups found.', 'info')
+    return redirect(url_for('main.contact_duplicate_review'))
+
+
+@main_bp.route('/contacts/duplicates/review/merge', methods=['POST'])
+@login_required
+def contact_duplicate_review_merge():
+    if not getattr(current_user, 'is_admin', False):
+        flash('Admin permission required.', 'danger')
+        return redirect(url_for('main.contact_duplicate_review'))
+    company_id = getattr(current_user, 'default_company_id', None)
+    ids = [int(x) for x in (request.form.get('contact_ids') or '').split(',') if x.strip().isdigit()]
+    primary_id = int(request.form.get('primary_contact_id') or 0)
+    action = request.form.get('action')
+    try:
+        if action == 'not_duplicate' and len(ids) >= 2:
+            from models import ContactDuplicateExclusion
+            a, b = sorted(ids[:2])
+            if not ContactDuplicateExclusion.query.filter_by(company_id=company_id, contact_id_a=a, contact_id_b=b).first():
+                db.session.add(ContactDuplicateExclusion(company_id=company_id, contact_id_a=a, contact_id_b=b, reason='admin review', created_by_user_id=current_user.id))
+                db.session.commit()
+            flash('Pair marked as not duplicate.', 'success')
+        elif action == 'merge' and primary_id in ids:
+            from services.contact_dedupe import merge_contacts
+            result = merge_contacts(primary_id, [x for x in ids if x != primary_id], actor_user_id=current_user.id, company_id=company_id)
+            flash(f'Merged {len(result.get("merged_contact_ids", []))} contacts.', 'success')
+        else:
+            flash('Invalid duplicate review action.', 'warning')
+    except Exception as exc:
+        db.session.rollback(); flash(str(exc), 'danger')
+    return redirect(url_for('main.contact_duplicate_review'))

--- a/scripts/apply_migrations.py
+++ b/scripts/apply_migrations.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Ledgered PostgreSQL SQL migration runner for LUXit deploys."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import psycopg2
+
+LOCK_KEY = 0x4C555849544D4947  # "LUXITMIG" truncated into a signed bigint-safe value
+VALID_NAME = re.compile(r"^[0-9A-Za-z_.-]+\.sql$")
+NONTRANSACTIONAL_MARKER = "-- luxit-migration: transaction=off"
+INCOMPATIBLE_TRANSACTION_RE = re.compile(
+    r"\b(CREATE\s+INDEX\s+CONCURRENTLY|REINDEX|VACUUM|CLUSTER|CREATE\s+DATABASE|DROP\s+DATABASE|ALTER\s+TYPE\b.*\bADD\s+VALUE)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Apply LUXit SQL migrations with a PostgreSQL ledger and advisory lock.")
+    parser.add_argument("database_url", nargs="?", default=os.environ.get("DATABASE_URL"))
+    parser.add_argument("migrations_dir", nargs="?", default="migrations")
+    parser.add_argument("--ledger-table", default=os.environ.get("MIGRATION_LEDGER_TABLE", "schema_migrations"))
+    parser.add_argument("--lock-timeout", type=int, default=int(os.environ.get("MIGRATION_LOCK_TIMEOUT_SECONDS", "60")))
+    parser.add_argument("--deployment-id", default=os.environ.get("GITHUB_SHA") or os.environ.get("DEPLOYMENT_ID"))
+    parser.add_argument("--allow-nontransactional", action="append", default=[], help="Explicit migration basename allowed to run without --single-transaction when marked transaction=off.")
+    return parser.parse_args()
+
+
+def quote_ident(name: str) -> str:
+    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name):
+        raise SystemExit(f"Unsafe ledger table name: {name!r}")
+    return '"' + name.replace('"', '""') + '"'
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    digest = h.hexdigest()
+    if not digest or len(digest) != 64:
+        raise SystemExit(f"Failed to calculate SHA-256 checksum for {path}")
+    return digest
+
+
+def discover_migrations(root: Path) -> list[Path]:
+    if not root.is_dir():
+        raise SystemExit(f"Migrations directory not found: {root}")
+    root_real = root.resolve()
+    seen: set[str] = set()
+    migrations: list[Path] = []
+    for child in root.iterdir():
+        if child.name.lower().endswith("rollback.sql") or "rollback" in child.name.lower():
+            continue
+        if child.suffix != ".sql":
+            if child.is_file():
+                raise SystemExit(f"Unexpected migration extension: {child.name}")
+            continue
+        if not VALID_NAME.match(child.name):
+            raise SystemExit(f"Unsafe migration filename: {child.name!r}")
+        if any(ord(ch) < 32 or ord(ch) == 127 for ch in child.name):
+            raise SystemExit(f"Migration filename contains control characters: {child.name!r}")
+        resolved = child.resolve()
+        if root_real not in [resolved, *resolved.parents]:
+            raise SystemExit(f"Migration symlink escapes migrations directory: {child}")
+        if child.name in seen:
+            raise SystemExit(f"Duplicate migration basename: {child.name}")
+        seen.add(child.name)
+        migrations.append(child)
+    ordered = sorted(migrations, key=lambda p: p.name)
+    if len({p.name for p in ordered}) != len(ordered):
+        raise SystemExit("Ambiguous migration ordering: duplicate basenames")
+    return ordered
+
+
+def acquire_lock(conn, timeout: int) -> None:
+    deadline = time.monotonic() + timeout
+    with conn.cursor() as cur:
+        while True:
+            cur.execute("SELECT pg_try_advisory_lock(%s)", (LOCK_KEY,))
+            if cur.fetchone()[0]:
+                return
+            if time.monotonic() >= deadline:
+                raise SystemExit(f"Timed out waiting for migration advisory lock after {timeout}s; another migration process may be running")
+            time.sleep(1)
+
+
+def ensure_ledger(conn, table_ident: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(f"""
+            CREATE TABLE IF NOT EXISTS {table_ident} (
+              filename text PRIMARY KEY,
+              checksum text NOT NULL,
+              applied_at timestamptz NOT NULL DEFAULT now(),
+              duration_ms integer NOT NULL DEFAULT 0,
+              deployment_id text NULL,
+              applied_by text NULL,
+              database_identity text NULL
+            )
+        """)
+    conn.commit()
+
+
+def database_identity(conn) -> str:
+    with conn.cursor() as cur:
+        cur.execute("SELECT current_database() || '@' || inet_server_addr()::text || ':' || inet_server_port()::text")
+        return cur.fetchone()[0]
+
+
+def applied_checksum(conn, table_ident: str, filename: str) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute(f"SELECT checksum FROM {table_ident} WHERE filename = %s", (filename,))
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def insert_ledger(conn, table_ident: str, filename: str, checksum: str, duration_ms: int, deployment_id: str | None, db_ident: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            f"INSERT INTO {table_ident} (filename, checksum, duration_ms, deployment_id, applied_by, database_identity) VALUES (%s, %s, %s, %s, current_user, %s)",
+            (filename, checksum, duration_ms, deployment_id, db_ident),
+        )
+    conn.commit()
+
+
+def migration_transaction_mode(path: Path, allow_nontransactional: set[str]) -> list[str]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    head = text[:4096].lower()
+    if NONTRANSACTIONAL_MARKER in head:
+        if path.name not in allow_nontransactional:
+            raise SystemExit(f"Migration {path.name} is marked nontransactional but is not explicitly allowlisted")
+        return []
+    if INCOMPATIBLE_TRANSACTION_RE.search(text):
+        raise SystemExit(f"Migration {path.name} contains transaction-incompatible SQL and must be explicitly marked/allowlisted with rollback consequences documented")
+    if re.search(r"^\s*BEGIN\s*;", text, re.IGNORECASE | re.MULTILINE) and re.search(r"^\s*COMMIT\s*;", text, re.IGNORECASE | re.MULTILINE):
+        return []
+    return ["--single-transaction"]
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.database_url:
+        raise SystemExit("DATABASE_URL is required")
+    if "sha256" not in hashlib.algorithms_available:
+        raise SystemExit("Python hashlib SHA-256 support is required")
+    migrations = discover_migrations(Path(args.migrations_dir))
+    table_ident = quote_ident(args.ledger_table)
+    conn = psycopg2.connect(args.database_url)
+    conn.autocommit = True
+    try:
+        acquire_lock(conn, args.lock_timeout)
+        db_ident = database_identity(conn)
+        ensure_ledger(conn, table_ident)
+        for path in migrations:
+            checksum = sha256_file(path)
+            current = applied_checksum(conn, table_ident, path.name)
+            if current == checksum:
+                print(f"Skipping already-applied migration: {path.name}")
+                continue
+            if current and current != checksum:
+                raise SystemExit(f"Migration checksum changed after application: {path.name}")
+            flags = migration_transaction_mode(path, set(args.allow_nontransactional))
+            cmd = ["psql", args.database_url, "-v", "ON_ERROR_STOP=1", *flags, "-f", str(path)]
+            print("Running migration:", path)
+            started = time.monotonic()
+            subprocess.run(cmd, check=True)
+            duration_ms = int((time.monotonic() - started) * 1000)
+            insert_ledger(conn, table_ident, path.name, checksum, duration_ms, args.deployment_id, db_ident)
+    finally:
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT pg_advisory_unlock(%s)", (LOCK_KEY,))
+        finally:
+            conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/apply_migrations.sh
+++ b/scripts/apply_migrations.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec python3 "$SCRIPT_DIR/apply_migrations.py" "$@"

--- a/scripts/bootstrap_migration_ledger.py
+++ b/scripts/bootstrap_migration_ledger.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Dry-run-first helper for bootstrapping the migration ledger safely."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import socket
+from datetime import datetime, timezone
+from pathlib import Path
+
+from apply_migrations import discover_migrations, quote_ident, sha256_file
+
+try:
+    import psycopg2
+except Exception:  # pragma: no cover
+    psycopg2 = None
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Audit/bootstrap LUXit schema_migrations without guessing uncertain migrations.")
+    p.add_argument("database_url", nargs="?", default=os.environ.get("DATABASE_URL"))
+    p.add_argument("migrations_dir", nargs="?", default="migrations")
+    p.add_argument("--ledger-table", default=os.environ.get("MIGRATION_LEDGER_TABLE", "schema_migrations"))
+    p.add_argument("--commit", default=os.environ.get("GITHUB_SHA") or os.environ.get("DEPLOYMENT_ID"))
+    p.add_argument("--actor", default=os.environ.get("USER") or "unknown")
+    p.add_argument("--confirm", action="store_true", help="Insert ledger rows only for migrations proven_applied by automatic checks.")
+    p.add_argument("--json", action="store_true")
+    return p.parse_args()
+
+
+def db_identity(conn):
+    with conn.cursor() as cur:
+        cur.execute("SELECT current_database(), inet_server_addr()::text, inet_server_port()::text")
+        db, addr, port = cur.fetchone()
+    return {"database": db, "server": addr, "port": port}
+
+
+def classify(conn, filename: str) -> tuple[str, str]:
+    # This bootstrap is intentionally conservative. It does not infer application from later tables.
+    # Specific per-migration proof rules can be added here only when they verify exact effects.
+    return "cannot_determine_automatically", "No exact proof rule is defined for this migration; ledger row will not be inserted."
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.database_url:
+        raise SystemExit("DATABASE_URL is required")
+    if psycopg2 is None:
+        raise SystemExit("psycopg2 is required")
+    table_ident = quote_ident(args.ledger_table)
+    migrations = discover_migrations(Path(args.migrations_dir))
+    conn = psycopg2.connect(args.database_url)
+    conn.set_session(readonly=not args.confirm, autocommit=True)
+    report = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "actor": args.actor,
+        "host": socket.gethostname(),
+        "application_commit": args.commit,
+        "ledger_table": args.ledger_table,
+        "database_identity": db_identity(conn),
+        "dry_run": not args.confirm,
+        "migrations": [],
+    }
+    try:
+        for path in migrations:
+            status, reason = classify(conn, path.name)
+            item = {"filename": path.name, "checksum": sha256_file(path), "status": status, "reason": reason}
+            report["migrations"].append(item)
+        if args.confirm:
+            proven = [m for m in report["migrations"] if m["status"] == "proven_applied"]
+            if len(proven) != len(report["migrations"]):
+                raise SystemExit("Refusing to seed ledger: one or more migrations are partially applied or cannot be determined automatically")
+            with conn.cursor() as cur:
+                cur.execute(f"CREATE TABLE IF NOT EXISTS {table_ident} (filename text PRIMARY KEY, checksum text NOT NULL, applied_at timestamptz NOT NULL DEFAULT now(), duration_ms integer NOT NULL DEFAULT 0, deployment_id text NULL, applied_by text NULL, database_identity text NULL)")
+                for m in proven:
+                    cur.execute(f"INSERT INTO {table_ident} (filename, checksum, deployment_id, applied_by, database_identity) VALUES (%s, %s, %s, %s, current_database()) ON CONFLICT (filename) DO NOTHING", (m["filename"], m["checksum"], args.commit, args.actor))
+    finally:
+        conn.close()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        for m in report["migrations"]:
+            print(f"{m['filename']}: {m['status']} - {m['reason']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/comms_permissions.py
+++ b/services/comms_permissions.py
@@ -32,15 +32,15 @@ def normalize_role(role: str | None) -> str:
 
 def user_access_for_company(user, company_id: int):
     from models import UserCompanyAccess
-    if not user or not company_id:
+    if not user or not company_id or not getattr(user, "active", True):
         return None
-    return UserCompanyAccess.query.filter_by(user_id=user.id, company_id=company_id).first()
+    return UserCompanyAccess.query.filter_by(user_id=user.id, company_id=company_id, is_active=True).first()
 
 
 def can_manage_users(user, company_id: int) -> bool:
     if not user or not company_id:
         return False
-    if getattr(user, "is_admin", False):
+    if getattr(user, "is_admin", False) and getattr(user, "active", True):
         return True
     acc = user_access_for_company(user, company_id)
     return bool(acc and acc.can_manage_users())
@@ -69,7 +69,7 @@ def accessible_phone_numbers(user, company_id: int) -> list[str]:
         if ta.from_phone and ta.from_phone not in all_numbers:
             all_numbers.append(ta.from_phone)
 
-    if getattr(user, "is_admin", False) or role in {"owner", "admin"}:
+    if getattr(user, "is_admin", False) and getattr(user, "active", True) or role in {"owner", "admin"}:
         return all_numbers
 
     explicit = [

--- a/services/contact_audience.py
+++ b/services/contact_audience.py
@@ -12,18 +12,11 @@ PHONE_SOURCE_TAG_RULES = [{"phone_number": "+19165989519", "tag": "MyOrder Custo
 SYSTEM_KEYWORDS = {"STOP", "STOPALL", "UNSUBSCRIBE", "CANCEL", "END", "QUIT", "HELP", "INFO", "START", "UNSTOP"}
 
 
+from services.phone_normalization import normalize_phone_e164
+from services.contact_intelligence import apply_source_attribution, sync_contact_points
+
 def normalize_phone(number: str | None) -> str:
-    raw = (number or "").strip()
-    digits = re.sub(r"\D", "", raw)
-    if not digits:
-        return ""
-    if raw.startswith("+") and raw[1:].isdigit():
-        return raw
-    if len(digits) == 10:
-        return f"+1{digits}"
-    if len(digits) == 11 and digits.startswith("1"):
-        return f"+{digits}"
-    return f"+{digits}" if 10 <= len(digits) <= 15 else ""
+    return normalize_phone_e164(number)
 
 
 def _split_tags(tags):
@@ -98,6 +91,10 @@ def upsert_contact_from_source(company_id: int, phone: str | None = None, email:
         contact.source_phone_number = normalize_phone(source_phone_number)
     contact.source = contact.source or source_channel
     contact.source_detail = contact.source_detail or source_context
+    source_map = {"sms": "twilio_inbound_sms", "csv_import": "csv_import", "manual": "manual_entry", "api": "api"}
+    intel_source = source_map.get((source_channel or "").lower(), source_channel or "unknown")
+    sync_contact_points(contact, phone, email, intel_source)
+    apply_source_attribution(contact, intel_source, detail=source_context, metadata={"provider": source_provider, "source_phone_number": source_phone_number})
     contact.first_seen_at = contact.first_seen_at or now
     contact.last_seen_at = now
     contact.tenant_id = contact.tenant_id or tenant_id or company_id

--- a/services/contact_dedupe.py
+++ b/services/contact_dedupe.py
@@ -7,21 +7,15 @@ from collections import defaultdict
 from datetime import datetime
 
 from extensions import db
-from models import Contact, IntegrationAuditLog
+from models import Contact, IntegrationAuditLog, ContactDuplicateExclusion
 
 logger = logging.getLogger(__name__)
 
 
+from services.phone_normalization import normalize_phone_e164
+
 def normalize_phone(raw: str | None) -> str:
-    raw = (raw or "").strip()
-    digits = "".join(ch for ch in raw if ch.isdigit())
-    if raw.startswith("+") and raw[1:].isdigit():
-        return raw
-    if len(digits) == 10:
-        return f"+1{digits}"
-    if len(digits) == 11 and digits.startswith("1"):
-        return f"+{digits}"
-    return raw
+    return normalize_phone_e164(raw)
 
 
 def normalize_email(raw: str | None) -> str:
@@ -78,7 +72,7 @@ def _contact_keys(contact: Contact) -> set[str]:
     name = _full_name(contact)
     company = (contact.company or "").strip().lower()
     if name and company:
-        keys.add(f"company:{tenant}:name_company:{name}:{company}")
+        keys.add(f"company:{tenant}:possible_name_company:{name}:{company}")
     return keys
 
 
@@ -95,6 +89,13 @@ def find_duplicate_contacts(company_id: int | None = None) -> list[dict]:
         for key in _contact_keys(contact):
             buckets[key].append(contact)
 
+    excluded_pairs = set()
+    exq = ContactDuplicateExclusion.query
+    if company_id is not None:
+        exq = exq.filter_by(company_id=company_id)
+    for ex in exq.all():
+        excluded_pairs.add(tuple(sorted((ex.contact_id_a, ex.contact_id_b))))
+
     groups = []
     seen_sets = set()
     for key, group in buckets.items():
@@ -102,6 +103,8 @@ def find_duplicate_contacts(company_id: int | None = None) -> list[dict]:
             continue
         ids = tuple(sorted(c.id for c in group))
         if ids in seen_sets:
+            continue
+        if len(ids) == 2 and tuple(ids) in excluded_pairs:
             continue
         seen_sets.add(ids)
         groups.append({"match_key": key, "contact_ids": list(ids), "contacts": group})
@@ -158,6 +161,12 @@ def merge_contacts(primary_contact_id: int, duplicate_contact_ids: list[int], *,
         for table, count in changed.items():
             audit["references_reassigned"][table] = audit["references_reassigned"].get(table, 0) + count
         dup.is_active = False
+        dup.status = "merged"
+        dup.archived_at = datetime.utcnow()
+        dup.merged_into_contact_id = primary.id
+        dup.merged_at = datetime.utcnow()
+        dup.merged_by_user_id = actor_user_id
+        dup.duplicate_status = "merged"
 
     audit["opt_out_preservation"]["sms_opted_out_after"] = bool(primary.sms_opted_out or primary.do_not_sms or primary.sms_opt_out_at)
     audit["opt_out_preservation"]["email_unsubscribed_after"] = bool(primary.email_unsubscribed or primary.do_not_email)
@@ -260,6 +269,8 @@ def merge_duplicate_contacts(company_id: int | None = None, *, dry_run: bool = F
     merged = 0
     references = 0
     for group in groups:
+        if ":possible_name_company:" in group.get("match_key", ""):
+            continue
         contacts = sorted(group["contacts"], key=lambda c: (c.created_at or datetime.utcnow(), c.id))
         primary = contacts[0]
         duplicates = [c.id for c in contacts[1:]]
@@ -280,3 +291,22 @@ def _audit_merge(primary: Contact, audit: dict, *, actor_user_id: int | None) ->
             changes=audit,
         )
     )
+
+
+def related_record_counts(contact_id: int) -> dict[str, int]:
+    """Reflectively count every mapped FK that references Contact."""
+    counts: dict[str, int] = {}
+    for mapper in db.Model.registry.mappers:
+        cls = mapper.class_; table = mapper.local_table
+        if table.name == Contact.__tablename__:
+            continue
+        for column in table.columns:
+            for fk in column.foreign_keys:
+                if fk.column.table.name == Contact.__tablename__ and fk.column.name == "id":
+                    try:
+                        count = cls.query.filter(column == contact_id).count()
+                        if count:
+                            counts[table.name] = counts.get(table.name, 0) + count
+                    except Exception:
+                        counts[table.name] = counts.get(table.name, 0)
+    return counts

--- a/services/contact_intelligence.py
+++ b/services/contact_intelligence.py
@@ -1,0 +1,154 @@
+"""Contact intelligence services: attribution, resolution, dedupe, Google matching, CRM helpers."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from email.utils import parseaddr
+import re
+
+from sqlalchemy import or_, func
+
+from extensions import db
+from models import Contact, ContactEmailAddress, ContactPhoneNumber, ContactSourceEvent, ContactTask, Opportunity
+from services.phone_normalization import normalize_phone
+
+CONTROLLED_SOURCES = {
+    "twilio_inbound_sms", "twilio_inbound_call", "twilio_outbound_sms", "twilio_outbound_call",
+    "myorder_customer", "website_form", "manual_entry", "csv_import", "google_contacts", "api",
+    "referral", "campaign", "contract", "invoice", "unknown", "legacy",
+}
+PLACEHOLDER_NAMES = {"unknown", "caller", "new contact", "new caller", "no name", "n/a", "na"}
+
+
+def normalize_email(value: str | None) -> str:
+    addr = parseaddr(value or "")[1].strip().lower()
+    return addr if re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", addr) else ""
+
+
+def meaningful_name(contact: Contact | None = None, name: str | None = None) -> bool:
+    raw = (name if name is not None else (getattr(contact, "name", None) or getattr(contact, "display_name", None) or "")).strip()
+    if not raw or raw.lower() in PLACEHOLDER_NAMES:
+        return False
+    digits = re.sub(r"\D", "", raw)
+    return len(digits) < 7
+
+
+def apply_source_attribution(contact: Contact, source: str, *, detail: str | None = None, campaign: str | None = None,
+                             url: str | None = None, referrer: str | None = None, event_type: str = "touch",
+                             user_id: int | None = None, metadata: dict | None = None, at: datetime | None = None) -> ContactSourceEvent:
+    now = at or datetime.utcnow()
+    source = (source or "unknown").strip().lower()
+    if source not in CONTROLLED_SOURCES:
+        source = "api"
+    if not contact.original_source:
+        contact.original_source = contact.source or source
+        contact.original_source_detail = contact.source_detail or detail
+        contact.original_source_campaign = campaign
+        contact.original_source_url = url
+        contact.original_referrer = referrer
+        contact.first_touch_at = contact.source_added_at or now
+    contact.latest_source = source
+    contact.latest_source_detail = detail
+    contact.latest_source_campaign = campaign
+    contact.latest_source_url = url
+    contact.latest_referrer = referrer
+    contact.last_touch_at = now
+    contact.source = contact.source or source
+    contact.source_detail = contact.source_detail or detail
+    contact.source_added_at = contact.source_added_at or now
+    contact.source_added_by_user_id = contact.source_added_by_user_id or user_id
+    evt = ContactSourceEvent(company_id=contact.company_id, contact_id=contact.id, source=source, source_detail=detail,
+                             campaign=campaign, source_url=url, referrer=referrer, event_type=event_type,
+                             event_at=now, event_metadata=metadata or {}, created_by_user_id=user_id)
+    db.session.add(evt)
+    return evt
+
+
+def sync_contact_points(contact: Contact, phone: str | None, email: str | None, source: str) -> None:
+    if phone:
+        res = normalize_phone(phone)
+        if res.normalized:
+            contact.primary_phone = contact.primary_phone or res.original
+            contact.phone = contact.phone or res.original
+            contact.normalized_phone = contact.normalized_phone or res.normalized
+            contact.phone_extension = contact.phone_extension or res.extension
+            exists = ContactPhoneNumber.query.filter_by(company_id=contact.company_id, contact_id=contact.id, normalized_value=res.normalized).first()
+            if not exists:
+                db.session.add(ContactPhoneNumber(company_id=contact.company_id, contact_id=contact.id, original_value=res.original, normalized_value=res.normalized, extension=res.extension, is_primary=not bool(contact.phone_numbers.count()), source=source))
+    norm_email = normalize_email(email)
+    if norm_email:
+        contact.primary_email = contact.primary_email or email.strip()
+        contact.email = contact.email or email.strip()
+        contact.normalized_email = contact.normalized_email or norm_email
+        exists = ContactEmailAddress.query.filter_by(company_id=contact.company_id, contact_id=contact.id, normalized_value=norm_email).first()
+        if not exists:
+            db.session.add(ContactEmailAddress(company_id=contact.company_id, contact_id=contact.id, original_value=email.strip(), normalized_value=norm_email, is_primary=not bool(contact.email_addresses.count()), source=source))
+
+
+def resolve_contact(company_id: int, *, phone: str | None = None, email: str | None = None, proposed_name: str | None = None,
+                    first_name: str | None = None, last_name: str | None = None, business_name: str | None = None,
+                    source: str = "unknown", detail: str | None = None, tenant_id: int | None = None,
+                    user_id: int | None = None, metadata: dict | None = None) -> Contact:
+    phone_result = normalize_phone(phone)
+    norm_email = normalize_email(email)
+    q = Contact.query.filter(Contact.company_id == company_id, Contact.is_active.is_(True))
+    contact = None
+    if phone_result.normalized:
+        contact = q.filter(Contact.normalized_phone == phone_result.normalized).first()
+    if not contact and norm_email:
+        contact = q.filter(or_(Contact.normalized_email == norm_email, func.lower(Contact.email) == norm_email)).first()
+    if not contact:
+        contact = Contact(company_id=company_id, tenant_id=tenant_id or company_id, is_active=True, status="active", created_at=datetime.utcnow(), created_by_user_id=user_id)
+        db.session.add(contact); db.session.flush()
+    if proposed_name and not meaningful_name(contact):
+        contact.name = proposed_name.strip(); contact.display_name = proposed_name.strip(); contact.name_source = "user"
+    if first_name and not contact.first_name: contact.first_name = first_name.strip()
+    if last_name and not contact.last_name: contact.last_name = last_name.strip()
+    if business_name and not (contact.business_name or contact.company):
+        contact.business_name = business_name.strip(); contact.company = business_name.strip()
+    sync_contact_points(contact, phone, email, source)
+    apply_source_attribution(contact, source, detail=detail, user_id=user_id, metadata=metadata)
+    contact.last_activity_at = datetime.utcnow()
+    db.session.flush()
+    return contact
+
+
+def apply_google_name_match(contact: Contact, candidates: list[dict]) -> str:
+    exact = [c for c in candidates if c.get("normalized_phone") and c.get("normalized_phone") == contact.normalized_phone]
+    good = [c for c in exact if meaningful_name(name=c.get("name"))]
+    if not good:
+        contact.google_match_status = "not_found"; return "not_found"
+    resources = {c.get("resource_id") for c in good}
+    if len(good) > 1 and len(resources) > 1:
+        contact.google_match_status = "ambiguous"; contact.google_match_confidence = 50; return "ambiguous"
+    match = good[0]
+    if not meaningful_name(contact):
+        contact.name = match["name"]; contact.display_name = match["name"]; contact.name_source = "google_contacts"
+    contact.google_contact_resource_id = match.get("resource_id")
+    contact.google_contact_etag = match.get("etag")
+    contact.google_match_status = "matched"
+    contact.google_match_confidence = 100
+    contact.google_matched_at = datetime.utcnow()
+    return "matched"
+
+
+def create_follow_up_task(company_id: int, contact_id: int, title: str, *, assigned_user_id=None, due_at=None, priority="normal") -> ContactTask:
+    task = ContactTask(company_id=company_id, contact_id=contact_id, title=title, assigned_user_id=assigned_user_id, due_at=due_at, priority=priority)
+    db.session.add(task); return task
+
+
+def create_opportunity(company_id: int, contact_id: int, name: str, *, owner_user_id=None, stage="new_lead", estimated_value=None, probability=0) -> Opportunity:
+    opp = Opportunity(company_id=company_id, contact_id=contact_id, name=name, owner_user_id=owner_user_id, stage=stage, estimated_value=estimated_value, probability=probability)
+    db.session.add(opp); return opp
+
+
+def cleanup_audit(company_id: int) -> dict:
+    q = Contact.query.filter_by(company_id=company_id, is_active=True)
+    total = q.count(); invalid = missing = 0
+    phones = {}; emails = {}
+    for c in q.yield_per(500):
+        if c.phone and not normalize_phone(c.phone).normalized: invalid += 1
+        if not meaningful_name(c): missing += 1
+        if c.normalized_phone: phones.setdefault(c.normalized_phone, []).append(c.id)
+        if normalize_email(c.email): emails.setdefault(normalize_email(c.email), []).append(c.id)
+    exact = sum(len(v)-1 for v in list(phones.values())+list(emails.values()) if len(v)>1)
+    return {"company_id": company_id, "total_contacts_scanned": total, "exact_duplicates": exact, "possible_duplicates": 0, "invalid_phone_numbers": invalid, "missing_names": missing, "proposed_merges": exact, "cross_tenant_conflicts_blocked": 0}

--- a/services/contact_intelligence_jobs.py
+++ b/services/contact_intelligence_jobs.py
@@ -1,0 +1,103 @@
+"""Persistent, resumable contact-intelligence jobs using the app database."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from extensions import db
+from models import Contact, ContactIntelligenceJob, GoogleContactLookup
+from services.contact_intelligence import apply_source_attribution, apply_google_name_match, meaningful_name, normalize_email, sync_contact_points
+from services.contact_dedupe import find_duplicate_contacts
+from services.phone_normalization import normalize_phone
+
+JOB_TYPES = {"phone_backfill", "attribution_backfill", "duplicate_scan", "google_sync", "unnamed_match"}
+
+
+def create_job(company_id: int, job_type: str, *, user_id: int | None = None, batch_size: int = 100, dry_run: bool = True) -> ContactIntelligenceJob:
+    if job_type not in JOB_TYPES:
+        raise ValueError("unsupported contact intelligence job type")
+    job = ContactIntelligenceJob(company_id=company_id, user_id=user_id, job_type=job_type, batch_size=max(1, min(int(batch_size or 100), 1000)), dry_run=bool(dry_run), status="queued")
+    db.session.add(job); db.session.commit(); return job
+
+
+def run_job(job_id: int, *, max_batches: int = 1) -> ContactIntelligenceJob:
+    job = db.session.get(ContactIntelligenceJob, int(job_id))
+    if not job:
+        raise ValueError("job not found")
+    job.status = "running"; job.started_at = job.started_at or datetime.utcnow(); db.session.commit()
+    try:
+        for _ in range(max(1, int(max_batches or 1))):
+            processed = _run_batch(job)
+            db.session.commit()
+            if processed < job.batch_size:
+                job.status = "completed"; job.completed_at = datetime.utcnow(); db.session.commit(); break
+        if job.status == "running":
+            job.status = "queued"; db.session.commit()
+    except Exception as exc:
+        db.session.rollback()
+        job = db.session.get(ContactIntelligenceJob, int(job_id))
+        job.status = "failed"; job.failed += 1; job.sanitized_last_error = str(exc)[:500]; job.completed_at = datetime.utcnow()
+        db.session.commit()
+    return job
+
+
+def _base_contacts(job):
+    last_id = int((job.checkpoint or {}).get("last_contact_id") or 0)
+    return (Contact.query.filter(Contact.company_id == job.company_id, Contact.id > last_id)
+            .order_by(Contact.id.asc()).limit(job.batch_size).all())
+
+
+def _checkpoint(job, contact_id):
+    cp = dict(job.checkpoint or {}); cp["last_contact_id"] = contact_id; job.checkpoint = cp; job.cursor = str(contact_id)
+
+
+def _run_batch(job: ContactIntelligenceJob) -> int:
+    if job.job_type == "duplicate_scan":
+        groups = find_duplicate_contacts(job.company_id)
+        job.total_found = len(groups); job.processed = len(groups); job.updated = len(groups); return 0
+    rows = _base_contacts(job); job.total_found = max(job.total_found, job.processed + len(rows))
+    for contact in rows:
+        try:
+            changed = False
+            if job.job_type == "phone_backfill":
+                before = contact.normalized_phone
+                sync_contact_points(contact, contact.phone or contact.primary_phone, contact.email or contact.primary_email, "legacy")
+                changed = before != contact.normalized_phone
+            elif job.job_type == "attribution_backfill":
+                if not contact.original_source:
+                    source = contact.source or "legacy"
+                    if not job.dry_run:
+                        apply_source_attribution(contact, source, detail=contact.source_detail, at=contact.created_at)
+                    changed = True
+                else:
+                    job.skipped += 1
+            elif job.job_type == "unnamed_match":
+                if meaningful_name(contact) or not contact.normalized_phone:
+                    job.skipped += 1
+                else:
+                    lookups = GoogleContactLookup.query.filter_by(company_id=job.company_id, normalized_phone=contact.normalized_phone).all()
+                    candidates = []
+                    for lookup in lookups:
+                        if lookup.is_ambiguous:
+                            candidates.extend(lookup.candidates or [])
+                        else:
+                            candidates.append({"normalized_phone": lookup.normalized_phone, "name": lookup.display_name, "resource_id": lookup.resource_id, "etag": lookup.etag})
+                    status = apply_google_name_match(contact, candidates) if candidates and not job.dry_run else "skipped"
+                    if status == "ambiguous": job.ambiguous += 1
+                    elif status == "matched": changed = True
+                    else: job.skipped += 1
+            elif job.job_type == "google_sync":
+                # API fetch is triggered through Google routes; this job type stores progress/status for resumable runs.
+                job.skipped += 1
+            if changed and not job.dry_run:
+                job.updated += 1
+            elif changed:
+                job.skipped += 1
+            job.processed += 1; _checkpoint(job, contact.id)
+        except Exception as exc:
+            job.failed += 1
+            failures = list(job.failures or [])
+            failures.append({"contact_id": contact.id, "error": str(exc)[:300]})
+            job.failures = failures[-100:]
+            job.sanitized_last_error = str(exc)[:500]
+            _checkpoint(job, contact.id)
+    return len(rows)

--- a/services/google_contacts.py
+++ b/services/google_contacts.py
@@ -752,6 +752,57 @@ def _finish_sync_job(db, job, status: str, payload: dict, error: str | None = No
     db.session.flush()
 
 
+def _cache_google_lookup(company_id: int, user_id: int, phone_map: dict, *, dry_run: bool = False) -> dict:
+    """Persist a local, token-free Google phone/name cache for async matching."""
+    from extensions import db
+    from models import GoogleContactLookup, GoogleContactConnection
+    if dry_run or not isinstance(phone_map, dict):
+        return {"cached": 0, "ambiguous": 0}
+    connection = GoogleContactConnection.query.filter_by(company_id=company_id, user_id=user_id).first()
+    grouped = {}
+    for norm, raw in phone_map.items():
+        if str(norm).startswith("__") or str(norm).startswith("email:"):
+            continue
+        data = _google_data(norm, raw)
+        normalized = data.get("normalized_phone") or normalize_phone(data.get("phone"))
+        if not normalized:
+            continue
+        grouped.setdefault(normalized, []).append(data)
+    cached = ambiguous = 0
+    for normalized, candidates in grouped.items():
+        lookup = GoogleContactLookup.query.filter_by(company_id=company_id, user_id=user_id, normalized_phone=normalized).first()
+        if not lookup:
+            lookup = GoogleContactLookup(company_id=company_id, user_id=user_id, normalized_phone=normalized)
+            db.session.add(lookup)
+        lookup.connection_id = connection.id if connection else None
+        lookup.candidate_count = len(candidates)
+        lookup.is_ambiguous = len({c.get("resource_name") for c in candidates}) > 1
+        lookup.display_name = None if lookup.is_ambiguous else (candidates[0].get("name") or "")
+        lookup.resource_id = None if lookup.is_ambiguous else candidates[0].get("resource_name")
+        lookup.etag = None if lookup.is_ambiguous else candidates[0].get("etag")
+        lookup.candidates = [{"normalized_phone": normalized, "name": c.get("name"), "resource_id": c.get("resource_name"), "etag": c.get("etag")} for c in candidates]
+        lookup.last_seen_at = datetime.utcnow()
+        cached += 1
+        if lookup.is_ambiguous: ambiguous += 1
+    return {"cached": cached, "ambiguous": ambiguous}
+
+
+def upsert_connection_from_token(user_id: int, company_id: int):
+    """Mirror legacy GoogleOAuthToken metadata into the CRM connection table without exposing tokens."""
+    from extensions import db
+    from models import GoogleContactConnection
+    tok = get_token(user_id)
+    conn = GoogleContactConnection.query.filter_by(company_id=company_id, user_id=user_id).first()
+    if not conn:
+        conn = GoogleContactConnection(company_id=company_id, user_id=user_id)
+        db.session.add(conn)
+    conn.google_account_email = getattr(tok, "google_account_email", None) if tok else conn.google_account_email
+    conn.scopes = [SCOPES]
+    conn.sync_status = "connected" if tok else "disconnected"
+    conn.last_successful_sync_at = getattr(tok, "last_successful_sync_at", None) if tok else conn.last_successful_sync_at
+    return conn
+
+
 def sync_contacts(user_id: int, company_id: int, dry_run: bool = False) -> dict:
     """Fetch Google contacts and enrich/merge Audience contacts. Supports dry-run previews."""
     from extensions import db
@@ -832,6 +883,7 @@ def sync_contacts(user_id: int, company_id: int, dry_run: bool = False) -> dict:
         return payload
 
     meta = phone_map.pop("__meta__", {}) if isinstance(phone_map, dict) else {}
+    cache_stats = _cache_google_lookup(company_id, user_id, phone_map, dry_run=dry_run)
     job.current_page_count = int(meta.get("pages_processed") or 0)
     job.contacts_processed = int(meta.get("contacts_processed") or len(phone_map))
     updated_ids, created, merged, matched, skipped = set(), 0, 0, 0, 0
@@ -879,8 +931,9 @@ def sync_contacts(user_id: int, company_id: int, dry_run: bool = False) -> dict:
                 created += 1
                 _append_preview(preview, "will_create", {"contact_name": data.get("name"), "incoming_google_contact": data}, preview_omitted, preview_limit)
                 if not dry_run:
-                    contact = Contact(company_id=company_id, is_subscribed=False)
-                    db.session.add(contact); db.session.flush()
+                    from services.contact_intelligence import resolve_contact
+                    contact = resolve_contact(company_id, phone=data.get("normalized_phone") or data.get("phone"), email=data.get("email"), proposed_name=data.get("name"), first_name=data.get("first_name"), last_name=data.get("last_name"), business_name=data.get("company"), source="google_contacts", detail="Google Contacts sync", user_id=user_id)
+                    contact.is_subscribed = False
                     _apply_google_to_contact(contact, data, dry_run=False)
             if contact and len(samples) < 10:
                 samples.append({"contact_id": contact.id, "name": data.get("name"), "phone": data.get("normalized_phone") or norm})
@@ -907,7 +960,8 @@ def sync_contacts(user_id: int, company_id: int, dry_run: bool = False) -> dict:
                    "contacts_processed": int(meta.get("contacts_processed") or len(phone_map)),
                    "new_next_sync_token_persisted": bool((not dry_run) and meta.get("next_sync_token")),
                    "status": "completed", "incremental": bool(meta.get("incremental")),
-                   "review_required": bool(preview["possible_merge_requires_review"] or preview_omitted.get("possible_merge_requires_review"))}
+                   "review_required": bool(preview["possible_merge_requires_review"] or preview_omitted.get("possible_merge_requires_review")),
+                   "lookup_cache": cache_stats}
         if dry_run:
             job_id = job.id
             db.session.rollback()

--- a/services/integrations/twilio_service.py
+++ b/services/integrations/twilio_service.py
@@ -173,21 +173,18 @@ def _ensure_lead(phone: str, company_id: int | None, first_msg: str) -> bool:
     """Create contact + conversation if phone is unknown. Returns True if created."""
     try:
         from extensions import db
-        from models import TwilioConversation, Contact
+        from models import TwilioConversation
+        from services.contact_intelligence import resolve_contact
+        from services.contact_audience import add_contact_tag
         existing = TwilioConversation.query.filter_by(
             from_number=phone, company_id=company_id
         ).first()
         if existing:
             return False
-        # Create contact
-        contact = Contact(
-            phone=phone,
-            company_id=company_id,
-            tags="sms_opt_in,new_lead",
-            source="inbound_sms",
-            is_subscribed=True,
-        )
-        db.session.add(contact)
+        contact = resolve_contact(company_id, phone=phone, source="twilio_inbound_sms", detail="First inbound SMS capture")
+        add_contact_tag(contact, "sms_opt_in")
+        add_contact_tag(contact, "new_lead")
+        contact.is_subscribed = True
         db.session.flush()
         # Create conversation
         convo = TwilioConversation(

--- a/services/phone_normalization.py
+++ b/services/phone_normalization.py
@@ -1,0 +1,70 @@
+"""Canonical server-side phone normalization for contacts and communications."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+try:
+    import phonenumbers
+    from phonenumbers import PhoneNumberFormat
+except Exception:  # pragma: no cover
+    phonenumbers = None
+    PhoneNumberFormat = None
+
+_EXTENSION_RE = re.compile(r"(?:ext\.?|extension|x|#)\s*([0-9]{1,10})\s*$", re.I)
+
+
+@dataclass(frozen=True)
+class PhoneNormalizationResult:
+    original: str
+    normalized: str | None
+    extension: str | None
+    is_valid: bool
+    country: str
+    error: str | None = None
+
+
+def split_extension(value: str | None) -> tuple[str, str | None]:
+    raw = (value or "").strip()
+    match = _EXTENSION_RE.search(raw)
+    if not match:
+        return raw, None
+    return raw[: match.start()].strip(), match.group(1)
+
+
+def normalize_phone(value: str | None, default_country: str = "US") -> PhoneNormalizationResult:
+    original = (value or "").strip()
+    country = (default_country or "US").upper()
+    base, ext = split_extension(original)
+    if not base:
+        return PhoneNormalizationResult(original, None, ext, False, country, "blank")
+    if phonenumbers is None:
+        digits = re.sub(r"\D", "", base)
+        if len(digits) == 10 and country in {"US", "CA"}:
+            return PhoneNormalizationResult(original, f"+1{digits}", ext, True, country)
+        if len(digits) == 11 and digits.startswith("1"):
+            return PhoneNormalizationResult(original, f"+{digits}", ext, True, country)
+        if base.startswith("+") and 8 <= len(digits) <= 15:
+            return PhoneNormalizationResult(original, f"+{digits}", ext, True, country)
+        return PhoneNormalizationResult(original, None, ext, False, country, "invalid")
+    try:
+        parsed = phonenumbers.parse(base, None if base.startswith("+") else country)
+        if not phonenumbers.is_valid_number(parsed):
+            return PhoneNormalizationResult(original, None, ext, False, country, "invalid")
+        return PhoneNormalizationResult(original, phonenumbers.format_number(parsed, PhoneNumberFormat.E164), ext, True, country)
+    except Exception as exc:
+        return PhoneNormalizationResult(original, None, ext, False, country, str(exc))
+
+
+def normalize_phone_e164(value: str | None, default_country: str = "US") -> str:
+    result = normalize_phone(value, default_country)
+    return result.normalized or ""
+
+
+def format_phone_display(value: str | None, default_country: str = "US") -> str:
+    result = normalize_phone(value, default_country)
+    if not result.normalized or phonenumbers is None:
+        return (value or "").strip()
+    parsed = phonenumbers.parse(result.normalized, None)
+    rendered = phonenumbers.format_number(parsed, PhoneNumberFormat.NATIONAL if result.normalized.startswith("+1") else PhoneNumberFormat.INTERNATIONAL)
+    return f"{rendered} x{result.extension}" if result.extension else rendered

--- a/services/user_lifecycle.py
+++ b/services/user_lifecycle.py
@@ -1,0 +1,129 @@
+"""Tenant-scoped user archive/restore helpers."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import union_all
+
+from extensions import db
+from models import Company, IntegrationAuditLog, PhoneNumberUserPermission, PushSubscription, User, UserCompanyAccess
+
+OWNER_ROLES = {UserCompanyAccess.ROLE_OWNER, UserCompanyAccess.ROLE_ADMIN}
+
+
+def _active_user_ids_for_company(company_id: int):
+    via_default = db.session.query(User.id).filter(User.default_company_id == company_id, User.active == True)
+    via_access = (
+        db.session.query(UserCompanyAccess.user_id.label("id"))
+        .join(User, User.id == UserCompanyAccess.user_id)
+        .filter(UserCompanyAccess.company_id == company_id, UserCompanyAccess.is_active == True, User.active == True)
+    )
+    return {r[0] for r in via_default.all()} | {r[0] for r in via_access.all()}
+
+
+def active_team_member_count(company_id: int) -> int:
+    return len(_active_user_ids_for_company(company_id))
+
+
+def active_owner_user_ids(company_id: int) -> set[int]:
+    ids = {
+        r[0]
+        for r in db.session.query(User.id)
+        .filter(User.default_company_id == company_id, User.active == True, User.is_admin == True)
+        .all()
+    }
+    ids |= {
+        r[0]
+        for r in db.session.query(UserCompanyAccess.user_id)
+        .join(User, User.id == UserCompanyAccess.user_id)
+        .filter(
+            UserCompanyAccess.company_id == company_id,
+            UserCompanyAccess.is_active == True,
+            User.active == True,
+            UserCompanyAccess.role.in_(OWNER_ROLES),
+        )
+        .all()
+    }
+    return ids
+
+
+def restoration_eligible(user: User, company_id: int) -> tuple[bool, str]:
+    company = db.session.get(Company, company_id)
+    if not company or not company.is_active:
+        return False, "Company is inactive or missing"
+    if not active_owner_user_ids(company_id):
+        return False, "Company must have an active owner/admin before restoration"
+    existing = User.query.filter(User.email == user.email, User.id != user.id, User.active == True).first()
+    if existing:
+        return False, "Another active user already has this email"
+    max_members = getattr(company, "max_team_members", None)
+    if max_members is not None and active_team_member_count(company_id) >= max_members:
+        return False, "Company seat limit is reached"
+    return True, "Eligible"
+
+
+def archive_user_for_company(user: User, company_id: int, actor: User) -> None:
+    if user.id == actor.id:
+        raise ValueError("Cannot archive your own account")
+    if getattr(user, "is_admin", False):
+        raise ValueError("Platform administrators cannot be archived from tenant management")
+    belongs_to_company = user.default_company_id == company_id or UserCompanyAccess.query.filter_by(user_id=user.id, company_id=company_id).first() is not None
+    if not belongs_to_company:
+        raise ValueError("User is not a member of this company")
+    owners_after = active_owner_user_ids(company_id) - {user.id}
+    if not owners_after:
+        raise ValueError("Cannot archive the final active owner/admin for this company")
+    now = datetime.utcnow()
+    accesses = UserCompanyAccess.query.filter_by(user_id=user.id, company_id=company_id, is_active=True).all()
+    had_default = user.default_company_id == company_id
+    for acc in accesses:
+        acc.previous_role = acc.role
+        acc.is_active = False
+        acc.archived_at = now
+        acc.archived_by_user_id = actor.id
+        acc.can_access_mobile_inbox = False
+        acc.can_access_full_app = False
+        acc.comms_hub_enabled = False
+        acc.pwa_access_enabled = False
+        acc.manage_users_enabled = False
+        acc.communications_license = False
+    PhoneNumberUserPermission.query.filter_by(company_id=company_id, user_id=user.id).update({
+        "can_access_pwa": False,
+        "can_view_sms": False,
+        "can_send_sms": False,
+        "can_view_calls": False,
+        "can_call": False,
+        "can_view_voicemail": False,
+        "can_manage_number": False,
+        "can_send_campaigns": False,
+    })
+    PushSubscription.query.filter_by(company_id=company_id, user_id=user.id, is_active=True).update({"is_active": False})
+    user.active = False
+    user.archived_at = now
+    user.archived_by_user_id = actor.id
+    user.archived_company_id = company_id
+    user.session_revoked_at = now
+    if had_default:
+        user.default_company_id = None
+    db.session.add(IntegrationAuditLog(company_id=company_id, service_slug="users", action="archive", user_id=actor.id, changes={"target_user_id": user.id, "access_rows": len(accesses)}))
+
+
+def restore_user_for_company(user: User, company_id: int, actor: User) -> None:
+    ok, reason = restoration_eligible(user, company_id)
+    if not ok:
+        raise ValueError(reason)
+    access = UserCompanyAccess.query.filter_by(user_id=user.id, company_id=company_id).first()
+    if not access:
+        raise ValueError("User has no archived access row for this company")
+    access.is_active = True
+    access.archived_at = None
+    access.archived_by_user_id = None
+    access.role = access.previous_role or access.role or UserCompanyAccess.ROLE_VIEWER
+    access.previous_role = None
+    access.can_access_full_app = True
+    user.active = True
+    user.archived_at = None
+    user.archived_by_user_id = None
+    user.archived_company_id = None
+    user.default_company_id = company_id
+    db.session.add(IntegrationAuditLog(company_id=company_id, service_slug="users", action="restore", user_id=actor.id, changes={"target_user_id": user.id, "company_id": company_id}))

--- a/templates/contact_duplicate_review.html
+++ b/templates/contact_duplicate_review.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container py-4">
+  <h1>Contact Duplicate Review</h1>
+  <p class="text-muted">Company-scoped review center. No automatic production merges are performed from scans.</p>
+  <div class="mb-3">
+    <form method="post" action="{{ url_for('main.contact_duplicate_review_scan') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button class="btn btn-primary">Audit duplicate candidates</button>
+    </form>
+  </div>
+  {% for group in groups %}
+  <div class="card mb-3">
+    <div class="card-header"><strong>{{ group.match_key }}</strong> · {{ group.contact_ids|length }} contacts</div>
+    <div class="card-body">
+      <div class="row">
+        {% for c in group.contacts %}
+        <div class="col-md-6">
+          <h5>#{{ c.id }} {{ c.name or (c.first_name ~ ' ' ~ c.last_name)|trim or 'Unnamed' }}</h5>
+          <dl class="row small">
+            <dt class="col-4">Phone</dt><dd class="col-8">{{ c.phone }} / {{ c.normalized_phone }}</dd>
+            <dt class="col-4">Email</dt><dd class="col-8">{{ c.email }}</dd>
+            <dt class="col-4">Original source</dt><dd class="col-8">{{ c.original_source or c.source }}</dd>
+            <dt class="col-4">Latest source</dt><dd class="col-8">{{ c.latest_source }}</dd>
+            <dt class="col-4">Tags</dt><dd class="col-8">{{ c.tags }}</dd>
+            <dt class="col-4">Related counts</dt><dd class="col-8"><pre>{{ related_counts.get(c.id, {}) }}</pre></dd>
+          </dl>
+        </div>
+        {% endfor %}
+      </div>
+      <form method="post" action="{{ url_for('main.contact_duplicate_review_merge') }}" class="row g-2">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="contact_ids" value="{{ group.contact_ids|join(',') }}">
+        <div class="col-md-4"><input class="form-control" name="primary_contact_id" placeholder="Master contact ID"></div>
+        <div class="col-md-4"><button class="btn btn-danger" name="action" value="merge">Merge after preview</button></div>
+        <div class="col-md-4"><button class="btn btn-secondary" name="action" value="not_duplicate">Mark not duplicate</button></div>
+      </form>
+    </div>
+  </div>
+  {% else %}
+  <div class="alert alert-success">No duplicate candidates found.</div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/templates/contacts.html
+++ b/templates/contacts.html
@@ -41,12 +41,20 @@
                 <thead>
                     <tr>
                         <th>Name</th>
-                        <th>Email</th>
-                        <th>Segment</th>
-                        <th>Company</th>
+                        <th>Business</th>
                         <th>Phone</th>
+                        <th>Email</th>
+                        <th>Original source</th>
+                        <th>Latest source</th>
                         <th>Tags</th>
-                        <th>Created</th>
+                        <th>Owner</th>
+                        <th>Lifecycle</th>
+                        <th>Lead</th>
+                        <th>Last activity</th>
+                        <th>Next follow-up</th>
+                        <th>Open opp value</th>
+                        <th>Duplicate</th>
+                        <th>Google</th>
                         <th>Actions</th>
                     </tr>
                 </thead>
@@ -56,21 +64,11 @@
                         <td>
                             <strong>{{ contact.full_name }}</strong>
                         </td>
-                        <td>{{ contact.email }}</td>
-                        <td>
-                            <span class="badge 
-                                {% if contact.segment == 'customer' %}bg-success
-                                {% elif contact.segment == 'vip' %}bg-warning text-dark
-                                {% elif contact.segment == 'prospect' %}bg-info
-                                {% elif contact.segment == 'newsletter' %}bg-primary
-                                {% elif contact.segment == 'churned' %}bg-danger
-                                {% elif contact.segment == 'inactive' %}bg-secondary
-                                {% else %}bg-secondary{% endif %}">
-                                {{ contact.segment|default('lead', true)|title }}
-                            </span>
-                        </td>
-                        <td>{{ contact.company or '-' }}</td>
-                        <td>{{ contact.phone or '-' }}</td>
+                        <td>{{ contact.business_name or contact.company or '-' }}</td>
+                        <td>{{ contact.normalized_phone or contact.phone or '-' }}</td>
+                        <td>{{ contact.primary_email or contact.email or '-' }}</td>
+                        <td>{{ contact.original_source or contact.source or '-' }}</td>
+                        <td>{{ contact.latest_source or '-' }}</td>
                         <td>
                             {% if contact.tags %}
                                 {% for tag in contact.tags.split(',') %}
@@ -80,16 +78,23 @@
                                 -
                             {% endif %}
                         </td>
-                        <td>{{ contact.created_at.strftime('%Y-%m-%d') }}</td>
+                        <td>{{ contact.owner_user_id or '-' }}</td>
+                        <td>{{ contact.lifecycle_stage or contact.segment or '-' }}</td>
+                        <td>{{ contact.lead_status or '-' }}</td>
+                        <td>{{ contact.last_activity_at.strftime('%Y-%m-%d') if contact.last_activity_at else '-' }}</td>
+                        <td>{{ contact.next_follow_up_at.strftime('%Y-%m-%d') if contact.next_follow_up_at else '-' }}</td>
+                        <td>{{ '%.2f'|format(opp_values.get(contact.id, 0) or 0) }}</td>
+                        <td>{{ contact.duplicate_status or '-' }}</td>
+                        <td>{{ contact.google_match_status or '-' }}</td>
                         <td>
                             <button type="button" class="btn btn-sm btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editContactModal" 
                                 onclick="editContact({{ contact.id }}, '{{ contact.first_name|e }}', '{{ contact.last_name|e }}', '{{ contact.email|e }}', '{{ contact.company|default('', true)|e }}', '{{ contact.phone|default('', true)|e }}', '{{ contact.tags|default('', true)|e }}', '{{ contact.segment|default('', true)|e }}')">
                                 <i data-feather="edit"></i>
                             </button>
-                            <form method="POST" action="{{ url_for('main.delete_contact', contact_id=contact.id) }}" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this contact?')">
+                            <form method="POST" action="{{ url_for('main.delete_contact', contact_id=contact.id) }}" class="d-inline" onsubmit="return confirm('Archive this contact? Related records will be preserved.')">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                                 <button type="submit" class="btn btn-sm btn-outline-danger">
-                                    <i data-feather="trash-2"></i>
+                                    <i data-feather="archive"></i>
                                 </button>
                             </form>
                         </td>

--- a/templates/manage_users.html
+++ b/templates/manage_users.html
@@ -6,6 +6,9 @@
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
     <h1 class="h2"><i data-feather="users"></i> Manage Users</h1>
     <div>
+        <a href="{{ url_for('main.manage_users', archived='1' if not show_archived else None) }}" class="btn btn-outline-info">
+            <i data-feather="archive"></i> {{ 'Active Users' if show_archived else 'Archived Users' }}
+        </a>
         <a href="{{ url_for('main.add_user') }}" class="btn btn-primary">
             <i data-feather="user-plus"></i> Add User
         </a>
@@ -31,6 +34,13 @@
                 <th>Username</th>
                 <th>Email</th>
                 <th>Role</th>
+                {% if show_archived %}
+                <th>Company memberships</th>
+                <th>Prior role</th>
+                <th>Archived</th>
+                <th>Archived by</th>
+                <th>Restoration eligibility</th>
+                {% endif %}
                 <th class="text-center" title="Can log in and use the Mobile Inbox PWA">Mobile Inbox</th>
                 <th class="text-center" title="Can access the full LUXit dashboard">Full App</th>
                 <th>Joined</th>
@@ -66,6 +76,16 @@
                         <span class="badge bg-secondary text-muted">No company link</span>
                     {% endif %}
                 </td>
+                {% if show_archived %}
+                {% set eligible = restoration_by_user.get(user.id) %}
+                <td>{{ acc.company.name if acc and acc.company else user.archived_company_id or '—' }}</td>
+                <td>{{ acc.previous_role or acc.role if acc else '—' }}</td>
+                <td>{{ user.archived_at.strftime('%m/%d/%Y %H:%M') if user.archived_at else '—' }}</td>
+                <td>{{ user.archived_by_user_id or '—' }}</td>
+                <td>
+                    <span class="badge {{ 'bg-success' if eligible and eligible[0] else 'bg-secondary' }}">{{ eligible[1] if eligible else 'Unknown' }}</span>
+                </td>
+                {% endif %}
                 <td class="text-center">
                     <div class="form-check form-switch d-flex justify-content-center m-0">
                         <input class="form-check-input" type="checkbox" role="switch"
@@ -91,12 +111,23 @@
                             <i data-feather="edit"></i> Edit
                         </a>
                         {% if user.id != current_user.id %}
-                        <form method="POST" action="{{ url_for('main.delete_user', user_id=user.id) }}" class="d-inline"
-                              onsubmit="return confirm('Delete {{ user.username }}? This cannot be undone.')">
-                            <button type="submit" class="btn btn-outline-danger">
-                                <i data-feather="trash-2"></i>
-                            </button>
-                        </form>
+                        {% if show_archived %}
+                            <form method="POST" action="{{ url_for('main.restore_user', user_id=user.id) }}" class="d-inline"
+                                  onsubmit="return confirm('Restore {{ user.username }} for this company only?')">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                                <button type="submit" class="btn btn-outline-success">
+                                    <i data-feather="rotate-ccw"></i>
+                                </button>
+                            </form>
+                        {% else %}
+                            <form method="POST" action="{{ url_for('main.delete_user', user_id=user.id) }}" class="d-inline"
+                                  onsubmit="return confirm('Archive {{ user.username }}? Access will be revoked but history preserved.')">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                                <button type="submit" class="btn btn-outline-danger">
+                                    <i data-feather="archive"></i>
+                                </button>
+                            </form>
+                        {% endif %}
                         {% endif %}
                     </div>
                 </td>

--- a/tests/test_contact_intelligence.py
+++ b/tests/test_contact_intelligence.py
@@ -1,0 +1,130 @@
+import os
+from datetime import datetime, timedelta
+
+import pytest
+
+from app import create_app
+from extensions import db
+from models import Company, Contact, ContactSourceEvent, ContactTask, Opportunity, User, user_company
+from services.contact_audience import upsert_contact_from_source
+from services.contact_dedupe import find_duplicate_contacts, merge_contacts
+from services.contact_intelligence import apply_google_name_match, cleanup_audit, create_follow_up_task, create_opportunity, resolve_contact
+from services.phone_normalization import normalize_phone, normalize_phone_e164
+
+
+@pytest.fixture
+def app():
+    os.environ["FLASK_ENV"] = "testing"
+    app = create_app()
+    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def tenant(app):
+    company = Company(name="Intelligence Co")
+    other = Company(name="Other Co")
+    user = User(username="intel", email="intel@example.com", default_company_id=None, is_admin=True)
+    user.password_hash = "testpass"
+    db.session.add_all([company, other, user]); db.session.flush()
+    user.default_company_id = company.id
+    db.session.execute(user_company.insert().values(user_id=user.id, company_id=company.id, is_default=True))
+    db.session.commit()
+    return user, company, other
+
+
+def test_phone_normalization_common_us_and_extension():
+    assert normalize_phone_e164("(916) 555-1212") == "+19165551212"
+    assert normalize_phone_e164("916-555-1212") == "+19165551212"
+    assert normalize_phone_e164("+1 916 555 1212") == "+19165551212"
+    result = normalize_phone("(916) 555-1212 x44")
+    assert result.normalized == "+19165551212"
+    assert result.extension == "44"
+    assert result.is_valid is True
+
+
+def test_phone_normalization_international_invalid_and_blank():
+    assert normalize_phone_e164("+44 20 7946 0958") == "+442079460958"
+    assert normalize_phone("not a phone").is_valid is False
+    assert normalize_phone("").normalized is None
+
+
+def test_resolve_contact_records_source_and_reuses_safe_match(tenant):
+    user, company, _ = tenant
+    first = resolve_contact(company.id, phone="916-555-1212", proposed_name="Caller", source="twilio_inbound_sms", detail="Inbound SMS to +19165551212", user_id=user.id)
+    second = resolve_contact(company.id, phone="+1 916 555 1212", email="person@example.com", source="website_form", detail="Website consultation form")
+    db.session.commit()
+    assert first.id == second.id
+    assert first.original_source == "twilio_inbound_sms"
+    assert first.latest_source == "website_form"
+    assert ContactSourceEvent.query.filter_by(contact_id=first.id).count() == 2
+
+
+def test_duplicate_detection_exact_phone_email_only_and_tenant_scoped(tenant):
+    _, company, other = tenant
+    a = Contact(company_id=company.id, phone="9165551212", normalized_phone="+19165551212", name="Same Name", is_active=True)
+    b = Contact(company_id=company.id, phone="+1 916 555 1212", normalized_phone="+19165551212", name="Different", is_active=True)
+    name_only = Contact(company_id=company.id, name="Same Name", is_active=True)
+    other_tenant = Contact(company_id=other.id, phone="+19165551212", normalized_phone="+19165551212", is_active=True)
+    db.session.add_all([a, b, name_only, other_tenant]); db.session.commit()
+    groups = [set(g["contact_ids"]) for g in find_duplicate_contacts(company.id)]
+    assert {a.id, b.id} in groups
+    assert all(name_only.id not in g for g in groups)
+    assert all(other_tenant.id not in g for g in groups)
+
+
+def test_merge_archives_not_deletes_and_preserves_tasks_opportunities(tenant):
+    user, company, _ = tenant
+    master = Contact(company_id=company.id, email="merge@example.com", is_active=True, original_source="manual_entry", first_touch_at=datetime.utcnow() - timedelta(days=2))
+    dupe = Contact(company_id=company.id, email="MERGE@example.com", normalized_email="merge@example.com", tags="VIP", is_active=True, latest_source="campaign", last_touch_at=datetime.utcnow())
+    db.session.add_all([master, dupe]); db.session.flush()
+    task = create_follow_up_task(company.id, dupe.id, "Call back", assigned_user_id=user.id)
+    opp = create_opportunity(company.id, dupe.id, "Big Deal", owner_user_id=user.id, estimated_value=1000)
+    db.session.commit()
+    result = merge_contacts(master.id, [dupe.id], actor_user_id=user.id, company_id=company.id)
+    db.session.refresh(dupe)
+    assert dupe.is_active is False
+    assert dupe.merged_into_contact_id == master.id
+    assert ContactTask.query.get(task.id).contact_id == master.id
+    assert Opportunity.query.get(opp.id).contact_id == master.id
+    assert result["references_reassigned"]["contact_task"] == 1
+    assert result["references_reassigned"]["opportunity"] == 1
+
+
+def test_google_match_fills_missing_name_but_not_reliable_existing(tenant):
+    _, company, _ = tenant
+    missing = Contact(company_id=company.id, phone="+19165551212", normalized_phone="+19165551212", is_active=True)
+    named = Contact(company_id=company.id, phone="+19165550000", normalized_phone="+19165550000", name="Customer Confirmed", name_source="user", is_active=True)
+    db.session.add_all([missing, named]); db.session.commit()
+    assert apply_google_name_match(missing, [{"normalized_phone":"+19165551212", "name":"Jane Google", "resource_id":"people/1", "etag":"a"}]) == "matched"
+    assert missing.name == "Jane Google"
+    assert missing.name_source == "google_contacts"
+    assert apply_google_name_match(named, [{"normalized_phone":"+19165550000", "name":"Other Google", "resource_id":"people/2"}]) == "matched"
+    assert named.name == "Customer Confirmed"
+
+
+def test_google_ambiguous_and_cleanup_audit(tenant):
+    _, company, _ = tenant
+    contact = Contact(company_id=company.id, phone="+19165551212", normalized_phone="+19165551212", is_active=True)
+    db.session.add(contact); db.session.commit()
+    status = apply_google_name_match(contact, [
+        {"normalized_phone":"+19165551212", "name":"A", "resource_id":"people/a"},
+        {"normalized_phone":"+19165551212", "name":"B", "resource_id":"people/b"},
+    ])
+    assert status == "ambiguous"
+    report = cleanup_audit(company.id)
+    assert report["total_contacts_scanned"] >= 1
+    assert "proposed_merges" in report
+
+
+def test_upsert_contact_from_source_uses_intelligence_source(tenant):
+    _, company, _ = tenant
+    contact = upsert_contact_from_source(company.id, phone="9165551212", source_channel="csv_import", source_provider="test", source_context="Imported from customers.csv")
+    db.session.commit()
+    assert contact.original_source == "csv_import"
+    assert contact.latest_source == "csv_import"
+    assert contact.phone_numbers.count() == 1

--- a/tests/test_contact_intelligence_routes_jobs.py
+++ b/tests/test_contact_intelligence_routes_jobs.py
@@ -1,0 +1,130 @@
+import os
+
+import pytest
+
+from app import create_app
+from extensions import db
+from models import Company, Contact, ContactDuplicateExclusion, ContactIntelligenceJob, User, user_company
+
+
+@pytest.fixture
+def app():
+    os.environ["FLASK_ENV"] = "testing"
+    app = create_app()
+    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove(); db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, is_admin=True):
+    company = Company(name="Route Co")
+    user = User(username="route", email="route@example.com", default_company_id=None, is_admin=is_admin)
+    user.password_hash = "testpass"
+    db.session.add_all([company, user]); db.session.flush()
+    user.default_company_id = company.id
+    db.session.execute(user_company.insert().values(user_id=user.id, company_id=company.id, is_default=True))
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id); sess["_fresh"] = True
+    return user, company
+
+
+def test_contacts_add_route_uses_canonical_resolution(client):
+    _, company = login(client)
+    resp1 = client.post("/contacts/add", data={"email":"one@example.com", "phone":"(916) 555-1212", "first_name":"One"}, follow_redirects=False)
+    resp2 = client.post("/contacts/add", data={"email":"one@example.com", "phone":"+1 916 555 1212", "first_name":"Duplicate"}, follow_redirects=False)
+    assert resp1.status_code in {302, 303}
+    assert resp2.status_code in {302, 303}
+    contacts = Contact.query.filter_by(company_id=company.id).all()
+    assert len(contacts) == 1
+    assert contacts[0].normalized_phone == "+19165551212"
+    assert contacts[0].original_source == "manual_entry"
+    assert contacts[0].phone_numbers.count() == 1
+
+
+def test_contact_intelligence_job_api_requires_admin_and_resumes(client):
+    _, company = login(client, is_admin=False)
+    denied = client.post("/api/marketing/contacts/intelligence/jobs", json={"job_type":"phone_backfill"})
+    assert denied.status_code == 403
+    user = User.query.first(); user.is_admin = True; db.session.commit()
+    db.session.add_all([
+        Contact(company_id=company.id, phone="9165551212", is_active=True),
+        Contact(company_id=company.id, phone="9165551213", is_active=True),
+    ]); db.session.commit()
+    created = client.post("/api/marketing/contacts/intelligence/jobs", json={"job_type":"phone_backfill", "batch_size":1, "dry_run":False})
+    assert created.status_code == 200
+    job_id = created.get_json()["job"]["id"]
+    run1 = client.post(f"/api/marketing/contacts/intelligence/jobs/{job_id}/run", json={"max_batches":1})
+    assert run1.status_code == 200
+    assert run1.get_json()["job"]["processed"] == 1
+    run2 = client.post(f"/api/marketing/contacts/intelligence/jobs/{job_id}/run", json={"max_batches":5})
+    body = run2.get_json()["job"]
+    assert body["processed"] == 2
+    assert body["status"] == "completed"
+
+
+def test_not_duplicate_pair_is_persisted_and_excluded(client):
+    _, company = login(client)
+    a = Contact(company_id=company.id, email="a@example.com", normalized_phone="+19165551212", is_active=True)
+    b = Contact(company_id=company.id, email="b@example.com", normalized_phone="+19165551212", is_active=True)
+    db.session.add_all([a,b]); db.session.commit()
+    resp = client.post("/api/marketing/contacts/duplicates/not-duplicate", json={"contact_id_a":a.id, "contact_id_b":b.id})
+    assert resp.status_code == 200
+    assert ContactDuplicateExclusion.query.filter_by(company_id=company.id).count() == 1
+    review = client.get("/api/marketing/contacts/duplicates")
+    assert review.status_code == 200
+    assert review.get_json()["count"] == 0
+
+
+def test_google_status_and_suggestion_do_not_expose_tokens_or_overwrite_manual_name(client):
+    _, company = login(client)
+    status = client.get("/api/marketing/contacts/google/status")
+    assert status.status_code == 200
+    assert "token" not in str(status.get_json()).lower()
+    contact = Contact(company_id=company.id, phone="+19165551212", normalized_phone="+19165551212", name="Manual Name", name_source="user", is_active=True)
+    db.session.add(contact); db.session.commit()
+    resp = client.post(f"/api/marketing/contacts/{contact.id}/google/suggestion", json={"action":"accept", "name":"Google Name"})
+    assert resp.status_code == 409
+    db.session.refresh(contact)
+    assert contact.name == "Manual Name"
+
+
+def test_public_newsletter_requires_trusted_company(client):
+    resp = client.post("/newsletter-subscribe", json={"email":"public@example.com"})
+    assert resp.status_code == 400
+    assert Contact.query.filter_by(email="public@example.com").count() == 0
+
+
+def test_public_newsletter_uses_explicit_company_and_stays_isolated(client):
+    user, company = login(client)
+    other = Company(name="Other Public Co")
+    db.session.add(other); db.session.commit()
+    resp = client.post(f"/newsletter-subscribe?company_id={company.id}", json={"email":"public@example.com"})
+    assert resp.status_code == 200
+    assert Contact.query.filter_by(company_id=company.id, email="public@example.com").count() == 1
+    assert Contact.query.filter_by(company_id=other.id, email="public@example.com").count() == 0
+
+
+def test_contact_delete_archives_and_restore_preserves_record(client):
+    _, company = login(client)
+    contact = Contact(company_id=company.id, email="archive@example.com", is_active=True, status="active")
+    db.session.add(contact); db.session.commit()
+    resp = client.post(f"/contacts/{contact.id}/delete", follow_redirects=False)
+    assert resp.status_code in {302, 303}
+    db.session.refresh(contact)
+    assert contact.is_active is False
+    assert contact.status == "archived"
+    assert contact.archived_at is not None
+    resp = client.post(f"/contacts/{contact.id}/restore", follow_redirects=False)
+    assert resp.status_code in {302, 303}
+    db.session.refresh(contact)
+    assert contact.is_active is True
+    assert contact.status == "active"
+    assert contact.archived_at is None

--- a/tests/test_deploy_migration_workflow.py
+++ b/tests/test_deploy_migration_workflow.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+
+def test_production_workflow_runs_ledger_migrations_before_restart():
+    workflow = Path(".github/workflows/push-to-production.yml").read_text(encoding="utf-8")
+    assert 'test -n "${DATABASE_URL:-}"' in workflow
+    migration_pos = workflow.index('scripts/apply_migrations.sh "$DATABASE_URL" migrations')
+    syntax_pos = workflow.index('echo "== Python syntax check =="')
+    restart_pos = workflow.index('echo "== Restart live service =="')
+    assert migration_pos < syntax_pos < restart_pos
+    assert 'set -euo pipefail' in workflow
+    assert 'script_stop: true' in workflow
+
+
+def test_migration_runner_uses_advisory_lock_transactions_and_safe_ledger():
+    runner = Path("scripts/apply_migrations.py").read_text(encoding="utf-8")
+    assert "pg_try_advisory_lock" in runner
+    assert "Timed out waiting for migration advisory lock" in runner
+    assert "ensure_ledger(conn, table_ident)" in runner
+    assert "applied_checksum(conn, table_ident, path.name)" in runner
+    assert '["--single-transaction"]' in runner
+    assert "INCOMPATIBLE_TRANSACTION_RE" in runner
+    assert "BEGIN" in runner and "COMMIT" in runner
+    assert '"psql", args.database_url, "-v", "ON_ERROR_STOP=1", *flags, "-f", str(path)' in runner
+    assert "duration_ms integer NOT NULL DEFAULT 0" in runner
+    assert "deployment_id text NULL" in runner
+    assert "VALUES (%s, %s, %s, %s, current_user, %s)" in runner
+    assert "VALID_NAME" in runner
+    assert "Migration symlink escapes migrations directory" in runner
+    assert "hashlib.sha256" in runner
+    audit = Path("docs/migration_transaction_audit.md").read_text(encoding="utf-8")
+    assert "20260714_contact_intelligence_crm.sql" in audit
+    assert "Safe with `--single-transaction`" in audit
+    assert "Already transaction wrapped" in audit
+
+
+def test_migration_bootstrap_is_separate_dry_run_first_and_refuses_uncertain_seed():
+    bootstrap = Path("scripts/bootstrap_migration_ledger.py").read_text(encoding="utf-8")
+    assert "readonly=not args.confirm" in bootstrap
+    assert "cannot_determine_automatically" in bootstrap
+    assert "Refusing to seed ledger" in bootstrap
+    assert "proven_applied" in bootstrap
+    assert "application_commit" in bootstrap
+    assert "database_identity" in bootstrap
+
+
+def test_user_archive_migration_is_forward_safe_and_before_restart():
+    workflow = Path(".github/workflows/push-to-production.yml").read_text(encoding="utf-8")
+    migration_pos = workflow.index('scripts/apply_migrations.sh "$DATABASE_URL" migrations')
+    restart_pos = workflow.index('echo "== Restart live service =="')
+    assert migration_pos < restart_pos
+    sql = Path("migrations/20260718_user_archive_restore.sql").read_text(encoding="utf-8")
+    required = [
+        'ALTER TABLE "user" ADD COLUMN IF NOT EXISTS active BOOLEAN NOT NULL DEFAULT TRUE',
+        'ALTER TABLE "user" ADD COLUMN IF NOT EXISTS archived_at TIMESTAMP NULL',
+        'ALTER TABLE "user" ADD COLUMN IF NOT EXISTS archived_by_user_id INTEGER NULL REFERENCES "user"(id) ON DELETE SET NULL',
+        'UPDATE "user" SET active = TRUE WHERE active IS NULL',
+    ]
+    for fragment in required:
+        assert fragment in sql

--- a/tests/test_sms_crm_phone_line_completion.py
+++ b/tests/test_sms_crm_phone_line_completion.py
@@ -230,8 +230,11 @@ def test_live_gate_workflow_and_comms_pwa_routes(client_ctx):
     app, client, c1, _, user, line1, _ = client_ctx
     # Production deploy workflow must run migrations/*.sql through psql.
     workflow = open(".github/workflows/push-to-production.yml", encoding="utf-8").read()
-    assert "migrations/*.sql" in workflow
-    assert 'psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"' in workflow
+    migration_script = open("scripts/apply_migrations.py", encoding="utf-8").read()
+    assert 'scripts/apply_migrations.sh "$DATABASE_URL" migrations' in workflow
+    assert 'child.suffix != ".sql"' in migration_script
+    assert 'sorted(migrations, key=lambda p: p.name)' in migration_script
+    assert '"psql", args.database_url, "-v", "ON_ERROR_STOP=1", *flags, "-f", str(path)' in migration_script
 
     # Admin route health for live-gate routes requested by review.
     for path in ("/twilio/comms", "/app/inbox"):

--- a/tests/test_user_archive_restore.py
+++ b/tests/test_user_archive_restore.py
@@ -1,0 +1,154 @@
+from werkzeug.security import generate_password_hash
+import pytest
+
+from app import create_app
+from extensions import db
+from models import Company, IntegrationAuditLog, PhoneNumberUserPermission, PushSubscription, TwilioPhoneNumber, User, UserCompanyAccess
+from services.user_lifecycle import active_owner_user_ids, active_team_member_count, archive_user_for_company, restore_user_for_company
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update(TESTING=True, SERVER_NAME="localhost", WTF_CSRF_ENABLED=False)
+    with app.app_context():
+        db.create_all()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    with app.test_client() as c:
+        yield c
+
+
+def _user(name, company=None, *, active=True, is_admin=False):
+    u = User(username=name, email=f"{name}@users.test", password_hash=generate_password_hash("pw"), active=active, is_admin=is_admin)
+    if company:
+        u.default_company_id = company.id
+    db.session.add(u); db.session.flush()
+    return u
+
+
+def _company(name="User Archive Co", seats=None):
+    c = Company(name=name, is_active=True, max_team_members=seats)
+    db.session.add(c); db.session.flush()
+    return c
+
+
+def _access(user, company, role="viewer", active=True, **kw):
+    acc = UserCompanyAccess(user_id=user.id, company_id=company.id, role=role, is_active=active, **kw)
+    db.session.add(acc); db.session.flush()
+    return acc
+
+
+def _login(client, user_or_id):
+    uid = getattr(user_or_id, "id", user_or_id)
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(uid)
+        sess["_fresh"] = True
+
+
+def test_final_owner_detection_counts_direct_and_access_paths_distinctly(app):
+    with app.app_context():
+        co = _company(); other = _company("Other")
+        direct_owner = _user("direct_owner", co, is_admin=True)
+        access_owner = _user("access_owner")
+        _access(access_owner, co, role="owner")
+        both = _user("both_owner", co, is_admin=True)
+        _access(both, co, role="owner")
+        inactive = _user("inactive_owner", co, active=False, is_admin=True)
+        other_owner = _user("other_owner", other, is_admin=True)
+        db.session.commit()
+        assert active_owner_user_ids(co.id) == {direct_owner.id, access_owner.id, both.id}
+        assert inactive.id not in active_owner_user_ids(co.id)
+        assert other_owner.id not in active_owner_user_ids(co.id)
+
+
+def test_final_owner_archive_blocks_only_owner_and_allows_other_membership_paths(app):
+    with app.app_context():
+        co = _company(); actor = _user("actor", co)
+        target = _user("target")
+        _access(actor, co, role="staff")
+        _access(target, co, role="owner")
+        db.session.commit()
+        with pytest.raises(ValueError, match="final active owner"):
+            archive_user_for_company(target, co.id, actor)
+        other_owner = _user("other_direct", co, is_admin=True)
+        db.session.flush()
+        archive_user_for_company(target, co.id, actor)
+        db.session.commit()
+        assert target.active is False
+        assert other_owner.id in active_owner_user_ids(co.id)
+
+
+def test_seat_counts_distinct_active_users_and_restore_no_double_count(app):
+    with app.app_context():
+        co = _company(seats=4); other = _company("Other Seats")
+        direct = _user("seat_direct", co)
+        access = _user("seat_access"); _access(access, co)
+        both = _user("seat_both", co); _access(both, co)
+        inactive = _user("seat_inactive", co, active=False); _access(inactive, co)
+        outsider = _user("seat_out", other); _access(outsider, other)
+        db.session.commit()
+        assert active_team_member_count(co.id) == 3
+        assert co.team_member_count == 3
+        assert co.team_seats_available == 1
+        actor = _user("seat_actor", co, is_admin=True); _access(actor, co, role="owner")
+        db.session.commit()
+        archive_user_for_company(access, co.id, actor); db.session.commit()
+        assert active_team_member_count(co.id) == 3  # direct, both, actor
+        restore_user_for_company(access, co.id, actor); db.session.commit()
+        assert active_team_member_count(co.id) == 4
+
+
+def test_archive_restore_route_revokes_access_denies_old_session_and_keeps_history(client, app):
+    with app.app_context():
+        co = _company(); owner = _user("route_owner", co); _access(owner, co, role="owner", manage_users_enabled=True)
+        staff = _user("route_staff", co); _access(staff, co, role="staff", pwa_access_enabled=True, can_access_mobile_inbox=True)
+        pn = TwilioPhoneNumber(company_id=co.id, phone_number="+15551234567", is_active=True)
+        db.session.add(pn); db.session.flush()
+        db.session.add(PhoneNumberUserPermission(company_id=co.id, phone_number_id=pn.id, user_id=staff.id, can_access_pwa=True))
+        db.session.add(PushSubscription(company_id=co.id, user_id=staff.id, endpoint="https://push.users.test/1", is_active=True))
+        db.session.commit(); owner_id, staff_id = owner.id, staff.id
+    staff_client = app.test_client()
+    login_resp = staff_client.post("/auth/login", data={"username":"route_staff", "password":"pw"}, follow_redirects=False)
+    assert login_resp.status_code in {302, 303}
+    with app.app_context():
+        owner = db.session.get(User, owner_id)
+        staff = db.session.get(User, staff_id)
+        archive_user_for_company(staff, co.id, owner)
+        db.session.commit()
+        assert staff.active is False and staff.archived_at is not None
+        assert UserCompanyAccess.query.filter_by(user_id=staff_id, company_id=co.id, is_active=False).first()
+        assert PushSubscription.query.filter_by(user_id=staff_id, company_id=co.id, is_active=True).count() == 0
+        assert IntegrationAuditLog.query.filter_by(company_id=co.id, service_slug="users", action="archive").count() == 1
+    denied = staff_client.get("/dashboard", follow_redirects=False)
+    assert denied.status_code in {302, 401}
+    with app.app_context():
+        owner = db.session.get(User, owner_id)
+        staff = db.session.get(User, staff_id)
+        restore_user_for_company(staff, co.id, owner)
+        db.session.commit()
+    assert staff_client.get("/dashboard", follow_redirects=False).status_code in {302, 401}
+    with app.app_context():
+        staff = db.session.get(User, staff_id)
+        assert staff.active is True and staff.default_company_id == co.id
+        assert UserCompanyAccess.query.filter_by(user_id=staff_id, company_id=co.id, is_active=True).first()
+        assert IntegrationAuditLog.query.filter_by(company_id=co.id, service_slug="users", action="restore").count() == 1
+
+
+def test_cross_tenant_and_global_admin_archive_protection(client, app):
+    with app.app_context():
+        co = _company("Tenant A"); other = _company("Tenant B")
+        owner = _user("tenant_owner", co); _access(owner, co, role="owner", manage_users_enabled=True)
+        outsider = _user("tenant_outsider", other); _access(outsider, other, role="staff")
+        platform = _user("platform_admin", co, is_admin=True)
+        db.session.commit(); owner_id, outsider_id, platform_id = owner.id, outsider.id, platform.id
+    _login(client, owner_id)
+    assert client.post(f"/user/delete/{outsider_id}", follow_redirects=True).status_code == 200
+    with app.app_context():
+        assert db.session.get(User, outsider_id).active is True
+    assert client.post(f"/user/delete/{platform_id}", follow_redirects=True).status_code == 200
+    with app.app_context():
+        assert db.session.get(User, platform_id).active is True

--- a/twilio_sms.py
+++ b/twilio_sms.py
@@ -1835,7 +1835,7 @@ def _inbound_call_impl():
             f"</Response>"
         )
 
-    if configured_call_forward_to and (ta.voice_forwarding_enabled or getattr(ta, "call_forwarding_enabled", False)):
+    if in_hours and configured_call_forward_to and (ta.voice_forwarding_enabled or getattr(ta, "call_forwarding_enabled", False)):
         # Explicit per-line call forwarding wins over browser ringing. This
         # applies only to voice webhooks; SMS routing never reads these fields.
         twiml = _dial_twiml(configured_call_forward_to)


### PR DESCRIPTION
### Motivation

- Introduce a Contact Intelligence / CRM feature set (contact phone/email canonicalization, attribution, dedupe, Google Contacts sync, opportunities/tasks) and tenant-scoped routes to support richer audience workflows. 
- Make SQL migrations safe and auditable in production by adding a ledgered migration runner and bootstrapping helpers, and ensure deploys run those migrations before restarting services. 
- Implement tenant-scoped user archival/restore lifecycle so tenant admins can disable access without deleting historical records and to revoke stale sessions.

### Description

- Add a migration runner and helpers: `scripts/apply_migrations.py`, `scripts/apply_migrations.sh`, and `scripts/bootstrap_migration_ledger.py`, plus GitHub Actions workflow change to call the runner before the syntax check and restart. 
- Add SQL migrations: `migrations/20260714_contact_intelligence_crm.sql` (contact intelligence schema) and `migrations/20260718_user_archive_restore.sql` (user/archive fields and indexes). 
- Extend models with CRM and archival fields and new tables (`ContactPhoneNumber`, `ContactEmailAddress`, `ContactSourceEvent`, `GoogleContactConnection`, `Opportunity`, `ContactTask`, `ContactIntelligenceJob`, `GoogleContactLookup`, `ContactDuplicateExclusion`) and add archive-related fields to `User` and `UserCompanyAccess`. 
- Add services implementing the features: `services/phone_normalization.py`, `services/contact_intelligence.py`, `services/contact_intelligence_jobs.py`, `services/contact_dedupe.py` (hardening and helpers), `services/contact_audience.py` (integration), and `services/user_lifecycle.py` (archive/restore helpers), plus integration updates to Twilio and comms permission checks. 
- Update app and auth code to revoke sessions for archived users (`app.py`, `auth.py`) and thread session markers at login; switch many routes to use canonical `resolve_contact` flows, contact archive/restore endpoints, manage-users UI changes, duplicate-review UI and routes, and multiple templates. 
- Add CLI/docs/tests: documentation files under `docs/`, new templates, and a comprehensive test suite covering contact intelligence, jobs/routes, migration workflow, user archive/restore, and integration points under `tests/`; add `phonenumbers` to `requirements.txt`.

### Testing

- Added automated tests including `tests/test_contact_intelligence.py`, `tests/test_contact_intelligence_routes_jobs.py`, `tests/test_user_archive_restore.py`, `tests/test_deploy_migration_workflow.py`, and other integration/unit tests, and ran the test suite with `pytest` locally. 
- The newly added tests exercise phone normalization, contact resolution/upsert, duplicate detection/merge, Google-matching logic, contact intelligence jobs, public form/company isolation, contact archiving/restoring, and migration-runner expectations. 
- The test run completed successfully with the newly added tests passing (local `pytest -q` run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5671b2f884832288b56add6b590aa6)